### PR TITLE
Fix lagging issues when using two way data bind

### DIFF
--- a/projects/ajsf-core/src/lib/json-schema-form.component.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.component.ts
@@ -197,6 +197,9 @@ export class JsonSchemaFormComponent implements ControlValueAccessor, OnChanges,
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if (changes.data && isEqual(changes.data.previousValue, changes.data.currentValue)) {      
+      return;
+    }
     this.updateForm();
     // Check if there's changes in Framework then load assets if that's the
     if (changes.framework) {


### PR DESCRIPTION
When we are using json schema form with the following sytnax, we realized the UI was lagging because of an infinite loop triggered/triggering `ngOnChanges`.

```html
<json-schema-form
                    [schema]="schema"
                    [(data)]="data"
                    [layout]="layout"
                    [framework]="framework"
                    [options]="jsonFormOptions"
                    [widgets]="widgets"
                    (onChanges)="onFormChanges($event)"
                    (isValid)="isValid($event)"
                    (onSubmit)="onSubmit($event)">
</json-schema-form>
```

Adding a condition for checking the equality of previous and current value, fixes the infinite loop.

```ts
if (changes.data && isEqual(changes.data.previousValue, changes.data.currentValue)) {      
      return;
}
```