### PR TITLE
ci: verify before the approval gate, and stop unpublished versions triggering releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Setup Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: '.nvmrc'
     - run: npm ci
     - run: npm run build:demo
 
     - name: deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist/demo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ name: Release
 # workflow run, so that chain would silently never publish. Making it work
 # needs a PAT or a GitHub App, which reintroduces the long-lived credential
 # OIDC exists to remove. So the tag is an output here, not an input.
+#
+# Three jobs, in this order for a reason. An environment protection rule blocks
+# a job before ANY of its steps run, so building inside the gated job would
+# mean approving before knowing whether it compiles. `verify` is therefore
+# ungated and runs first, and `release` publishes the artifact `verify` already
+# built. Approving means "this built and passed, ship it" rather than "go ahead
+# and try".
 
 on:
   push:
@@ -27,7 +34,7 @@ jobs:
       publish: ${{ steps.check.outputs.publish }}
       dist-tag: ${{ steps.check.outputs.dist-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Is this version already published
         id: check
@@ -54,28 +61,17 @@ jobs:
             echo "[release] @ajsf/core@$VERSION is not on npm, releasing"
           fi
 
-  release:
+  verify:
     needs: decide
     if: needs.decide.outputs.publish == 'true'
     runs-on: ubuntu-latest
-    # Requires a manual approval before anything reaches npm. Merging decides
-    # WHAT ships and when the build runs; this decides whether it actually
-    # goes out. Publishing is irreversible, so the pause the manual tag used
-    # to provide lives here instead. Configure the environment once in
-    # Settings > Environments > npm-publish with yourself as a required
-    # reviewer. Free on public repositories.
-    environment: npm-publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Use an npm that supports OIDC
-        run: npm i -g npm@latest
 
       - run: npm ci
 
@@ -103,6 +99,44 @@ jobs:
             fi
           done
           echo "[release] all four packages at $VERSION"
+
+      # Publishing the artifact verify built, rather than rebuilding inside the
+      # gated job, means what ships is exactly what passed.
+      - name: Upload the verified packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: ajsf-dist-${{ needs.decide.outputs.version }}
+          path: dist/@ajsf/
+          retention-days: 7
+          if-no-files-found: error
+
+  release:
+    needs: [decide, verify]
+    if: needs.decide.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    # Requires a manual approval before anything reaches npm. By the time this
+    # job is offered for approval, verify has already built and tested the
+    # exact artifact it will publish. Configure the environment once in
+    # Settings > Environments > npm-publish with yourself as a required
+    # reviewer. Free on public repositories.
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use an npm that supports OIDC
+        run: npm i -g npm@latest
+
+      - name: Download the verified packages
+        uses: actions/download-artifact@v8
+        with:
+          name: ajsf-dist-${{ needs.decide.outputs.version }}
+          path: dist/@ajsf/
 
       - name: Publish core
         run: npm publish dist/@ajsf/core --provenance --access public --tag ${{ needs.decide.outputs.dist-tag }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v11
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue'


### PR DESCRIPTION
## Summary

Moves build and test work before the manual publishing approval. Reviewers can now approve a release after seeing that its validation passed.

## Changes

The release workflow now has three jobs. `decide` checks the requested version, `verify` installs dependencies, runs tests, builds the libraries, and uploads `dist/@ajsf/`, then the gated `release` job downloads and publishes that same artifact.

This means the files sent to npm are the files produced by the successful validation job.

The PR also updates the GitHub Actions used by the release, CI, deploy, CodeQL, and stale workflows to current supported versions.

## Validation

All six workflow files parsed. The job order was checked as `decide`, `verify`, then `release`. The 13 script tests passed on Node 16.13.2.

This was a follow up to #361 after the first release run showed that environment approval blocked the old job before any validation step could start.
