### PR TITLE
test: add a 320-case schema rendering corpus

### DIFF
--- a/projects/ajsf-bootstrap3/src/lib/corpus.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/corpus.spec.ts
@@ -1,0 +1,5 @@
+import { Bootstrap3FrameworkModule } from './bootstrap3-framework.module';
+import { runCorpus } from '../../../../testing/corpus/harness';
+
+// The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
+runCorpus('bootstrap-3', [Bootstrap3FrameworkModule]);

--- a/projects/ajsf-bootstrap4/src/lib/corpus.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/corpus.spec.ts
@@ -1,0 +1,5 @@
+import { Bootstrap4FrameworkModule } from './bootstrap4-framework.module';
+import { runCorpus } from '../../../../testing/corpus/harness';
+
+// The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
+runCorpus('bootstrap-4', [Bootstrap4FrameworkModule]);

--- a/projects/ajsf-core/src/lib/corpus-loader.spec.ts
+++ b/projects/ajsf-core/src/lib/corpus-loader.spec.ts
@@ -1,0 +1,27 @@
+import { loadCorpus, SKIPPED_NOT_JSON } from '../../../../testing/corpus/schemas';
+
+describe('corpus loader', () => {
+  it('loads the example schemas', () => {
+    const corpus = loadCorpus();
+    expect(corpus.length).toBeGreaterThan(0);
+  });
+
+  it('gives every entry a name and a parsed object', () => {
+    loadCorpus().forEach(entry => {
+      expect(entry.name).toBeTruthy();
+      expect(entry.form).toBeTruthy();
+      expect(typeof entry.form).toEqual('object');
+    });
+  });
+
+  it('skips exactly the four schemas that are not valid JSON', () => {
+    const names = loadCorpus().map(e => e.name);
+    SKIPPED_NOT_JSON.forEach(skipped => expect(names).not.toContain(skipped));
+    expect(SKIPPED_NOT_JSON.length).toEqual(4);
+  });
+
+  it('covers the schemas the demo can actually load as JSON', () => {
+    // 84 files on disk, 4 of which embed JavaScript and are eval'd by the demo.
+    expect(loadCorpus().length).toEqual(80);
+  });
+});

--- a/projects/ajsf-core/src/lib/corpus.spec.ts
+++ b/projects/ajsf-core/src/lib/corpus.spec.ts
@@ -1,0 +1,6 @@
+import { JsonSchemaFormModule } from './json-schema-form.module';
+import { NoFrameworkModule } from './framework-library/no-framework.module';
+import { runCorpus } from '../../../../testing/corpus/harness';
+
+// Source copies, because this project is @ajsf/core itself.
+runCorpus('no-framework', [JsonSchemaFormModule, NoFrameworkModule]);

--- a/projects/ajsf-material/src/lib/corpus.spec.ts
+++ b/projects/ajsf-material/src/lib/corpus.spec.ts
@@ -1,0 +1,5 @@
+import { MaterialDesignFrameworkModule } from './material-design-framework.module';
+import { runCorpus } from '../../../../testing/corpus/harness';
+
+// The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
+runCorpus('material-design', [MaterialDesignFrameworkModule]);

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1,0 +1,1282 @@
+{
+  "bootstrap-3/asf-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/asf-basic-json-schema-type": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/asf-bootstrap-grid": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/asf-complex-key-support": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/asf-hack-conditional-required": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/asf-kitchen-sink": {
+    "controls": 11,
+    "error": null
+  },
+  "bootstrap-3/asf-simple": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/asf-tab-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/asf-titlemap-examples": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-3/jsf-factory-sleek": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-ace": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-actions": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-advancedfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-array": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-array-simple": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-authfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-autocomplete": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-checkbox": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-checkboxbuttons": {
+    "controls": 0,
+    "error": "value.forEach is not a function"
+  },
+  "bootstrap-3/jsf-fields-checkboxes": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-color": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-common": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-fieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-help": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-hidden": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-iconselect": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-imageselect": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-password": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-questions": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-radiobuttons": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-radios": {
+    "controls": 13,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-range": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-section": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-select": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-selectfieldset": {
+    "controls": 1,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-selectfieldset-key": {
+    "controls": 1,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-submit": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-tabarray": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-tabarray-maxitems": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-tabarray-value": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-fields-textarea": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-gettingstarted": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-previousvalues": {
+    "controls": 10,
+    "error": null
+  },
+  "bootstrap-3/jsf-previousvalues-multidimensional": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-basic": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-default": {
+    "controls": 13,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-inlineref": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-morecomplex": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/jsf-schema-required": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-3/jsf-templating-idx": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-templating-tpldata": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-templating-value": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-3/jsf-templating-values": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-3/json-schema-draft01": {
+    "controls": 17,
+    "error": null
+  },
+  "bootstrap-3/json-schema-draft02": {
+    "controls": 18,
+    "error": null
+  },
+  "bootstrap-3/json-schema-draft03": {
+    "controls": 20,
+    "error": null
+  },
+  "bootstrap-3/json-schema-draft04": {
+    "controls": 19,
+    "error": null
+  },
+  "bootstrap-3/json-schema-draft06": {
+    "controls": 21,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-data-only": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-deep-ref": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-flex-layout": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-layout-only": {
+    "controls": 0,
+    "error": "Cannot set properties of undefined (setting 'isInputWidget')"
+  },
+  "bootstrap-3/ng-jsf-nested-arrays": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-select-list-examples": {
+    "controls": 10,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-select-widget-examples": {
+    "controls": 19,
+    "error": null
+  },
+  "bootstrap-3/ng-jsf-simple-array": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/rjsf-alternatives": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/rjsf-arrays": {
+    "controls": 31,
+    "error": null
+  },
+  "bootstrap-3/rjsf-custom": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/rjsf-date-and-time": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-3/rjsf-errors": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-3/rjsf-files": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-3/rjsf-large": {
+    "controls": 12,
+    "error": null
+  },
+  "bootstrap-3/rjsf-nested": {
+    "controls": 8,
+    "error": null
+  },
+  "bootstrap-3/rjsf-numbers": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-3/rjsf-ordering": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-3/rjsf-references": {
+    "controls": 8,
+    "error": null
+  },
+  "bootstrap-3/rjsf-simple": {
+    "controls": 7,
+    "error": null
+  },
+  "bootstrap-3/rjsf-single": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/asf-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/asf-basic-json-schema-type": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/asf-bootstrap-grid": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/asf-complex-key-support": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/asf-hack-conditional-required": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/asf-kitchen-sink": {
+    "controls": 11,
+    "error": null
+  },
+  "bootstrap-4/asf-simple": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/asf-tab-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/asf-titlemap-examples": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-4/jsf-factory-sleek": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-ace": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-actions": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-advancedfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-array": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-array-simple": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-authfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-autocomplete": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-checkbox": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-checkboxbuttons": {
+    "controls": 0,
+    "error": "value.forEach is not a function"
+  },
+  "bootstrap-4/jsf-fields-checkboxes": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-color": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-common": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-fieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-help": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-hidden": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-iconselect": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-imageselect": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-password": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-questions": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-radiobuttons": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-radios": {
+    "controls": 13,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-range": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-section": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-select": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-selectfieldset": {
+    "controls": 1,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-selectfieldset-key": {
+    "controls": 1,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-submit": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-tabarray": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-tabarray-maxitems": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-tabarray-value": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-fields-textarea": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-gettingstarted": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-previousvalues": {
+    "controls": 10,
+    "error": null
+  },
+  "bootstrap-4/jsf-previousvalues-multidimensional": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-array": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-basic": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-default": {
+    "controls": 13,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-inlineref": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-morecomplex": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/jsf-schema-required": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-4/jsf-templating-idx": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-templating-tpldata": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-templating-value": {
+    "controls": 2,
+    "error": null
+  },
+  "bootstrap-4/jsf-templating-values": {
+    "controls": 4,
+    "error": null
+  },
+  "bootstrap-4/json-schema-draft01": {
+    "controls": 17,
+    "error": null
+  },
+  "bootstrap-4/json-schema-draft02": {
+    "controls": 18,
+    "error": null
+  },
+  "bootstrap-4/json-schema-draft03": {
+    "controls": 20,
+    "error": null
+  },
+  "bootstrap-4/json-schema-draft04": {
+    "controls": 19,
+    "error": null
+  },
+  "bootstrap-4/json-schema-draft06": {
+    "controls": 21,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-data-only": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-deep-ref": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-flex-layout": {
+    "controls": 15,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-layout-only": {
+    "controls": 0,
+    "error": "Cannot set properties of undefined (setting 'isInputWidget')"
+  },
+  "bootstrap-4/ng-jsf-nested-arrays": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-select-list-examples": {
+    "controls": 10,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-select-widget-examples": {
+    "controls": 19,
+    "error": null
+  },
+  "bootstrap-4/ng-jsf-simple-array": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/rjsf-alternatives": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/rjsf-arrays": {
+    "controls": 31,
+    "error": null
+  },
+  "bootstrap-4/rjsf-custom": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/rjsf-date-and-time": {
+    "controls": 5,
+    "error": null
+  },
+  "bootstrap-4/rjsf-errors": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-4/rjsf-files": {
+    "controls": 3,
+    "error": null
+  },
+  "bootstrap-4/rjsf-large": {
+    "controls": 12,
+    "error": null
+  },
+  "bootstrap-4/rjsf-nested": {
+    "controls": 8,
+    "error": null
+  },
+  "bootstrap-4/rjsf-numbers": {
+    "controls": 9,
+    "error": null
+  },
+  "bootstrap-4/rjsf-ordering": {
+    "controls": 6,
+    "error": null
+  },
+  "bootstrap-4/rjsf-references": {
+    "controls": 8,
+    "error": null
+  },
+  "bootstrap-4/rjsf-simple": {
+    "controls": 7,
+    "error": null
+  },
+  "bootstrap-4/rjsf-single": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/asf-array": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/asf-basic-json-schema-type": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/asf-bootstrap-grid": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/asf-complex-key-support": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/asf-hack-conditional-required": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/asf-kitchen-sink": {
+    "controls": 8,
+    "error": null
+  },
+  "material-design/asf-simple": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/asf-tab-array": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/asf-titlemap-examples": {
+    "controls": 14,
+    "error": null
+  },
+  "material-design/jsf-factory-sleek": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/jsf-fields-ace": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-actions": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-advancedfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-array": {
+    "controls": 8,
+    "error": null
+  },
+  "material-design/jsf-fields-array-simple": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-authfieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-autocomplete": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/jsf-fields-checkbox": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/jsf-fields-checkboxbuttons": {
+    "controls": 0,
+    "error": "value.forEach is not a function"
+  },
+  "material-design/jsf-fields-checkboxes": {
+    "controls": 17,
+    "error": null
+  },
+  "material-design/jsf-fields-color": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-common": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-fieldset": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-help": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-hidden": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-iconselect": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-imageselect": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-password": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-questions": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-radiobuttons": {
+    "controls": 0,
+    "error": null
+  },
+  "material-design/jsf-fields-radios": {
+    "controls": 12,
+    "error": null
+  },
+  "material-design/jsf-fields-range": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-section": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/jsf-fields-select": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/jsf-fields-selectfieldset": {
+    "controls": 0,
+    "error": null
+  },
+  "material-design/jsf-fields-selectfieldset-key": {
+    "controls": 0,
+    "error": null
+  },
+  "material-design/jsf-fields-submit": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-tabarray": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-tabarray-maxitems": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-fields-tabarray-value": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-fields-textarea": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-gettingstarted": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-previousvalues": {
+    "controls": 9,
+    "error": null
+  },
+  "material-design/jsf-previousvalues-multidimensional": {
+    "controls": 5,
+    "error": null
+  },
+  "material-design/jsf-schema-array": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/jsf-schema-basic": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-schema-default": {
+    "controls": 12,
+    "error": null
+  },
+  "material-design/jsf-schema-inlineref": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/jsf-schema-morecomplex": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/jsf-schema-required": {
+    "controls": 8,
+    "error": null
+  },
+  "material-design/jsf-templating-idx": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-templating-tpldata": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-templating-value": {
+    "controls": 1,
+    "error": null
+  },
+  "material-design/jsf-templating-values": {
+    "controls": 3,
+    "error": null
+  },
+  "material-design/json-schema-draft01": {
+    "controls": 16,
+    "error": null
+  },
+  "material-design/json-schema-draft02": {
+    "controls": 17,
+    "error": null
+  },
+  "material-design/json-schema-draft03": {
+    "controls": 19,
+    "error": null
+  },
+  "material-design/json-schema-draft04": {
+    "controls": 18,
+    "error": null
+  },
+  "material-design/json-schema-draft06": {
+    "controls": 20,
+    "error": null
+  },
+  "material-design/ng-jsf-data-only": {
+    "controls": 14,
+    "error": null
+  },
+  "material-design/ng-jsf-deep-ref": {
+    "controls": 5,
+    "error": null
+  },
+  "material-design/ng-jsf-flex-layout": {
+    "controls": 14,
+    "error": null
+  },
+  "material-design/ng-jsf-layout-only": {
+    "controls": 0,
+    "error": null
+  },
+  "material-design/ng-jsf-nested-arrays": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/ng-jsf-select-list-examples": {
+    "controls": 9,
+    "error": null
+  },
+  "material-design/ng-jsf-select-widget-examples": {
+    "controls": 12,
+    "error": null
+  },
+  "material-design/ng-jsf-simple-array": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/rjsf-alternatives": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/rjsf-arrays": {
+    "controls": 31,
+    "error": null
+  },
+  "material-design/rjsf-custom": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/rjsf-date-and-time": {
+    "controls": 4,
+    "error": null
+  },
+  "material-design/rjsf-errors": {
+    "controls": 9,
+    "error": null
+  },
+  "material-design/rjsf-files": {
+    "controls": 2,
+    "error": null
+  },
+  "material-design/rjsf-large": {
+    "controls": 11,
+    "error": null
+  },
+  "material-design/rjsf-nested": {
+    "controls": 7,
+    "error": null
+  },
+  "material-design/rjsf-numbers": {
+    "controls": 8,
+    "error": null
+  },
+  "material-design/rjsf-ordering": {
+    "controls": 5,
+    "error": null
+  },
+  "material-design/rjsf-references": {
+    "controls": 7,
+    "error": null
+  },
+  "material-design/rjsf-simple": {
+    "controls": 6,
+    "error": null
+  },
+  "material-design/rjsf-single": {
+    "controls": 1,
+    "error": null
+  },
+  "no-framework/asf-array": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/asf-basic-json-schema-type": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/asf-bootstrap-grid": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/asf-complex-key-support": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/asf-hack-conditional-required": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/asf-kitchen-sink": {
+    "controls": 11,
+    "error": null
+  },
+  "no-framework/asf-simple": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/asf-tab-array": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/asf-titlemap-examples": {
+    "controls": 15,
+    "error": null
+  },
+  "no-framework/jsf-factory-sleek": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/jsf-fields-ace": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-actions": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-advancedfieldset": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-array": {
+    "controls": 9,
+    "error": null
+  },
+  "no-framework/jsf-fields-array-simple": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-authfieldset": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-autocomplete": {
+    "controls": 6,
+    "error": null
+  },
+  "no-framework/jsf-fields-checkbox": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/jsf-fields-checkboxbuttons": {
+    "controls": 0,
+    "error": "value.forEach is not a function"
+  },
+  "no-framework/jsf-fields-checkboxes": {
+    "controls": 15,
+    "error": null
+  },
+  "no-framework/jsf-fields-color": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-common": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-fieldset": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-help": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-hidden": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-iconselect": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-imageselect": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-password": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-questions": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-radiobuttons": {
+    "controls": 9,
+    "error": null
+  },
+  "no-framework/jsf-fields-radios": {
+    "controls": 13,
+    "error": null
+  },
+  "no-framework/jsf-fields-range": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-section": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/jsf-fields-select": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/jsf-fields-selectfieldset": {
+    "controls": 1,
+    "error": null
+  },
+  "no-framework/jsf-fields-selectfieldset-key": {
+    "controls": 1,
+    "error": null
+  },
+  "no-framework/jsf-fields-submit": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-tabarray": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-tabarray-maxitems": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-fields-tabarray-value": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-fields-textarea": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-gettingstarted": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-previousvalues": {
+    "controls": 10,
+    "error": null
+  },
+  "no-framework/jsf-previousvalues-multidimensional": {
+    "controls": 6,
+    "error": null
+  },
+  "no-framework/jsf-schema-array": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/jsf-schema-basic": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-schema-default": {
+    "controls": 13,
+    "error": null
+  },
+  "no-framework/jsf-schema-inlineref": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/jsf-schema-morecomplex": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/jsf-schema-required": {
+    "controls": 9,
+    "error": null
+  },
+  "no-framework/jsf-templating-idx": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-templating-tpldata": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-templating-value": {
+    "controls": 2,
+    "error": null
+  },
+  "no-framework/jsf-templating-values": {
+    "controls": 4,
+    "error": null
+  },
+  "no-framework/json-schema-draft01": {
+    "controls": 17,
+    "error": null
+  },
+  "no-framework/json-schema-draft02": {
+    "controls": 18,
+    "error": null
+  },
+  "no-framework/json-schema-draft03": {
+    "controls": 20,
+    "error": null
+  },
+  "no-framework/json-schema-draft04": {
+    "controls": 19,
+    "error": null
+  },
+  "no-framework/json-schema-draft06": {
+    "controls": 21,
+    "error": null
+  },
+  "no-framework/ng-jsf-data-only": {
+    "controls": 15,
+    "error": null
+  },
+  "no-framework/ng-jsf-deep-ref": {
+    "controls": 6,
+    "error": null
+  },
+  "no-framework/ng-jsf-flex-layout": {
+    "controls": 15,
+    "error": null
+  },
+  "no-framework/ng-jsf-layout-only": {
+    "controls": 0,
+    "error": null
+  },
+  "no-framework/ng-jsf-nested-arrays": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/ng-jsf-select-list-examples": {
+    "controls": 10,
+    "error": null
+  },
+  "no-framework/ng-jsf-select-widget-examples": {
+    "controls": 19,
+    "error": null
+  },
+  "no-framework/ng-jsf-simple-array": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/rjsf-alternatives": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/rjsf-arrays": {
+    "controls": 31,
+    "error": null
+  },
+  "no-framework/rjsf-custom": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/rjsf-date-and-time": {
+    "controls": 5,
+    "error": null
+  },
+  "no-framework/rjsf-errors": {
+    "controls": 9,
+    "error": null
+  },
+  "no-framework/rjsf-files": {
+    "controls": 3,
+    "error": null
+  },
+  "no-framework/rjsf-large": {
+    "controls": 12,
+    "error": null
+  },
+  "no-framework/rjsf-nested": {
+    "controls": 8,
+    "error": null
+  },
+  "no-framework/rjsf-numbers": {
+    "controls": 9,
+    "error": null
+  },
+  "no-framework/rjsf-ordering": {
+    "controls": 6,
+    "error": null
+  },
+  "no-framework/rjsf-references": {
+    "controls": 8,
+    "error": null
+  },
+  "no-framework/rjsf-simple": {
+    "controls": 7,
+    "error": null
+  },
+  "no-framework/rjsf-single": {
+    "controls": 2,
+    "error": null
+  }
+}

--- a/testing/corpus/harness.ts
+++ b/testing/corpus/harness.ts
@@ -1,0 +1,113 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CorpusSchema, loadCorpus } from './schemas';
+import baseline from './baseline.json';
+
+/**
+ * Set to true, run the suites, and copy the printed JSON into baseline.json.
+ * Karma runs in a browser and cannot write files, so recording goes through
+ * the console.
+ */
+const RECORD = false;
+
+export interface CorpusResult {
+  controls: number;
+  error: string | null;
+}
+
+@Component({
+  template: `<json-schema-form [form]="form" [framework]="framework"></json-schema-form>`,
+})
+class CorpusHostComponent {
+  form: any;
+  framework: string;
+}
+
+/**
+ * Counts the form controls the framework actually rendered. Deliberately
+ * counts native elements rather than AJSF internals: it is meant to notice
+ * "this schema stopped rendering" across an Angular upgrade, not to assert
+ * any particular widget implementation.
+ */
+function countControls(fixture: ComponentFixture<CorpusHostComponent>): number {
+  return fixture.nativeElement.querySelectorAll(
+    'input, select, textarea, mat-select, mat-slider'
+  ).length;
+}
+
+/**
+ * `modules` must supply both json-schema-form and the framework under test.
+ *
+ * Do not import JsonSchemaFormModule here. The framework packages import it
+ * from '@ajsf/core', which tsconfig maps to dist/, while ajsf-core's own specs
+ * use the source. Importing it in this file puts both copies in the same
+ * TestBed and Angular fails with NG0300, "Multiple components match node with
+ * tagname json-schema-form". Each spec passes whichever copy is right for it.
+ */
+export function runCorpus(frameworkName: string, modules: Type<any>[]) {
+  describe(`corpus: ${frameworkName}`, () => {
+    const corpus: CorpusSchema[] = loadCorpus();
+    const recorded: Record<string, CorpusResult> = {};
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        // Whatever declares json-schema-form must be in here. Without it the
+        // element matches nothing and every schema renders zero controls while
+        // the suite still reports success.
+        imports: [...modules, NoopAnimationsModule],
+        declarations: [CorpusHostComponent],
+        // Turn an unmatched element or binding into a failure rather than a
+        // console warning, so this cannot silently regress again.
+        schemas: [],
+      }).compileComponents();
+    }));
+
+    afterAll(() => {
+      if (RECORD) {
+        // eslint-disable-next-line no-console
+        console.log(`CORPUS_BASELINE ${frameworkName} ${JSON.stringify(recorded)}`);
+      }
+    });
+
+    it('has schemas to render', () => {
+      expect(corpus.length).toBeGreaterThan(0);
+    });
+
+    corpus.forEach((entry) => {
+      it(`renders ${entry.name}`, () => {
+        const key = `${frameworkName}/${entry.name}`;
+        const fixture = TestBed.createComponent(CorpusHostComponent);
+        fixture.componentInstance.form = entry.form;
+        fixture.componentInstance.framework = frameworkName;
+
+        let error: string | null = null;
+        let controls = 0;
+        try {
+          fixture.detectChanges();
+          controls = countControls(fixture);
+        } catch (e) {
+          error = (e as Error).message || String(e);
+        }
+
+        if (RECORD) {
+          recorded[key] = { controls, error };
+          return;
+        }
+
+        const expected: CorpusResult = (baseline as any)[key];
+        expect(expected)
+          .withContext(`no baseline for ${key}. Re-record with RECORD = true.`)
+          .toBeDefined();
+        if (!expected) { return; }
+
+        expect(error)
+          .withContext(`${key} threw where the baseline did not`)
+          .toEqual(expected.error);
+        expect(controls)
+          .withContext(`${key} rendered ${controls} controls, baseline has ${expected.controls}`)
+          .toEqual(expected.controls);
+      });
+    });
+  });
+}

--- a/testing/corpus/schemas.ts
+++ b/testing/corpus/schemas.ts
@@ -1,0 +1,46 @@
+declare const require: any;
+
+export interface CorpusSchema {
+  /** File name without the .json extension, as used by the demo's example picker. */
+  name: string;
+  /** The whole parsed object, passed to json-schema-form's single `form` input. */
+  form: any;
+}
+
+/**
+ * Four of the example schemas are not valid JSON: they embed JavaScript event
+ * handlers, and the demo falls back to `eval` for those (see
+ * `demo.component.ts`, `generateForm`). Webpack's JSON loader parses at build
+ * time, so including them here would break the build rather than the test.
+ * They are skipped, and `EXPECTED_SKIPPED` keeps that honest: if the count
+ * ever changes, `corpus.spec.ts` fails and someone has to look.
+ */
+export const SKIPPED_NOT_JSON = [
+  'jsf-events',
+  'rjsf-custom-array',
+  'rjsf-validation',
+  'rjsf-widgets',
+];
+
+export function loadCorpus(): CorpusSchema[] {
+  // The exclusion has to live in this regex, not in a .filter() below.
+  // require.context resolves at build time, so webpack's JSON loader parses
+  // every match while bundling. Filtering afterwards is too late: the four
+  // JavaScript-bearing files break the build, and karma then reports
+  // "Executed 0 of 0 SUCCESS" rather than an error.
+  //
+  // Webpack statically analyses this call, so the pattern must be a literal
+  // and cannot be built from SKIPPED_NOT_JSON. The spec asserts the two agree.
+  const context = require.context(
+    '../../demo/assets/example-schemas',
+    false,
+    /^\.\/(?!jsf-events|rjsf-custom-array|rjsf-validation|rjsf-widgets)[^/]*\.json$/
+  );
+  return context
+    .keys()
+    .sort()
+    .map((key: string) => ({
+      name: key.replace(/^\.\//, '').replace(/\.json$/, ''),
+      form: context(key),
+    }));
+}


### PR DESCRIPTION
## Summary

Adds a regression corpus for schema rendering. It covers 80 example schemas in each of the four frameworks, for 320 cases in total.

## How it works

Each case records the number of rendered controls and any thrown error in `testing/corpus/baseline.json`. Later Angular upgrades can compare against this baseline and show which schema or framework changed.

The baseline intentionally records existing behavior, including known errors. This PR does not change product behavior and does not require a release.

The loader excludes examples containing executable event handlers before webpack imports them. The shared harness also accepts each framework's modules explicitly, which avoids loading two copies of `@ajsf/core` into one Angular test module.

## Validation

A baseline entry was changed temporarily to confirm that the suite reports a useful failure, then restored. The final corpus passed with 106 core tests and 82 tests in each framework package.
