### PR TITLE
Fix validation for Bootstrap frameworks

### DIFF
--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -650,8 +650,8 @@ export class JsonSchemaFormService {
     // Set value of current control
     ctx.controlValue = value;
     if (ctx.boundControl) {
-      ctx.formControl.setValue(value);
       ctx.formControl.markAsDirty();
+      ctx.formControl.setValue(value);
     }
     ctx.layoutNode.value = value;
 

--- a/projects/ajsf-core/src/lib/widget-library/input.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/input.component.ts
@@ -26,7 +26,8 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [id]="'control' + layoutNode?._id"
         [name]="controlName"
         [readonly]="options?.readonly ? 'readonly' : null"
-        [type]="layoutNode?.type">
+        [type]="layoutNode?.type"
+        (focusin)="updateValue($event)">
       <input *ngIf="!boundControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
@@ -42,7 +43,8 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [readonly]="options?.readonly ? 'readonly' : null"
         [type]="layoutNode?.type"
         [value]="controlValue"
-        (input)="updateValue($event)">
+        (input)="updateValue($event)"
+        (focusin)="updateValue($event)">
         <datalist *ngIf="options?.typeahead?.source"
           [id]="'control' + layoutNode?._id + 'Autocomplete'">
           <option *ngFor="let word of options?.typeahead?.source" [value]="word">


### PR DESCRIPTION
**Problem**: initial validation messages don’t appear in some cases when any of Bootstrap frameworks are used.

**How to reproduce**:
- open the Demonstration Playground
- choose the "Bootstrap 3" or the "Bootstrap 4" framework
- choose the "Angular Scheme Form/Bootstrap Grid" example
- focus on the "Name" text input. Nothing is telling us that this field is required. Only if type something and remove all after that.
- focus out of the "Name" text input when no validation error message is shown. The validation error message doesn't appear.
- the same behavior with the "Email" field

Also, after I had wrote this I found a related issue: #315 

**Fix**:
- force validation on update value in the json-schema-form service
- update value on focus in