### PR TITLE
Consider formGroup validity beside the AJV validation on data validation

### DIFF
--- a/projects/ajsf-core/src/lib/json-schema-form.component.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.component.ts
@@ -729,7 +729,13 @@ export class JsonSchemaFormComponent implements ControlValueAccessor, OnChanges,
       });
 
       // Trigger change detection on statusChanges to show updated errors
-      this.jsf.formGroup.statusChanges.subscribe(() => this.changeDetector.markForCheck());
+      this.jsf.formGroup.statusChanges.subscribe(() => {
+        // Set JSF to invalid if form group status changes to invalid
+        if (!this.jsf.formGroup.valid) {
+          this.isValid.emit(false);
+        }
+        this.changeDetector.markForCheck();
+      });
       this.jsf.isValidChanges.subscribe(isValid => this.isValid.emit(isValid));
       this.jsf.validationErrorChanges.subscribe(err => this.validationErrors.emit(err));
 

--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -246,7 +246,8 @@ export class JsonSchemaFormService {
       this.arrayMap,
       this.formOptions.returnEmptyFields
     );
-    this.isValid = this.validateFormData(this.data);
+    // Consider formGroup validity status and AJV data validation to set global validity status
+    this.isValid = this.validateFormData(this.data) && this.formGroup?.valid;
     this.validData = this.isValid ? this.data : null;
     const compileErrors = errors => {
       const compiledErrors = {};

--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -261,9 +261,9 @@ export class JsonSchemaFormService {
     };
     this.ajvErrors = this.validateFormData.errors;
     this.validationErrors = compileErrors(this.validateFormData.errors);
+    this.isValidChanges.next(this.isValid);
     if (updateSubscriptions) {
       this.dataChanges.next(this.data);
-      this.isValidChanges.next(this.isValid);
       this.validationErrorChanges.next(this.ajvErrors);
     }
   }


### PR DESCRIPTION
The only validation used to set JSF validity is the AJV validation so the form is set `valid` if every JSON schema validators are satisfied but the errors set directly on formGroup by custom widgets are bypassed.

For example: Custom TinyMCE widget's `maxLength` cannot be limited via JSON schema as the content of the WYSIWYG includes HTML code, so we need to do some treatments to `setErrors` manually via an additional validator (async) in the widget and we need it to be able to block form submit.