### PR TITLE
Added export of WidgetLibraryService

### DIFF
--- a/projects/angular6-json-schema-form/src/public_api.ts
+++ b/projects/angular6-json-schema-form/src/public_api.ts
@@ -6,9 +6,9 @@ export * from './lib/json-schema-form.service';
 export * from './lib/json-schema-form.component';
 export * from './lib/framework-library';
 export * from './lib/widget-library';
+export * from './lib/widget-library/widget-library.service';
 export * from './lib/shared';
 export * from './lib/framework-library/material-design-framework/material-design-framework.module';
 export * from './lib/framework-library/bootstrap-3-framework/bootstrap-3-framework.module';
 export * from './lib/framework-library/bootstrap-4-framework/bootstrap-4-framework.module';
 export * from './lib/framework-library/no-framework/no-framework.module';
-


### PR DESCRIPTION
We need to use WidgetLibraryService from our application to override default widgets.

It's possible right now by using Angular weird unicode letters imports like
`import { ɵc as WidgetLibraryService } from 'angular6-json-schema-form';`

But you don't want to do it :)
