### PR TITLE
Update index.ts

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/framework-library/index.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/index.ts
@@ -1,5 +1,7 @@
 export { FrameworkLibraryService } from './framework-library.service';
 
+export { Framework } from './framework';
+
 export { NoFramework } from './no-framework/no.framework';
 export { NoFrameworkModule } from './no-framework/no-framework.module';
 

--- a/projects/angular6-json-schema-form/src/public_api.ts
+++ b/projects/angular6-json-schema-form/src/public_api.ts
@@ -11,4 +11,5 @@ export * from './lib/framework-library/material-design-framework/material-design
 export * from './lib/framework-library/bootstrap-3-framework/bootstrap-3-framework.module';
 export * from './lib/framework-library/bootstrap-4-framework/bootstrap-4-framework.module';
 export * from './lib/framework-library/no-framework/no-framework.module';
-
+export * from './lib/json-schema-form.module';
+export * from './lib/widget-library/widget-library.module';


### PR DESCRIPTION
To be able to add a custom framework, `Framework` class must be accessible as well.
This is to fix the issue I raised here:
https://github.com/hamzahamidi/Angular6-json-schema-form/issues/106