### PR TITLE
test(core): cover layout, form group, schema and service

### DIFF
--- a/projects/ajsf-core/src/lib/json-schema-form.service.spec.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.spec.ts
@@ -1,0 +1,1464 @@
+import { TestBed } from '@angular/core/testing';
+import { UntypedFormArray, UntypedFormGroup } from '@angular/forms';
+
+import { JsonSchemaFormModule } from './json-schema-form.module';
+import { JsonSchemaFormService } from './json-schema-form.service';
+import { WidgetLibraryService } from './widget-library/widget-library.service';
+import { convertSchemaToDraft6, resolveSchemaReferences } from './shared';
+
+/**
+ * Characterization tests for JsonSchemaFormService.
+ *
+ * These pin the behaviour the service has today, bugs included. Anything that
+ * looks wrong is still asserted exactly as it really behaves and flagged with a
+ * `// BUG:` comment.
+ *
+ * JsonSchemaFormService is declared `@Injectable()` with no `providedIn`, and
+ * the only place that provides it is JsonSchemaFormComponent. So it has to be
+ * listed in `providers` here; importing JsonSchemaFormModule alone is not
+ * enough. JsonSchemaFormModule is imported from the source path (never dist)
+ * for the same reason corpus.spec.ts does: this project is @ajsf/core itself,
+ * and mixing the two copies produces NG0300.
+ */
+describe('JsonSchemaFormService', () => {
+  let jsf: JsonSchemaFormService;
+  let widgetLibrary: WidgetLibraryService;
+
+  /** Deep clone without pulling lodash into the spec. */
+  const clone = (value: any): any => JSON.parse(JSON.stringify(value));
+
+  /**
+   * Replays the sequence JsonSchemaFormComponent runs in initializeSchema() and
+   * activateForm(), minus the parts that need a rendered component. Everything
+   * downstream (layout, formGroupTemplate, formGroup, dataMap, arrayMap) is
+   * produced by the real code paths.
+   */
+  function buildForm(schema: any, layout: any[] = null, formValues: any = null): void {
+    jsf.resetAllValues();
+    jsf.schema = convertSchemaToDraft6(clone(schema));
+    jsf.compileAjvSchema();
+    jsf.schema = resolveSchemaReferences(
+      jsf.schema,
+      jsf.schemaRefLibrary,
+      jsf.schemaRecursiveRefMap,
+      jsf.dataRecursiveRefMap,
+      jsf.arrayMap
+    );
+    jsf.layout = layout ? clone(layout) : ['*'];
+    jsf.formValues = formValues || {};
+    jsf.buildLayout(widgetLibrary);
+    jsf.buildFormGroupTemplate(jsf.formValues);
+    jsf.buildFormGroup();
+  }
+
+  const personSchema: any = {
+    type: 'object',
+    properties: {
+      name: { type: 'string', title: 'Name', minLength: 3 },
+      age: { type: 'integer' },
+      tags: { type: 'array', title: 'Tag {{idx}}', items: { type: 'string' } },
+    },
+    required: ['name'],
+  };
+
+  /** Index of a top level layout node, by its name. */
+  const nodeIndex = (name: string): number =>
+    jsf.layout.findIndex((node: any) => node.name === name);
+
+  /** A widget context object of the shape the widget components build. */
+  const ctxFor = (name: string): any => {
+    const index = nodeIndex(name);
+    return { layoutNode: jsf.layout[index], dataIndex: [], layoutIndex: [index] };
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [JsonSchemaFormModule],
+      providers: [JsonSchemaFormService],
+    });
+    jsf = TestBed.inject(JsonSchemaFormService);
+    widgetLibrary = TestBed.inject(WidgetLibraryService);
+    jsf.resetAllValues();
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('a newly constructed service, before resetAllValues', () => {
+    // A direct `new` is used here because the shared beforeEach already reset
+    // the injected instance. The constructor takes no arguments, so this is the
+    // same object DI would hand out.
+    let raw: JsonSchemaFormService;
+
+    beforeEach(() => {
+      raw = new JsonSchemaFormService();
+    });
+
+    it('leaves formOptions undefined until resetAllValues runs', () => {
+      // BUG: `formOptions` has no field initializer, so every method that reads
+      // it (setOptions, initializeControl, validateData) fails on a service that
+      // has not been reset yet.
+      expect(raw.formOptions).toBeUndefined();
+    });
+
+    it('throws from setOptions because formOptions is still undefined', () => {
+      // BUG: same root cause as above.
+      expect(() => raw.setOptions({ debug: true })).toThrowError(TypeError);
+    });
+
+    it('starts with empty data, schema and layout', () => {
+      expect(raw.data).toEqual({});
+      expect(raw.schema).toEqual({});
+      expect(raw.layout).toEqual([]);
+    });
+
+    it('starts with a layoutRefLibrary that holds a single null root entry', () => {
+      expect(raw.layoutRefLibrary).toEqual({ '': null });
+    });
+
+    it('starts with no compiled validator and an unknown validity', () => {
+      expect(raw.validateFormData).toBeNull();
+      expect(raw.isValid).toBeNull();
+      expect(raw.validData).toBeNull();
+      expect(raw.formGroup).toBeNull();
+    });
+
+    it('loads the English validation messages from the constructor', () => {
+      expect(raw.language).toEqual('en-US');
+      expect(raw.defaultFormOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('This field is required.');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setLanguage', () => {
+    it('uses the two letter prefix to pick the message set', () => {
+      jsf.setLanguage('fr-FR');
+      expect(jsf.language).toEqual('fr-FR');
+      expect(jsf.defaultFormOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('Est obligatoire.');
+    });
+
+    it('accepts a bare two letter code', () => {
+      jsf.setLanguage('de');
+      expect(jsf.defaultFormOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('Darf nicht leer sein');
+    });
+
+    it('falls back to English when called with no argument', () => {
+      jsf.setLanguage('zh');
+      jsf.setLanguage();
+      expect(jsf.language).toEqual('en-US');
+      expect(jsf.defaultFormOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('This field is required.');
+    });
+
+    it('wipes the validation messages for an unsupported language', () => {
+      // BUG: an unknown language code looks up `undefined` and cloneDeep passes
+      // it straight through, so every field loses its messages instead of
+      // falling back to English.
+      jsf.setLanguage('xx-XX');
+      expect(jsf.language).toEqual('xx-XX');
+      expect(jsf.defaultFormOptions.defautWidgetOptions.validationMessages).toBeUndefined();
+    });
+
+    it('copies the messages rather than sharing the locale object', () => {
+      jsf.setLanguage('en-US');
+      const messages = jsf.defaultFormOptions.defautWidgetOptions.validationMessages;
+      messages.required = 'mutated';
+      jsf.setLanguage('en-US');
+      expect(jsf.defaultFormOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('This field is required.');
+    });
+
+    it('is picked up by the next resetAllValues', () => {
+      jsf.setLanguage('de');
+      jsf.resetAllValues();
+      expect(jsf.formOptions.defautWidgetOptions.validationMessages.required)
+        .toEqual('Darf nicht leer sein');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('getData, getSchema and getLayout', () => {
+    it('returns the live data object', () => {
+      jsf.data = { a: 1 };
+      expect(jsf.getData()).toBe(jsf.data);
+      expect(jsf.getData()).toEqual({ a: 1 });
+    });
+
+    it('returns the live schema object', () => {
+      jsf.schema = { type: 'object' };
+      expect(jsf.getSchema()).toBe(jsf.schema);
+    });
+
+    it('returns the live layout array', () => {
+      jsf.layout = ['*'];
+      expect(jsf.getLayout()).toBe(jsf.layout);
+    });
+
+    it('returns the built schema and layout after a form is built', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      expect(jsf.getSchema().type).toEqual('object');
+      expect(Array.isArray(jsf.getLayout())).toBe(true);
+      expect(jsf.getData()).toEqual(jasmine.objectContaining({ name: 'Bob' }));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('resetAllValues', () => {
+    it('clears the schema, layout, formGroup and data', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      jsf.resetAllValues();
+
+      expect(jsf.schema).toEqual({});
+      expect(jsf.layout).toEqual([]);
+      expect(jsf.formGroup).toBeNull();
+      expect(jsf.formGroupTemplate).toEqual({});
+      expect(jsf.data).toEqual({});
+      expect(jsf.formValues).toEqual({});
+      expect(jsf.validData).toBeNull();
+      expect(jsf.isValid).toBeNull();
+      expect(jsf.validationErrors).toBeNull();
+      expect(jsf.validateFormData).toBeNull();
+      expect(jsf.framework).toBeNull();
+    });
+
+    it('replaces the four lookup maps with empty ones', () => {
+      buildForm(personSchema, null, { name: 'Bob', tags: ['x'] });
+      expect(jsf.arrayMap.size).toBeGreaterThan(0);
+      expect(jsf.dataMap.size).toBeGreaterThan(0);
+
+      jsf.resetAllValues();
+
+      expect(jsf.arrayMap.size).toEqual(0);
+      expect(jsf.dataMap.size).toEqual(0);
+      expect(jsf.dataRecursiveRefMap.size).toEqual(0);
+      expect(jsf.schemaRecursiveRefMap.size).toEqual(0);
+    });
+
+    it('clears the three ref libraries and drops the root layoutRefLibrary key', () => {
+      jsf.resetAllValues();
+      expect(jsf.layoutRefLibrary).toEqual({});
+      expect(jsf.schemaRefLibrary).toEqual({});
+      expect(jsf.templateRefLibrary).toEqual({});
+    });
+
+    it('clears the three compatibility flags and tpldata', () => {
+      jsf.JsonFormCompatibility = true;
+      jsf.ReactJsonSchemaFormCompatibility = true;
+      jsf.AngularSchemaFormCompatibility = true;
+      jsf.setTpldata({ a: 1 });
+
+      jsf.resetAllValues();
+
+      expect(jsf.JsonFormCompatibility).toBe(false);
+      expect(jsf.ReactJsonSchemaFormCompatibility).toBe(false);
+      expect(jsf.AngularSchemaFormCompatibility).toBe(false);
+      expect(jsf.tpldata).toEqual({});
+    });
+
+    it('gives formOptions a fresh copy of defaultFormOptions', () => {
+      jsf.resetAllValues();
+      expect(jsf.formOptions).not.toBe(jsf.defaultFormOptions);
+      expect(jsf.formOptions.addSubmit).toEqual('auto');
+      expect(jsf.formOptions.defautWidgetOptions).not.toBe(
+        jsf.defaultFormOptions.defautWidgetOptions
+      );
+    });
+
+    it('leaves ajvErrors, dataErrors and hasRootReference behind', () => {
+      // BUG: resetAllValues resets validationErrors but not ajvErrors, and it
+      // never clears dataErrors or hasRootReference, so stale state survives a
+      // form reload.
+      jsf.ajvErrors = [{ dataPath: '/x' }];
+      jsf.dataErrors.set('/x', 'boom');
+      jsf.hasRootReference = true;
+
+      jsf.resetAllValues();
+
+      expect(jsf.ajvErrors).toEqual([{ dataPath: '/x' }]);
+      expect(jsf.dataErrors.size).toEqual(1);
+      expect(jsf.hasRootReference).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setOptions', () => {
+    it('assigns top level options onto formOptions', () => {
+      jsf.setOptions({ addSubmit: false, debug: true });
+      expect(jsf.formOptions.addSubmit).toBe(false);
+      expect(jsf.formOptions.debug).toBe(true);
+    });
+
+    it('folds the legacy defaultOptions key into defautWidgetOptions', () => {
+      jsf.setOptions({ defaultOptions: { notitle: true } });
+      expect(jsf.formOptions.defautWidgetOptions.notitle).toBe(true);
+      expect('defaultOptions' in jsf.formOptions).toBe(false);
+    });
+
+    it('merges defautWidgetOptions without replacing the whole object', () => {
+      jsf.setOptions({ defautWidgetOptions: { feedback: true } });
+      expect(jsf.formOptions.defautWidgetOptions.feedback).toBe(true);
+      expect(jsf.formOptions.defautWidgetOptions.addable).toBe(true);
+    });
+
+    it('converts disableErrorState and disableSuccessState to their enable form', () => {
+      jsf.setOptions({
+        defautWidgetOptions: { disableErrorState: true, disableSuccessState: false },
+      });
+      expect(jsf.formOptions.defautWidgetOptions.enableErrorState).toBe(false);
+      expect(jsf.formOptions.defautWidgetOptions.enableSuccessState).toBe(true);
+      expect('disableErrorState' in jsf.formOptions.defautWidgetOptions).toBe(false);
+      expect('disableSuccessState' in jsf.formOptions.defautWidgetOptions).toBe(false);
+    });
+
+    it('copies the incoming options instead of keeping a reference', () => {
+      const incoming: any = { widgets: { custom: 'x' } };
+      jsf.setOptions(incoming);
+      expect(jsf.formOptions.widgets).not.toBe(incoming.widgets);
+      expect(jsf.formOptions.widgets).toEqual({ custom: 'x' });
+    });
+
+    it('ignores null, undefined, strings and numbers', () => {
+      const before = JSON.stringify(Object.keys(jsf.formOptions));
+      jsf.setOptions(null);
+      jsf.setOptions(undefined);
+      jsf.setOptions('nope');
+      jsf.setOptions(5);
+      jsf.setOptions(true);
+      expect(JSON.stringify(Object.keys(jsf.formOptions))).toEqual(before);
+    });
+
+    it('accepts an array without changing anything, because isObject allows arrays', () => {
+      jsf.setOptions([]);
+      expect(jsf.formOptions.addSubmit).toEqual('auto');
+    });
+
+    it('can be called repeatedly, later calls winning', () => {
+      jsf.setOptions({ framework: 'a' });
+      jsf.setOptions({ framework: 'b' });
+      expect(jsf.formOptions.framework).toEqual('b');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('compileAjvSchema', () => {
+    it('throws on a schema that has no properties key', () => {
+      // BUG: the 'ui:order' check reads `this.schema.properties['ui:order']`
+      // without checking that `properties` exists, so a bare
+      // `{ type: 'object' }` schema (which the component passes through
+      // untouched) crashes before ajv is ever called.
+      jsf.schema = { type: 'object' };
+      expect(() => jsf.compileAjvSchema()).toThrowError(TypeError);
+    });
+
+    it('throws on the empty schema left by resetAllValues', () => {
+      expect(() => jsf.compileAjvSchema()).toThrowError(TypeError);
+    });
+
+    it('compiles a valid schema into a callable validator', () => {
+      jsf.schema = { type: 'object', properties: { a: { type: 'string' } } };
+      jsf.compileAjvSchema();
+      expect(typeof jsf.validateFormData).toEqual('function');
+      expect(jsf.validateFormData({ a: 'x' })).toBe(true);
+      expect(jsf.validateFormData({ a: 1 })).toBe(false);
+    });
+
+    it('moves a ui:order array out of properties and onto the schema root', () => {
+      jsf.schema = {
+        type: 'object',
+        properties: { 'ui:order': ['b', 'a'], a: { type: 'string' }, b: { type: 'string' } },
+      };
+      jsf.compileAjvSchema();
+      expect(jsf.schema['ui:order']).toEqual(['b', 'a']);
+      expect('ui:order' in jsf.schema.properties).toBe(false);
+    });
+
+    it('leaves a non array ui:order property alone', () => {
+      jsf.schema = {
+        type: 'object',
+        properties: { 'ui:order': { a: 1 }, a: { type: 'string' } },
+      };
+      jsf.compileAjvSchema();
+      expect(jsf.schema['ui:order']).toBeUndefined();
+      expect(jsf.schema.properties['ui:order']).toEqual({ a: 1 });
+    });
+
+    it('does not recompile once a validator exists', () => {
+      jsf.schema = { type: 'object', properties: { a: { type: 'string' } } };
+      jsf.compileAjvSchema();
+      const first = jsf.validateFormData;
+      jsf.schema = { type: 'object', properties: { b: { type: 'number' } } };
+      jsf.compileAjvSchema();
+      expect(jsf.validateFormData).toBe(first);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('validateData', () => {
+    it('throws when no schema has been compiled yet', () => {
+      spyOn(console, 'error');
+      expect(() => jsf.validateData({ a: 1 })).toThrowError(TypeError);
+    });
+
+    it('marks valid data as valid and mirrors it into validData', () => {
+      buildForm(personSchema, null, { name: 'Bob', age: 42, tags: ['x'] });
+      jsf.validateData({ name: 'Bobby', age: 42, tags: ['x'] });
+
+      expect(jsf.isValid).toBe(true);
+      expect(jsf.validData).toBe(jsf.data);
+      expect(jsf.data).toEqual({ name: 'Bobby', age: 42, tags: ['x'] });
+      expect(jsf.validationErrors).toEqual({});
+      expect(jsf.ajvErrors).toBeNull();
+    });
+
+    it('collects ajv errors keyed by dataPath when the data is invalid', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      jsf.validateData({ name: 'x', age: 1, tags: [] });
+
+      expect(jsf.isValid).toBe(false);
+      expect(jsf.validData).toBeNull();
+      expect(Object.keys(jsf.validationErrors)).toEqual(['/name']);
+      expect(jsf.validationErrors['/name'].length).toEqual(1);
+      expect(Array.isArray(jsf.ajvErrors)).toBe(true);
+      expect(jsf.ajvErrors[0].dataPath).toEqual('/name');
+      expect(jsf.ajvErrors[0].keyword).toEqual('minLength');
+    });
+
+    it('emits on dataChanges, isValidChanges and validationErrorChanges', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      const seen: any = { data: null, valid: null, errors: 'untouched' };
+      jsf.dataChanges.subscribe(value => (seen.data = value));
+      jsf.isValidChanges.subscribe(value => (seen.valid = value));
+      jsf.validationErrorChanges.subscribe(value => (seen.errors = value));
+
+      jsf.validateData({ name: 'Bobby' });
+
+      expect(seen.data).toEqual({ name: 'Bobby' });
+      expect(seen.valid).toBe(true);
+      expect(seen.errors).toBeNull();
+    });
+
+    it('skips the observables when updateSubscriptions is false', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      let emissions = 0;
+      jsf.dataChanges.subscribe(() => emissions++);
+      jsf.isValidChanges.subscribe(() => emissions++);
+      jsf.validationErrorChanges.subscribe(() => emissions++);
+
+      jsf.validateData({ name: 'Bobby' }, false);
+
+      expect(emissions).toEqual(0);
+      expect(jsf.isValid).toBe(true);
+    });
+
+    it('drops empty arrays and objects because returnEmptyFields is read off the wrong level', () => {
+      // BUG: the default lives at formOptions.defautWidgetOptions.returnEmptyFields,
+      // but validateData reads formOptions.returnEmptyFields, which is undefined.
+      // formatFormData therefore always runs with returnEmptyFields falsy.
+      buildForm(personSchema, null, { name: 'Bob' });
+      expect(jsf.formOptions.returnEmptyFields).toBeUndefined();
+      expect(jsf.formOptions.defautWidgetOptions.returnEmptyFields).toBe(true);
+
+      jsf.validateData({ name: 'Bobby', age: null, tags: [] });
+
+      expect(jsf.data).toEqual({ name: 'Bobby' });
+    });
+
+    it('keeps empty containers once returnEmptyFields is set at the top level', () => {
+      buildForm(
+        { type: 'object', properties: { a: { type: 'string' }, list: { type: 'array', items: { type: 'string' } } } },
+        null,
+        {}
+      );
+      jsf.formOptions.returnEmptyFields = true;
+      jsf.validateData(jsf.formGroup.value);
+      expect(jsf.data).toEqual({ a: '', list: [''] });
+    });
+
+    it('runs again whenever the formGroup value changes', () => {
+      buildForm(personSchema, null, { name: 'Bobby' });
+      expect(jsf.isValid).toBe(true);
+
+      jsf.formGroup.get('name').setValue('Al');
+
+      expect(jsf.isValid).toBe(false);
+      expect(jsf.data.name).toEqual('Al');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('buildLayout', () => {
+    it('expands a "*" layout into one node per schema property plus a submit button', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      const types = jsf.layout.map((node: any) => node.type);
+      expect(types).toEqual(['text', 'integer', 'array', 'submit']);
+      expect(jsf.layout.map((node: any) => node.name))
+        .toEqual(['name', 'age', 'tags', undefined]);
+    });
+
+    it('attaches a widget and a dataPointer to each control node', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      const nameNode: any = jsf.layout[0];
+      expect(nameNode.dataPointer).toEqual('/name');
+      expect(nameNode.dataType).toEqual('string');
+      expect(nameNode.widget).toBeDefined();
+      expect(nameNode.options.title).toEqual('Name');
+      expect(nameNode.options.minLength).toEqual(3);
+      expect(nameNode.required).toBe(true);
+    });
+
+    it('honours an explicit layout and drops the properties it does not mention', () => {
+      buildForm(personSchema, [{ key: 'age', title: 'Years' }], {});
+      expect(jsf.layout.map((node: any) => node.name)).toEqual(['age', undefined]);
+      expect(jsf.layout[0].type).toEqual('integer');
+      expect(jsf.layout[0].options.title).toEqual('Years');
+    });
+
+    it('falls back to a known widget type when the layout names an unknown one', () => {
+      buildForm({ type: 'object', properties: { a: { type: 'string' } } },
+        [{ key: 'a', type: 'no-such-widget' }], {});
+      expect(jsf.layout[0].type).toEqual('text');
+      expect(jsf.layout[0].widget).toBeDefined();
+    });
+
+    it('builds one item node per array value plus a trailing $ref add button', () => {
+      buildForm(personSchema, null, { name: 'Bob', tags: ['x', 'y'] });
+      const tags: any = jsf.layout[nodeIndex('tags')];
+      expect(tags.items.length).toEqual(3);
+      expect(tags.items.map((item: any) => item.type)).toEqual(['text', 'text', '$ref']);
+      expect(tags.items.every((item: any) => item.arrayItem === true)).toBe(true);
+      expect(tags.items[2].$ref).toEqual('/tags/-');
+    });
+
+    it('records the array in arrayMap and the item template in templateRefLibrary', () => {
+      buildForm(personSchema, null, { name: 'Bob', tags: ['x'] });
+      expect(jsf.arrayMap.get('/tags')).toEqual(0);
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['/tags/-']);
+      expect(Object.keys(jsf.layoutRefLibrary)).toEqual(['/tags/-']);
+    });
+
+    it('maps every data pointer into dataMap', () => {
+      buildForm(personSchema, null, { name: 'Bob', tags: ['x'] });
+      expect([...jsf.dataMap.keys()]).toEqual(['', '/name', '/age', '/tags', '/tags/-']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('buildFormGroupTemplate and buildFormGroup', () => {
+    it('builds a FormGroup template that mirrors the schema properties', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      expect(jsf.formGroupTemplate.controlType).toEqual('FormGroup');
+      expect(Object.keys(jsf.formGroupTemplate.controls)).toEqual(['name', 'age', 'tags']);
+    });
+
+    it('builds a real FormGroup carrying the supplied values', () => {
+      buildForm(personSchema, null, { name: 'Bob', age: 42, tags: ['x', 'y'] });
+      expect(jsf.formGroup instanceof UntypedFormGroup).toBe(true);
+      expect(jsf.formGroup.value).toEqual({ name: 'Bob', age: 42, tags: ['x', 'y'] });
+      expect(jsf.formGroup.get('tags') instanceof UntypedFormArray).toBe(true);
+    });
+
+    it('applies schema defaults when no form values are supplied', () => {
+      buildForm({ type: 'object', properties: { a: { type: 'string', default: 'D' } } });
+      expect(jsf.formGroup.value).toEqual({ a: 'D' });
+    });
+
+    it('leaves the controls empty when setValues is false', () => {
+      jsf.resetAllValues();
+      jsf.schema = convertSchemaToDraft6({
+        type: 'object', properties: { a: { type: 'string', default: 'D' } },
+      });
+      jsf.compileAjvSchema();
+      jsf.schema = resolveSchemaReferences(
+        jsf.schema, jsf.schemaRefLibrary, jsf.schemaRecursiveRefMap,
+        jsf.dataRecursiveRefMap, jsf.arrayMap
+      );
+      jsf.layout = ['*'];
+      jsf.formValues = { a: 'V' };
+      jsf.buildLayout(widgetLibrary);
+      jsf.buildFormGroupTemplate(jsf.formValues, false);
+      jsf.buildFormGroup();
+
+      expect(jsf.formGroup.value).toEqual({ a: null });
+    });
+
+    it('leaves formGroup null when the template is empty', () => {
+      jsf.buildFormGroup();
+      expect(jsf.formGroup).toBeNull();
+    });
+
+    it('validates immediately after the formGroup is built', () => {
+      buildForm(personSchema, null, { name: 'Bo' });
+      expect(jsf.isValid).toBe(false);
+      expect(jsf.validationErrors['/name']).toBeDefined();
+    });
+
+    it('unsubscribes the previous valueChanges subscription when rebuilt', () => {
+      buildForm(personSchema, null, { name: 'Bob' });
+      const first = jsf.formValueSubscription;
+      jsf.buildFormGroup();
+      expect(jsf.formValueSubscription).not.toBe(first);
+      expect(first.closed).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('getFormControl and friends', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob', age: 42, tags: ['x', 'y'] }));
+
+    it('returns the control for a bound layout node', () => {
+      expect(jsf.getFormControl(ctxFor('name')).value).toEqual('Bob');
+    });
+
+    it('returns the control value directly', () => {
+      // The `AbstractControl` return type on getFormControlValue is wrong: the
+      // method returns `control.value`, so the cast is what the callers really
+      // deal with.
+      expect(<any>jsf.getFormControlValue(ctxFor('name'))).toEqual('Bob');
+    });
+
+    it('returns the containing group for a top level control', () => {
+      expect(jsf.getFormControlGroup(ctxFor('name'))).toBe(jsf.formGroup);
+    });
+
+    it('returns the control name and its indexed data pointer', () => {
+      expect(jsf.getFormControlName(ctxFor('name'))).toEqual('name');
+      expect(jsf.getDataPointer(ctxFor('name'))).toEqual('/name');
+      expect(jsf.getLayoutPointer(ctxFor('name'))).toEqual('/0');
+      expect(jsf.isControlBound(ctxFor('name'))).toBe(true);
+    });
+
+    it('resolves array item pointers through arrayMap', () => {
+      const tagsIndex = nodeIndex('tags');
+      const itemCtx: any = {
+        layoutNode: (jsf.layout[tagsIndex] as any).items[1],
+        dataIndex: [1],
+        layoutIndex: [tagsIndex, 1],
+      };
+      expect(jsf.getDataPointer(itemCtx)).toEqual('/tags/1');
+      expect(<any>jsf.getFormControlValue(itemCtx)).toEqual('y');
+      expect(jsf.getFormControlName(itemCtx)).toEqual('1');
+      expect(jsf.getLayoutPointer(itemCtx)).toEqual('/2/items/1');
+      expect(jsf.isControlBound(itemCtx)).toBe(true);
+    });
+
+    it('returns the layout array and the parent node for a top level node', () => {
+      expect(jsf.getLayoutArray(ctxFor('name')).length).toEqual(4);
+      expect(jsf.getParentNode(ctxFor('name')).length).toEqual(4);
+    });
+
+    it('returns the array node as the parent of an array item', () => {
+      const tagsIndex = nodeIndex('tags');
+      const itemCtx: any = {
+        layoutNode: (jsf.layout[tagsIndex] as any).items[0],
+        dataIndex: [0],
+        layoutIndex: [tagsIndex, 0],
+      };
+      expect(jsf.getParentNode(itemCtx).name).toEqual('tags');
+      expect(jsf.getLayoutArray(itemCtx).length).toEqual(3);
+    });
+
+    it('returns null from every accessor when the context has no layoutNode', () => {
+      spyOn(console, 'error');
+      expect(jsf.getFormControl({})).toBeNull();
+      expect(jsf.getFormControlValue({})).toBeNull();
+      expect(jsf.getFormControlGroup({})).toBeNull();
+      expect(jsf.getFormControlName({})).toBeNull();
+      expect(jsf.getDataPointer({})).toBeNull();
+      expect(jsf.getLayoutPointer({})).toBeNull();
+      expect(jsf.isControlBound({})).toBe(false);
+    });
+
+    it('returns null for a layout node with no dataPointer', () => {
+      const ctx: any = { layoutNode: { name: 'x' }, dataIndex: [], layoutIndex: [0] };
+      expect(jsf.getFormControl(ctx)).toBeNull();
+      expect(jsf.getFormControlValue(ctx)).toBeNull();
+      expect(jsf.getFormControlGroup(ctx)).toBeNull();
+      expect(jsf.getFormControlName(ctx)).toBeNull();
+      expect(jsf.getDataPointer(ctx)).toBeNull();
+    });
+
+    it('refuses to resolve a $ref node to a control', () => {
+      const ctx: any = {
+        layoutNode: { type: '$ref', dataPointer: '/name' }, dataIndex: [], layoutIndex: [0],
+      };
+      expect(jsf.getFormControl(ctx)).toBeNull();
+      expect(jsf.getFormControlValue(ctx)).toBeNull();
+    });
+
+    it('still resolves the containing group for a $ref node', () => {
+      const ctx: any = {
+        layoutNode: { type: '$ref', dataPointer: '/name' }, dataIndex: [], layoutIndex: [0],
+      };
+      expect(jsf.getFormControlGroup(ctx)).toBe(jsf.formGroup);
+    });
+
+    it('returns null from getFormControlName when dataIndex is missing', () => {
+      expect(jsf.getFormControlName({ layoutNode: { dataPointer: '/name' } })).toBeNull();
+      expect(jsf.getDataPointer({ layoutNode: { dataPointer: '/name' } })).toBeNull();
+    });
+
+    it('returns undefined, not null, for a pointer that does not exist', () => {
+      // BUG: getControl falls off the end of its search loop with a bare
+      // `return;`, so getFormControl hands back undefined rather than the null
+      // its signature and its own guard clauses promise.
+      const consoleError = spyOn(console, 'error');
+      const ctx: any = { layoutNode: { dataPointer: '/nope' }, dataIndex: [], layoutIndex: [0] };
+      expect(jsf.getFormControl(ctx)).toBeUndefined();
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('normalises a missing control to null in getFormControlValue', () => {
+      spyOn(console, 'error');
+      const ctx: any = { layoutNode: { dataPointer: '/nope' }, dataIndex: [], layoutIndex: [0] };
+      expect(jsf.getFormControlValue(ctx)).toBeNull();
+    });
+
+    it('reports an unbound control as not bound', () => {
+      spyOn(console, 'error');
+      const ctx: any = { layoutNode: { dataPointer: '/nope' }, dataIndex: [], layoutIndex: [0] };
+      expect(jsf.isControlBound(ctx)).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('initializeControl', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob' }));
+
+    it('returns false for a non object context', () => {
+      expect(jsf.initializeControl(null)).toBe(false);
+      expect(jsf.initializeControl(undefined)).toBe(false);
+      expect(jsf.initializeControl('ctx')).toBe(false);
+      expect(jsf.initializeControl(7)).toBe(false);
+    });
+
+    it('binds a context to its control and fills in the control metadata', () => {
+      const ctx = ctxFor('name');
+      expect(jsf.initializeControl(ctx)).toBe(true);
+      expect(ctx.boundControl).toBe(true);
+      expect(ctx.controlName).toEqual('name');
+      expect(ctx.controlValue).toEqual('Bob');
+      expect(ctx.controlDisabled).toBe(false);
+      expect(ctx.formControl).toBe(jsf.formGroup.get('name'));
+    });
+
+    it('reports the disabled state of the control', () => {
+      jsf.formGroup.get('name').disable();
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.controlDisabled).toBe(true);
+    });
+
+    it('does not bind when bind is false, but still finds the control', () => {
+      const ctx = ctxFor('name');
+      expect(jsf.initializeControl(ctx, false)).toBe(false);
+      expect(ctx.boundControl).toBe(false);
+      expect(ctx.formControl).toBeTruthy();
+      expect(ctx.controlValue).toEqual('Bob');
+    });
+
+    it('copies formOptions into ctx.options when the layout node has none', () => {
+      spyOn(console, 'error');
+      const ctx: any = { layoutNode: { name: 'ghost' }, dataIndex: [], layoutIndex: [0] };
+      jsf.initializeControl(ctx);
+      expect(ctx.options.addSubmit).toEqual('auto');
+      expect(ctx.options).not.toBe(jsf.formOptions);
+    });
+
+    it('keeps the layout node options for a built control node', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options).toBe(jsf.layout[0].options);
+    });
+
+    it('prefers the layoutNode options when they are not empty', () => {
+      const ctx: any = {
+        layoutNode: { name: 'ghost', options: { title: 'T' } },
+        dataIndex: [], layoutIndex: [0],
+      };
+      spyOn(console, 'error');
+      jsf.initializeControl(ctx, false);
+      expect(ctx.options).toBe(ctx.layoutNode.options);
+      expect(ctx.options.title).toEqual('T');
+    });
+
+    it('falls back to the layoutNode name and value for an unbound control', () => {
+      const ctx: any = {
+        layoutNode: { name: 'ghost', value: 'gv' }, dataIndex: [], layoutIndex: [0],
+      };
+      spyOn(console, 'error');
+      expect(jsf.initializeControl(ctx)).toBe(false);
+      expect(ctx.controlName).toEqual('ghost');
+      expect(ctx.controlValue).toEqual('gv');
+    });
+
+    it('uses null when the unbound layoutNode has no value', () => {
+      const ctx: any = { layoutNode: { name: 'ghost' }, dataIndex: [], layoutIndex: [0] };
+      spyOn(console, 'error');
+      jsf.initializeControl(ctx);
+      expect(ctx.controlValue).toBeNull();
+    });
+
+    it('warns on the console when a bound control cannot be found', () => {
+      const consoleError = spyOn(console, 'error');
+      const ctx: any = {
+        layoutNode: { name: 'nope', dataPointer: '/nope' }, dataIndex: [], layoutIndex: [0],
+      };
+      jsf.initializeControl(ctx, true);
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('sets errorMessage to null for a control that already validates', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.errorMessage).toBeNull();
+    });
+
+    it('formats the current errors for a control that does not validate', () => {
+      buildForm(personSchema, null, { name: 'Al' });
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.errorMessage)
+        .toEqual('Must be 3 characters or longer (current length: 2)');
+    });
+
+    it('turns showErrors on for a control that has a value under validateOnRender auto', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.showErrors).toBe(true);
+    });
+
+    it('leaves showErrors off for an empty control under validateOnRender auto', () => {
+      buildForm(personSchema, null, {});
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.showErrors).toBe(false);
+    });
+
+    it('leaves showErrors off when validateOnRender is false', () => {
+      jsf.formOptions.validateOnRender = false;
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.showErrors).toBe(false);
+    });
+
+    it('turns showErrors on for every control when validateOnRender is true', () => {
+      buildForm(personSchema, null, {});
+      jsf.formOptions.validateOnRender = true;
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      expect(ctx.options.showErrors).toBe(true);
+    });
+
+    it('refreshes errorMessage from the statusChanges subscription', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+
+      ctx.formControl.setValue('Al');
+      expect(ctx.options.errorMessage)
+        .toEqual('Must be 3 characters or longer (current length: 2)');
+
+      ctx.formControl.setValue('Alice');
+      expect(ctx.options.errorMessage).toBeNull();
+    });
+
+    it('ignores falsy values in the valueChanges subscription', () => {
+      // BUG: the subscription guards with `if (!!value)`, so clearing a field
+      // leaves ctx.controlValue holding the previous value.
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+
+      ctx.formControl.setValue('Alice');
+      expect(ctx.controlValue).toEqual('Alice');
+
+      ctx.formControl.setValue('');
+      expect(ctx.controlValue).toEqual('Alice');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('formatErrors', () => {
+    it('returns null when there are no errors', () => {
+      expect(jsf.formatErrors(null)).toBeNull();
+      expect(jsf.formatErrors(undefined)).toBeNull();
+      expect(jsf.formatErrors({})).toBeNull();
+    });
+
+    it('shows a required error when it is the only one', () => {
+      expect(jsf.formatErrors({ required: true })).toEqual('Required Error: True');
+    });
+
+    it('hides the required error when another error is present', () => {
+      expect(jsf.formatErrors({
+        required: true,
+        minLength: { minimumLength: 3, currentLength: 1 },
+      })).toEqual('Min Length Error: Minimum Length: 3, Current Length: 1');
+    });
+
+    it('calls a function message with the error data', () => {
+      expect(jsf.formatErrors(
+        { minLength: { minimumLength: 3 } },
+        { minLength: (error: any) => `need ${error.minimumLength}` }
+      )).toEqual('need 3');
+    });
+
+    it('returns a plain string message unchanged', () => {
+      expect(jsf.formatErrors({ minLength: {} }, { minLength: 'Too short' }))
+        .toEqual('Too short');
+    });
+
+    it('substitutes {{property}} placeholders from the error data', () => {
+      expect(jsf.formatErrors(
+        { minLength: { minimumLength: 3, currentLength: 1 } },
+        { minLength: 'Must be {{minimumLength}} long, got {{currentLength}}' }
+      )).toEqual('Must be 3 long, got 1');
+    });
+
+    it('builds a fallback message from the error data when no custom message exists', () => {
+      expect(jsf.formatErrors({ minLength: { minimumLength: 3 } }, {}))
+        .toEqual('Min Length Error: Minimum Length: 3');
+    });
+
+    it('renders boolean error values as the key and its negation', () => {
+      expect(jsf.formatErrors({ someRule: true }, {})).toEqual('Some Rule Error: True');
+      expect(jsf.formatErrors({ someRule: false }, {})).toEqual('Some Rule Error: False');
+    });
+
+    it('renders a scalar error value with underscores turned into spaces', () => {
+      expect(jsf.formatErrors({ some_rule: 'bad' }, {})).toEqual('Some rule Error: Bad');
+    });
+
+    it('joins several errors with a line break', () => {
+      expect(jsf.formatErrors({ aRule: true, bRule: false }, {}))
+        .toEqual('ARule Error: True<br>BRule Error: False');
+    });
+
+    it('ignores a string passed as validationMessages', () => {
+      // BUG: the guard replaces any non object validationMessages with {} before
+      // the `typeof validationMessages === 'string'` branch can ever be reached,
+      // so that branch is dead code and a plain string message is discarded.
+      expect(jsf.formatErrors({ minLength: {} }, 'One message'))
+        .toEqual('Min Length Error: ');
+    });
+
+    it('ignores a number passed as validationMessages', () => {
+      expect(jsf.formatErrors({ someRule: true }, 5)).toEqual('Some Rule Error: True');
+    });
+
+    it('ignores null passed as validationMessages', () => {
+      expect(jsf.formatErrors({ someRule: true }, null)).toEqual('Some Rule Error: True');
+    });
+
+    it('recurses into nested error objects', () => {
+      expect(jsf.formatErrors({ outer: { inner: { deep: true } } }, {}))
+        .toEqual('Outer Error: Inner: Deep');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('parseText', () => {
+    it('returns an empty string when called with no arguments', () => {
+      expect(jsf.parseText()).toEqual('');
+    });
+
+    it('passes through text that has no placeholders', () => {
+      expect(jsf.parseText('plain text')).toEqual('plain text');
+    });
+
+    it('passes null straight through', () => {
+      expect(jsf.parseText(null)).toBeNull();
+    });
+
+    it('substitutes the current value', () => {
+      expect(jsf.parseText('Hi {{value}}', 'Bob')).toEqual('Hi Bob');
+    });
+
+    it('substitutes a one based index for idx and $index', () => {
+      expect(jsf.parseText('Item {{idx}}', {}, {}, 2)).toEqual('Item 3');
+      expect(jsf.parseText('Item {{$index}}', {}, {}, 2)).toEqual('Item 3');
+    });
+
+    it('substitutes several placeholders in one pass', () => {
+      expect(jsf.parseText('{{value.first}} {{value.last}}', { first: 'A', last: 'B' }))
+        .toEqual('A B');
+    });
+
+    it('reads from the surrounding values object, with or without the values prefix', () => {
+      expect(jsf.parseText('{{values.other}}', {}, { other: 'X' })).toEqual('X');
+      expect(jsf.parseText('{{other}}', {}, { other: 'X' })).toEqual('X');
+    });
+
+    it('replaces an unresolvable placeholder with an empty string', () => {
+      expect(jsf.parseText('[{{nope}}]', {}, {})).toEqual('[]');
+    });
+
+    it('reads from tpldata once it has been set', () => {
+      jsf.setTpldata({ site: 'AJSF' });
+      expect(jsf.parseText('{{tpldata.site}}')).toEqual('AJSF');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('parseExpression', () => {
+    it('returns the empty values object for an empty expression', () => {
+      expect(jsf.parseExpression()).toEqual({});
+    });
+
+    it('returns an empty string for a non string expression', () => {
+      expect(jsf.parseExpression(<any>42)).toEqual('');
+      expect(jsf.parseExpression(<any>null)).toEqual('');
+      expect(jsf.parseExpression(<any>{})).toEqual('');
+    });
+
+    it('unwraps a single or double quoted literal', () => {
+      expect(jsf.parseExpression("'hello'")).toEqual('hello');
+      expect(jsf.parseExpression('"hello"')).toEqual('hello');
+    });
+
+    it('refuses to unwrap a literal that contains its own quote character', () => {
+      expect(jsf.parseExpression("'a'b'")).toEqual('');
+    });
+
+    it('turns a numeric key into a one based index', () => {
+      expect(jsf.parseExpression('idx', {}, {}, 3)).toEqual('4');
+      expect(jsf.parseExpression('$index', {}, {}, 0)).toEqual('1');
+    });
+
+    it('uses a string key verbatim', () => {
+      expect(jsf.parseExpression('$index', {}, {}, 'k')).toEqual('k');
+    });
+
+    it('resolves idx to an empty string when there is no key', () => {
+      expect(jsf.parseExpression('idx', {}, {}, null)).toEqual('');
+    });
+
+    it('returns the current value for the bare "value" expression', () => {
+      expect(jsf.parseExpression('value', 'V', {})).toEqual('V');
+    });
+
+    it('prefers a values entry named value over the current value', () => {
+      expect(jsf.parseExpression('value', 'V', { value: 'S' })).toEqual('S');
+    });
+
+    it('resolves a dotted path against value, values and tpldata', () => {
+      expect(jsf.parseExpression('value.a', { a: 1 }, {})).toEqual(<any>1);
+      expect(jsf.parseExpression('values.b', {}, { b: 2 })).toEqual(<any>2);
+      expect(jsf.parseExpression('tpldata.t', {}, {}, null, { t: 'TP' })).toEqual('TP');
+    });
+
+    it('resolves an unprefixed path against values', () => {
+      expect(jsf.parseExpression('c', {}, { c: 3 })).toEqual(<any>3);
+    });
+
+    it('returns an empty string for a path that resolves nowhere', () => {
+      expect(jsf.parseExpression('zzz', {}, {})).toEqual('');
+    });
+
+    it('evaluates an || chain left to right', () => {
+      expect(jsf.parseExpression("zzz || 'fallback'", {}, {})).toEqual('fallback');
+      expect(jsf.parseExpression("a || 'fallback'", {}, { a: 'A' })).toEqual('A');
+    });
+
+    it('evaluates an && chain', () => {
+      expect(jsf.parseExpression('a && b', {}, { a: 'A', b: 'B' })).toEqual('B');
+      expect(jsf.parseExpression('zzz && b', {}, { b: 'B' })).toEqual('');
+    });
+
+    it('concatenates the terms of a + chain', () => {
+      expect(jsf.parseExpression("a + '-' + b", {}, { a: 'A', b: 'B' })).toEqual('A-B');
+    });
+
+    it('returns an empty string for an expression it cannot parse', () => {
+      expect(jsf.parseExpression('a b c')).toEqual('');
+    });
+
+    it('returns an empty string for an indexed path expression', () => {
+      // BUG: [idx] is substituted, but the resulting bracket path is then handed
+      // to parseObjectPath in a form it cannot resolve, so the whole term is
+      // dropped instead of reading the array element.
+      expect(jsf.parseExpression(
+        "values.list[idx].n + ''", {}, { list: [{ n: 'zero' }, { n: 'one' }] }, 0
+      )).toEqual('');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('evaluateCondition', () => {
+    beforeEach(() => {
+      jsf.data = { name: 'Bob', items: [{ flag: true }, { flag: false }] };
+    });
+
+    it('is true when the node has no options at all', () => {
+      expect(jsf.evaluateCondition({}, [])).toBe(true);
+    });
+
+    it('is true when the node has options but no condition', () => {
+      expect(jsf.evaluateCondition({ options: {} }, [])).toBe(true);
+    });
+
+    it('resolves a model prefixed string condition against the data', () => {
+      expect(jsf.evaluateCondition({ options: { condition: 'model.name' } }, [])).toBe(true);
+      expect(jsf.evaluateCondition({ options: { condition: 'model.missing' } }, [])).toBe(false);
+    });
+
+    it('resolves an unprefixed string condition against the data directly', () => {
+      expect(jsf.evaluateCondition({ options: { condition: 'name' } }, [])).toBe(true);
+    });
+
+    it('substitutes [arrayIndex] with the last dataIndex entry', () => {
+      const node = { options: { condition: 'model.items[arrayIndex].flag' } };
+      expect(jsf.evaluateCondition(node, [0])).toBe(true);
+      expect(jsf.evaluateCondition(node, [1])).toBe(false);
+    });
+
+    it('tolerates a null dataIndex', () => {
+      expect(jsf.evaluateCondition({ options: { condition: 'model.name' } }, null)).toBe(true);
+    });
+
+    it('calls a function condition with the data', () => {
+      const condition = jasmine.createSpy('condition').and.returnValue(false);
+      expect(jsf.evaluateCondition({ options: { condition } }, [])).toBe(false);
+      expect(condition).toHaveBeenCalledWith(jsf.data);
+    });
+
+    it('compiles and runs a functionBody condition', () => {
+      expect(jsf.evaluateCondition(
+        { options: { condition: { functionBody: 'return model.name === "Bob";' } } }, []
+      )).toBe(true);
+      expect(jsf.evaluateCondition(
+        { options: { condition: { functionBody: 'return model.name === "Ann";' } } }, []
+      )).toBe(false);
+    });
+
+    it('passes dataIndex to the functionBody as arrayIndices', () => {
+      expect(jsf.evaluateCondition(
+        { options: { condition: { functionBody: 'return arrayIndices[0] === 1;' } } }, [1]
+      )).toBe(true);
+    });
+
+    it('falls back to true and logs when the functionBody throws', () => {
+      const consoleError = spyOn(console, 'error');
+      expect(jsf.evaluateCondition(
+        { options: { condition: { functionBody: 'return nope.nope;' } } }, []
+      )).toBe(true);
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('is true for a condition object with no functionBody', () => {
+      expect(jsf.evaluateCondition({ options: { condition: { foo: 1 } } }, [])).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setItemTitle', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob' }));
+
+    it('returns null for an unnamed array item with no explicit title', () => {
+      expect(jsf.setItemTitle({ options: {}, layoutNode: { name: '2' }, dataIndex: [0] }))
+        .toBeNull();
+      expect(jsf.setItemTitle({ options: {}, layoutNode: { name: '-' }, dataIndex: [0] }))
+        .toBeNull();
+    });
+
+    it('title cases the layout node name when there is no explicit title', () => {
+      expect(jsf.setItemTitle({ options: {}, layoutNode: { name: 'first_name' }, dataIndex: [0] }))
+        .toEqual('First_name');
+    });
+
+    it('resolves the value placeholder to null instead of the control value', () => {
+      // BUG: setItemTitle calls getFormControlValue(this) and
+      // getFormControlGroup(this), passing the service instead of the ctx it was
+      // handed. The service has no layoutNode, so both guards bail out and every
+      // {{value}} placeholder resolves against null.
+      expect(jsf.setItemTitle({
+        options: { title: 'Hello {{value}}' },
+        layoutNode: jsf.layout[0],
+        dataIndex: [],
+      })).toEqual('Hello null');
+    });
+
+    it('uses the explicit title when there is no placeholder', () => {
+      expect(jsf.setItemTitle({
+        options: { title: 'Plain' }, layoutNode: { name: '0' }, dataIndex: [0],
+      })).toEqual('Plain');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setArrayItemTitle', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob', tags: ['x', 'y'] }));
+
+    const tagsCtx = (): any => ctxFor('tags');
+    const tagsItem = (index: number): any => (jsf.layout[nodeIndex('tags')] as any).items[index];
+
+    it('falls back to the parent array title and parses its index placeholder', () => {
+      expect(jsf.setArrayItemTitle(tagsCtx(), tagsItem(0), 0)).toEqual('Tag 1');
+      expect(jsf.setArrayItemTitle(tagsCtx(), tagsItem(0), 1)).toEqual('Tag 2');
+    });
+
+    it('prefers the child title when the child is a $ref node', () => {
+      expect(jsf.setArrayItemTitle(tagsCtx(), tagsItem(2), 0)).toEqual('Add to Tag 1');
+    });
+
+    it('returns the falsy text unchanged when no title or legend is found', () => {
+      const parentCtx: any = {
+        layoutNode: { type: 'section', options: {} }, dataIndex: [], layoutIndex: [0],
+      };
+      expect(jsf.setArrayItemTitle(parentCtx, { type: 'text', options: {} }, 0)).toBeNull();
+    });
+
+    it('throws when called with no arguments at all', () => {
+      // BUG: parentCtx defaults to {}, so parentNode is undefined and the very
+      // next line reads `parentNode.type`.
+      expect(() => jsf.setArrayItemTitle()).toThrowError(TypeError);
+    });
+
+    it('uses the whole parent value when the index is past the end of the array', () => {
+      expect(jsf.setArrayItemTitle(tagsCtx(), tagsItem(0), 99)).toEqual('Tag 100');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('updateValue', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob', age: 42, tags: ['x'] }));
+
+    it('writes the value to the control, the context and the layout node', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+
+      jsf.updateValue(ctx, 'Alice');
+
+      expect(jsf.formGroup.get('name').value).toEqual('Alice');
+      expect(ctx.controlValue).toEqual('Alice');
+      expect(ctx.layoutNode.value).toEqual('Alice');
+      expect(ctx.formControl.dirty).toBe(true);
+    });
+
+    it('updates only the context when the control is not bound', () => {
+      const ctx: any = { layoutNode: { name: 'x' }, options: {}, boundControl: false };
+      jsf.updateValue(ctx, 7);
+      expect(ctx.controlValue).toEqual(7);
+      expect(ctx.layoutNode.value).toEqual(7);
+    });
+
+    it('copies the value into every control listed in copyValueTo', () => {
+      const ctx = ctxFor('name');
+      jsf.initializeControl(ctx);
+      ctx.options.copyValueTo = ['/age'];
+
+      jsf.updateValue(ctx, 'Alice');
+
+      expect(jsf.formGroup.get('age').value).toEqual('Alice');
+      expect(jsf.formGroup.get('age').dirty).toBe(true);
+    });
+
+    it('skips a copyValueTo pointer that resolves to nothing', () => {
+      const consoleError = spyOn(console, 'error');
+      const ctx: any = {
+        layoutNode: { name: 'x' }, options: { copyValueTo: ['/nope'] }, boundControl: false,
+      };
+      expect(() => jsf.updateValue(ctx, 1)).not.toThrow();
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('ignores a copyValueTo value that is not an array', () => {
+      const ctx: any = {
+        layoutNode: { name: 'x' }, options: { copyValueTo: '/age' }, boundControl: false,
+      };
+      expect(() => jsf.updateValue(ctx, 1)).not.toThrow();
+      expect(jsf.formGroup.get('age').value).toEqual(42);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('updateArrayCheckboxList', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob', tags: ['x', 'y'] }));
+
+    it('replaces the formArray contents with the checked items only', () => {
+      jsf.updateArrayCheckboxList(ctxFor('tags'), [
+        { value: 'a', checked: true },
+        { value: 'b', checked: false },
+        { value: 'c', checked: true },
+      ]);
+
+      expect(jsf.formGroup.get('tags').value).toEqual(['a', 'c']);
+      expect(jsf.formGroup.get('tags').dirty).toBe(true);
+    });
+
+    it('empties the formArray when nothing is checked', () => {
+      jsf.updateArrayCheckboxList(ctxFor('tags'), [{ value: 'a', checked: false }]);
+      expect(jsf.formGroup.get('tags').value).toEqual([]);
+    });
+
+    it('empties the formArray for an empty checkbox list', () => {
+      jsf.updateArrayCheckboxList(ctxFor('tags'), []);
+      expect(jsf.formGroup.get('tags').value).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('buildRemoteError', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob' }));
+
+    it('sets the supplied error code and message on the matching control', () => {
+      jsf.buildRemoteError({ name: [{ message: 'Bad name', code: 'bad_name' }] });
+      expect(jsf.formGroup.get('name').errors).toEqual({ bad_name: 'Bad name' });
+    });
+
+    it('keeps only the last error when several are supplied for one control', () => {
+      jsf.buildRemoteError({
+        name: [
+          { message: 'First', code: 'first' },
+          { message: 'Second', code: 'second' },
+        ],
+      });
+      expect(jsf.formGroup.get('name').errors).toEqual({ second: 'Second' });
+    });
+
+    it('ignores keys that do not match a control', () => {
+      expect(() => jsf.buildRemoteError({ nope: [{ message: 'x', code: 'y' }] }))
+        .not.toThrow();
+    });
+
+    it('does nothing for an empty error map', () => {
+      jsf.buildRemoteError({});
+      expect(jsf.formGroup.get('name').errors).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('addItem, moveArrayItem and removeItem', () => {
+    beforeEach(() => buildForm(personSchema, null, { name: 'Bob', tags: ['x', 'y'] }));
+
+    const tagsIndex = (): number => nodeIndex('tags');
+    const tagsNode = (): any => jsf.layout[tagsIndex()];
+    const refCtx = (): any => {
+      const items = tagsNode().items;
+      return {
+        layoutNode: items[items.length - 1],
+        dataIndex: [items.length - 1],
+        layoutIndex: [tagsIndex(), items.length - 1],
+      };
+    };
+    const itemCtx = (index: number): any => ({
+      layoutNode: tagsNode().items[index],
+      dataIndex: [index],
+      layoutIndex: [tagsIndex(), index],
+    });
+
+    it('rejects a context that is missing $ref, dataIndex or layoutIndex', () => {
+      expect(jsf.addItem({})).toBe(false);
+      expect(jsf.addItem({ layoutNode: { $ref: '/tags/-' } })).toBe(false);
+      expect(jsf.addItem({ layoutNode: { $ref: '/tags/-' }, dataIndex: [0] })).toBe(false);
+      expect(jsf.addItem({ layoutNode: {}, dataIndex: [0], layoutIndex: [0] })).toBe(false);
+    });
+
+    it('pushes a new control onto the formArray and a new node into the layout', () => {
+      expect(jsf.addItem(refCtx())).toBe(true);
+      expect(jsf.formGroup.get('tags').value).toEqual(['x', 'y', null]);
+      expect(tagsNode().items.length).toEqual(4);
+    });
+
+    it('copies arrayItem and arrayItemType onto the new layout node', () => {
+      jsf.addItem(refCtx());
+      const added: any = tagsNode().items[tagsNode().items.length - 2];
+      expect(added.arrayItem).toBe(true);
+      expect(added.arrayItemType).toEqual('list');
+      expect(added.type).toEqual('text');
+      expect(added.dataPointer).toEqual('/tags/-');
+    });
+
+    it('adds a named control to the formGroup when the node is not an array item', () => {
+      const items = tagsNode().items;
+      const synthetic: any = clone(items[items.length - 1]);
+      synthetic.arrayItem = false;
+      delete synthetic.arrayItemType;
+      synthetic.dataPointer = '/placeholder';
+      const ctx: any = { layoutNode: synthetic, dataIndex: [], layoutIndex: [jsf.layout.length] };
+
+      expect(jsf.addItem(ctx, 'extra')).toBe(true);
+      expect(jsf.formGroup.get('extra')).toBeTruthy();
+      const added: any = jsf.layout[jsf.layout.length - 1];
+      expect(added.name).toEqual('extra');
+      expect(added.options.title).toEqual('Extra');
+      expect(added.dataPointer).toEqual('/tags/-/extra');
+    });
+
+    it('rejects a moveArrayItem call with a missing or identical index', () => {
+      expect(jsf.moveArrayItem({}, 0, 1)).toBe(false);
+      expect(jsf.moveArrayItem(itemCtx(0), 0, 0)).toBe(false);
+      expect(jsf.moveArrayItem(itemCtx(0), undefined, 1)).toBe(false);
+      expect(jsf.moveArrayItem(itemCtx(0), 0, undefined)).toBe(false);
+    });
+
+    it('moves an item in both the formArray and the layout', () => {
+      expect(jsf.moveArrayItem(itemCtx(0), 0, 1)).toBe(true);
+      expect(jsf.formGroup.get('tags').value).toEqual(['y', 'x']);
+      expect(tagsNode().items.length).toEqual(3);
+    });
+
+    it('rejects a removeItem call with an incomplete context', () => {
+      expect(jsf.removeItem({})).toBe(false);
+      expect(jsf.removeItem({ layoutNode: { dataPointer: '/tags/-' } })).toBe(false);
+      expect(jsf.removeItem({ layoutNode: { dataPointer: '/tags/-' }, dataIndex: [0] }))
+        .toBe(false);
+    });
+
+    it('removes an array item from both the formArray and the layout', () => {
+      expect(jsf.removeItem(itemCtx(0))).toBe(true);
+      expect(jsf.formGroup.get('tags').value).toEqual(['y']);
+      expect(tagsNode().items.length).toEqual(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('buildSchemaFromData and buildSchemaFromLayout', () => {
+    it('infers a draft 6 schema from the internal formValues', () => {
+      jsf.formValues = { a: 'x', n: 3 };
+      jsf.buildSchemaFromData();
+      expect(jsf.schema).toEqual({
+        $schema: 'http://json-schema.org/draft-06/schema#',
+        type: 'object',
+        properties: { a: { type: 'string' }, n: { type: 'number' } },
+      });
+    });
+
+    it('returns the schema without storing it when data is passed in', () => {
+      const before = jsf.schema;
+      const result = jsf.buildSchemaFromData({ z: true });
+      expect(result.properties).toEqual({ z: { type: 'boolean' } });
+      expect(jsf.schema).toBe(before);
+    });
+
+    it('marks every property required when asked to', () => {
+      expect(jsf.buildSchemaFromData({ z: true }, true).required).toEqual(['z']);
+    });
+
+    it('wipes the schema, because buildSchemaFromLayout is an unfinished stub', () => {
+      // BUG: shared/json-schema.functions.ts buildSchemaFromLayout is a bare
+      // `return;` with its body commented out, so calling this method sets the
+      // service schema to undefined.
+      jsf.layout = [{ key: 'a', type: 'text' }];
+      jsf.buildSchemaFromLayout();
+      expect(jsf.schema).toBeUndefined();
+    });
+
+    it('returns undefined for an explicitly passed layout too', () => {
+      expect(jsf.buildSchemaFromLayout([{ key: 'q', type: 'number' }])).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('setTpldata', () => {
+    it('stores the supplied template data', () => {
+      jsf.setTpldata({ a: 1 });
+      expect(jsf.tpldata).toEqual({ a: 1 });
+    });
+
+    it('resets to an empty object when called with no argument', () => {
+      jsf.setTpldata({ a: 1 });
+      jsf.setTpldata();
+      expect(jsf.tpldata).toEqual({});
+    });
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
@@ -1,0 +1,1428 @@
+import {
+  UntypedFormArray,
+  UntypedFormControl,
+  UntypedFormGroup,
+} from '@angular/forms';
+import {
+  buildFormGroup,
+  buildFormGroupTemplate,
+  formatFormData,
+  getControl,
+  mergeValues,
+  setRequiredFields,
+} from './form-group.functions';
+
+/**
+ * Characterization tests for the form group function library.
+ *
+ * Every expectation below was taken from the function's actual output, so a few
+ * of them pin behaviour that is almost certainly wrong. Those are marked BUG.
+ */
+
+/**
+ * Builds a minimal stand-in for the JsonSchemaFormService, with the handful of
+ * properties buildFormGroupTemplate actually reads. A fresh object (and fresh
+ * Maps) is required for every call, because buildFormGroupTemplate mutates
+ * dataMap, templateRefLibrary and formOptions.fieldsRequired as it runs.
+ */
+function makeJsf(schema: any, options: any = {}): any {
+  return {
+    schema,
+    formValues: 'formValues' in options ? options.formValues : {},
+    formOptions: {
+      setSchemaDefaults: 'auto',
+      fieldsRequired: false,
+      ...(options.formOptions || {}),
+    },
+    dataMap: options.dataMap || new Map<string, any>(),
+    arrayMap: options.arrayMap || new Map<string, number>(),
+    dataRecursiveRefMap: options.dataRecursiveRefMap || new Map<string, string>(),
+    schemaRecursiveRefMap: options.schemaRecursiveRefMap || new Map<string, string>(),
+    templateRefLibrary: options.templateRefLibrary || {},
+  };
+}
+
+/** Turns a plain object description into the nested Map shape of jsf.dataMap. */
+function makeDataMap(entries: any): Map<string, any> {
+  const dataMap = new Map<string, any>();
+  Object.keys(entries).forEach(pointer => {
+    dataMap.set(pointer, new Map<string, any>(Object.entries(entries[pointer])));
+  });
+  return dataMap;
+}
+
+const noMap: any = new Map();
+
+describe('form-group.functions', () => {
+
+  describe('buildFormGroupTemplate: FormControl leaves', () => {
+
+    it('builds a FormControl template for a bare string schema', () => {
+      expect(buildFormGroupTemplate(makeJsf({ type: 'string' }))).toEqual({
+        controlType: 'FormControl',
+        value: { value: null, disabled: false },
+        validators: {},
+      } as any);
+    });
+
+    it('stores a primitive nodeValue on the control', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'string' }), 'hi');
+
+      expect(result.value).toEqual({ value: 'hi', disabled: false });
+    });
+
+    it('ignores a non-primitive nodeValue', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'string' }), { a: 1 });
+
+      expect(result.value).toEqual({ value: null, disabled: false });
+    });
+
+    it('reads the disabled flag out of the existing dataMap entry', () => {
+      const dataMap = new Map<string, any>();
+      dataMap.set('', new Map<string, any>([['disabled', true]]));
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'string' }, { dataMap }));
+
+      expect(result.value).toEqual({ value: null, disabled: true });
+    });
+
+    it('falls back to FormControl for an empty schema', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({}));
+
+      expect(result.controlType).toBe('FormControl');
+      expect(result.validators).toEqual({});
+    });
+
+    it('falls back to FormControl for type object without properties', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'object' }));
+
+      expect(result.controlType).toBe('FormControl');
+    });
+
+    it('falls back to FormControl for type array without items', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'array' }));
+
+      expect(result.controlType).toBe('FormControl');
+    });
+
+    it('falls back to FormControl when type is an array of types', () => {
+      // BUG: the controlType test uses `schemaType === 'object'`, so a perfectly
+      // legal `type: ['object', 'null']` schema never becomes a FormGroup and its
+      // properties are silently dropped.
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: ['object', 'null'],
+        properties: { a: { type: 'string' } },
+      }));
+
+      expect(result.controlType).toBe('FormControl');
+      expect(result.controls).toBeUndefined();
+    });
+
+    it('collects string validators from the schema', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'string', minLength: 2, maxLength: 5, pattern: '^a',
+      }));
+
+      expect(result.validators).toEqual({
+        pattern: ['^a'], minLength: [2], maxLength: [5],
+      });
+    });
+
+    it('collects numeric validators including the exclusive flag', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'integer', minimum: 1, exclusiveMinimum: true, maximum: 9, multipleOf: 2,
+      }));
+
+      expect(result.validators).toEqual({
+        minimum: [1, true],
+        maximum: [9, false],
+        multipleOf: [2],
+        type: ['integer'],
+      });
+    });
+
+    it('collects an enum validator', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({ type: 'string', enum: ['a', 'b'] }));
+
+      expect(result.validators).toEqual({ enum: [['a', 'b']] });
+    });
+  });
+
+  describe('buildFormGroupTemplate: FormGroup', () => {
+
+    it('builds a FormGroup for a flat object of two strings', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'string' } },
+      }));
+
+      expect(result).toEqual({
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: { value: null, disabled: false }, validators: {} },
+          b: { controlType: 'FormControl', value: { value: null, disabled: false }, validators: {} },
+        },
+        validators: {},
+      });
+    });
+
+    it('nests a FormGroup inside a FormGroup', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object',
+        properties: { outer: { type: 'object', properties: { inner: { type: 'number' } } } },
+      }));
+
+      expect(result.controls.outer.controlType).toBe('FormGroup');
+      expect(result.controls.outer.controls.inner.controlType).toBe('FormControl');
+      expect(result.controls.outer.controls.inner.validators).toEqual({ type: ['number'] });
+    });
+
+    it('distributes a nodeValue object across the child controls', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'object', properties: { a: { type: 'string' } } }),
+        { a: 'given' }
+      );
+
+      expect(result.controls.a.value).toEqual({ value: 'given', disabled: false });
+    });
+
+    it('produces no controls for additionalProperties without properties', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object', additionalProperties: { type: 'string' },
+      }));
+
+      expect(result.controlType).toBe('FormGroup');
+      expect(result.controls).toEqual({});
+    });
+
+    it('builds an additionalProperties control for a key named only in ui:order', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object',
+        'ui:order': ['a', 'extra'],
+        properties: { a: { type: 'string' } },
+        additionalProperties: { type: 'number' },
+      }));
+
+      expect(Object.keys(result.controls)).toEqual(['a', 'extra']);
+      expect(result.controls.extra.validators).toEqual({ type: ['number'] });
+    });
+
+    it('honours the ui:order key ordering', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object',
+        'ui:order': ['b', 'a'],
+        properties: { a: { type: 'string' }, b: { type: 'string' } },
+      }));
+
+      expect(Object.keys(result.controls)).toEqual(['b', 'a']);
+    });
+
+    it('expands a * in ui:order into the unnamed property keys', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object',
+        'ui:order': ['c', '*'],
+        properties: { a: { type: 'string' }, b: { type: 'string' }, c: { type: 'string' } },
+      }));
+
+      expect(Object.keys(result.controls)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('rewrites the caller ui:order array in place while expanding *', () => {
+      // BUG: propertyKeys is the very array held by schema['ui:order'], and the
+      // splice on line 121 mutates it, so the caller schema is modified.
+      const schema: any = {
+        type: 'object',
+        'ui:order': ['c', '*'],
+        properties: { a: { type: 'string' }, b: { type: 'string' }, c: { type: 'string' } },
+      };
+      buildFormGroupTemplate(makeJsf(schema));
+
+      expect(schema['ui:order']).toEqual(['c', 'a', 'b']);
+    });
+
+    it('skips a ui:order key that matches no property', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object', 'ui:order': ['a', 'zzz'], properties: { a: { type: 'string' } },
+      }));
+
+      expect(Object.keys(result.controls)).toEqual(['a']);
+    });
+  });
+
+  describe('buildFormGroupTemplate: schema defaults', () => {
+
+    it('applies a schema default when setSchemaDefaults is auto and formValues is empty', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'object', properties: { a: { type: 'string', default: 'hello' } },
+      }));
+
+      expect(result.controls.a.value).toEqual({ value: 'hello', disabled: false });
+    });
+
+    it('skips the schema default when setSchemaDefaults is auto and formValues is set', () => {
+      const result: any = buildFormGroupTemplate(makeJsf(
+        { type: 'object', properties: { a: { type: 'string', default: 'hello' } } },
+        { formValues: { a: 'x' } }
+      ));
+
+      expect(result.controls.a.value).toEqual({ value: null, disabled: false });
+    });
+
+    it('applies the schema default when setSchemaDefaults is true even with formValues', () => {
+      const result: any = buildFormGroupTemplate(makeJsf(
+        { type: 'object', properties: { a: { type: 'string', default: 'hello' } } },
+        { formValues: { a: 'x' }, formOptions: { setSchemaDefaults: true } }
+      ));
+
+      expect(result.controls.a.value).toEqual({ value: 'hello', disabled: false });
+    });
+
+    it('never applies a schema default when setSchemaDefaults is false', () => {
+      const result: any = buildFormGroupTemplate(makeJsf(
+        { type: 'object', properties: { a: { type: 'string', default: 'hello' } } },
+        { formOptions: { setSchemaDefaults: false } }
+      ));
+
+      expect(result.controls.a.value).toEqual({ value: null, disabled: false });
+    });
+
+    it('discards the supplied nodeValue when setValues is false', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'object', properties: { a: { type: 'string', default: 'hello' } } }),
+        { a: 'given' }, false
+      );
+
+      expect(result.controls.a.value).toEqual({ value: null, disabled: false });
+    });
+  });
+
+  describe('buildFormGroupTemplate: required fields', () => {
+
+    it('adds a required validator to the named control and reports fieldsRequired', () => {
+      const jsf = makeJsf({
+        type: 'object', required: ['a'],
+        properties: { a: { type: 'string' }, b: { type: 'string' } },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.a.validators).toEqual({ required: [] });
+      expect(result.controls.b.validators).toEqual({});
+      expect(jsf.formOptions.fieldsRequired).toBe(true);
+    });
+
+    it('accepts a bare string as the required value', () => {
+      const jsf = makeJsf({
+        type: 'object', required: 'a', properties: { a: { type: 'string' } },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.a.validators).toEqual({ required: [] });
+      expect(jsf.formOptions.fieldsRequired).toBe(true);
+    });
+
+    it('treats an empty required array as no required fields', () => {
+      const jsf = makeJsf({
+        type: 'object', required: [], properties: { a: { type: 'string' } },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.a.validators).toEqual({});
+      expect(jsf.formOptions.fieldsRequired).toBe(false);
+    });
+
+    it('resets fieldsRequired to false when an outer group has no required list', () => {
+      // BUG: fieldsRequired is assigned (not OR-ed) after the children recurse,
+      // so an outer object with no `required` overwrites the true a nested group
+      // just set, and the form reports that it has no required fields at all.
+      const jsf = makeJsf({
+        type: 'object',
+        properties: {
+          inner: { type: 'object', required: ['x'], properties: { x: { type: 'string' } } },
+        },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.inner.controls.x.validators).toEqual({ required: [] });
+      expect(jsf.formOptions.fieldsRequired).toBe(false);
+    });
+  });
+
+  describe('buildFormGroupTemplate: FormArray with list items', () => {
+
+    it('builds an empty FormArray and one template library entry when no data is given', () => {
+      const jsf = makeJsf({ type: 'array', items: { type: 'string' } });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controlType).toBe('FormArray');
+      expect(result.controls).toEqual([]);
+      expect(jsf.templateRefLibrary['/-']).toEqual({
+        controlType: 'FormControl',
+        value: { value: null, disabled: false },
+        validators: {},
+      });
+    });
+
+    it('builds one control per item of the supplied nodeValue array', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'string' } }), ['a', 'b']
+      );
+
+      expect(result.controls.length).toBe(2);
+      expect(result.controls[0].value).toEqual({ value: 'a', disabled: false });
+      expect(result.controls[1].value).toEqual({ value: 'b', disabled: false });
+    });
+
+    it('builds a FormGroup per item for an array of objects', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'object', properties: { n: { type: 'string' } } } }),
+        [{ n: 'x' }]
+      );
+
+      expect(result.controls.length).toBe(1);
+      expect(result.controls[0].controlType).toBe('FormGroup');
+      expect(result.controls[0].controls.n.value).toEqual({ value: 'x', disabled: false });
+    });
+
+    it('produces no controls for minItems when there is no data', () => {
+      // BUG: minItems is only consulted inside the tuple-items branch, so a plain
+      // list schema with minItems: 3 still starts out with zero controls.
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'string' }, minItems: 3 })
+      );
+
+      expect(result.controls).toEqual([]);
+      expect(result.validators).toEqual({ minItems: [3] });
+    });
+
+    it('truncates the supplied data to maxItems', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'string' }, maxItems: 1 }), ['a', 'b', 'c']
+      );
+
+      expect(result.controls.length).toBe(1);
+      expect(result.controls[0].value).toEqual({ value: 'a', disabled: false });
+    });
+
+    it('collects the array validators', () => {
+      const result: any = buildFormGroupTemplate(makeJsf({
+        type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 4, uniqueItems: true,
+      }));
+
+      expect(result.validators).toEqual({ minItems: [1], maxItems: [4], uniqueItems: [true] });
+    });
+
+    it('seeds the array from tupleItems plus listItems held in the dataMap', () => {
+      const dataMap = new Map<string, any>();
+      dataMap.set('', new Map<string, any>([['tupleItems', 2], ['listItems', 1]]));
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'string' } }, { dataMap })
+      );
+
+      expect(result.controls.length).toBe(3);
+      expect(result.controls[0]).toEqual({
+        controlType: 'FormControl', value: { value: null, disabled: false }, validators: {},
+      });
+    });
+
+    it('caps the seeded array length at the dataMap maxItems', () => {
+      const dataMap = new Map<string, any>();
+      dataMap.set('', new Map<string, any>([['maxItems', 2], ['tupleItems', 5], ['listItems', 0]]));
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: { type: 'string' } }, { dataMap })
+      );
+
+      expect(result.controls.length).toBe(2);
+    });
+
+    it('skips filling the array when the list item pointer is recursive', () => {
+      const jsf = makeJsf(
+        { type: 'array', items: { type: 'string' } },
+        { dataRecursiveRefMap: new Map<string, string>([['/-', '']]) }
+      );
+      const result: any = buildFormGroupTemplate(jsf, ['a', 'b']);
+
+      expect(result.controls).toEqual([]);
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['']);
+    });
+
+    it('throws when additionalItems is given without items', () => {
+      // BUG: with no `items` key the else branch points additionalItemsPointer at
+      // '/items', which resolves to undefined and blows up reading `.type`.
+      expect(() => buildFormGroupTemplate(
+        makeJsf({ type: 'array', additionalItems: { type: 'boolean' } })
+      )).toThrowError(TypeError);
+    });
+  });
+
+  describe('buildFormGroupTemplate: FormArray with tuple items', () => {
+
+    it('builds one control per tuple entry', () => {
+      const jsf = makeJsf({ type: 'array', items: [{ type: 'string' }, { type: 'number' }] });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.length).toBe(2);
+      expect(result.controls[0].validators).toEqual({});
+      expect(result.controls[1].validators).toEqual({ type: ['number'] });
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['/0', '/1']);
+    });
+
+    it('builds tuple entries below minItems directly, without a library entry', () => {
+      const jsf = makeJsf({
+        type: 'array', items: [{ type: 'string' }, { type: 'number' }], minItems: 1,
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.length).toBe(2);
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['/1']);
+    });
+
+    it('fills the tuple entries from the supplied nodeValue array', () => {
+      const result: any = buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: [{ type: 'string' }, { type: 'number' }] }), ['a', 5]
+      );
+
+      expect(result.controls[0].value).toEqual({ value: 'a', disabled: false });
+      expect(result.controls[1].value).toEqual({ value: 5, disabled: false });
+    });
+
+    it('pushes null for a tuple entry whose data pointer is recursive', () => {
+      const jsf = makeJsf(
+        { type: 'array', items: [{ type: 'string' }, { type: 'number' }] },
+        { dataRecursiveRefMap: new Map<string, string>([['/1', '']]) }
+      );
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.length).toBe(2);
+      expect(result.controls[1]).toBeNull();
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['/0', '']);
+    });
+
+    it('registers an additionalItems template alongside the tuple templates', () => {
+      const jsf = makeJsf({
+        type: 'array', items: [{ type: 'string' }], additionalItems: { type: 'boolean' },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.length).toBe(1);
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual(['/0', '/-']);
+    });
+
+    it('throws when the dataMap claims more tuple items than the schema has', () => {
+      const dataMap = new Map<string, any>();
+      dataMap.set('', new Map<string, any>([['tupleItems', 3]]));
+
+      expect(() => buildFormGroupTemplate(
+        makeJsf({ type: 'array', items: [{ type: 'string' }] }, { dataMap })
+      )).toThrowError(TypeError);
+    });
+  });
+
+  describe('buildFormGroupTemplate: $ref', () => {
+
+    it('returns null and leaves the library empty for a root $ref into definitions', () => {
+      // BUG: JsonPointer.toDataPointer is called with the local sub-schema rather
+      // than the root schema, so the reference never resolves and nothing is ever
+      // stored in templateRefLibrary for an ordinary #/definitions/... reference.
+      const jsf = makeJsf({
+        definitions: { thing: { type: 'string' } }, $ref: '#/definitions/thing',
+      });
+
+      expect(buildFormGroupTemplate(jsf)).toBeNull();
+      expect(jsf.templateRefLibrary).toEqual({});
+    });
+
+    it('stores null for a $ref property inside a FormGroup', () => {
+      const jsf = makeJsf({
+        type: 'object',
+        definitions: { thing: { type: 'string' } },
+        properties: { a: { $ref: '#/definitions/thing' } },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.a).toBeNull();
+      expect(jsf.templateRefLibrary).toEqual({});
+    });
+
+    it('does not resolve a $ref that points at a sibling property', () => {
+      const jsf = makeJsf({
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { $ref: '#/properties/a' } },
+      });
+      const result: any = buildFormGroupTemplate(jsf);
+
+      expect(result.controls.a.controlType).toBe('FormControl');
+      expect(result.controls.b).toBeNull();
+      expect(jsf.templateRefLibrary).toEqual({});
+    });
+
+    it('stores the boolean setValues flag as the referenced control value', () => {
+      // BUG: the recursive call on line 251 is
+      // buildFormGroupTemplate(jsf, setValues, setValues, schemaRef), which passes
+      // the boolean setValues where nodeValue belongs, so the stored template
+      // carries `value: true` instead of the schema default or null.
+      const jsf = makeJsf({ $ref: '#/properties/a', properties: { a: { type: 'string' } } });
+
+      expect(buildFormGroupTemplate(jsf)).toBeNull();
+      expect(jsf.templateRefLibrary['/a']).toEqual({
+        controlType: 'FormControl',
+        value: { value: true, disabled: false },
+        validators: {},
+      });
+    });
+
+    it('removes the placeholder library entry when the referenced template is null', () => {
+      const jsf = makeJsf({ $ref: '#/properties/a', properties: { a: { $ref: '#/nowhere' } } });
+
+      expect(buildFormGroupTemplate(jsf)).toBeNull();
+      expect(Object.keys(jsf.templateRefLibrary)).toEqual([]);
+    });
+  });
+
+  describe('buildFormGroupTemplate: dataMap side effects', () => {
+
+    it('records a schemaPointer, schemaType, templatePointer and templateType per node', () => {
+      const jsf = makeJsf({
+        type: 'object', properties: { a: { type: 'string' } },
+      });
+      buildFormGroupTemplate(jsf);
+
+      expect([...jsf.dataMap.keys()]).toEqual(['', '/a']);
+      expect([...jsf.dataMap.get('/a')]).toEqual([
+        ['schemaPointer', '/properties/a'],
+        ['schemaType', 'string'],
+        ['templatePointer', '/controls/a'],
+        ['templateType', 'FormControl'],
+      ]);
+    });
+
+    it('records the pointers of a nested object', () => {
+      const jsf = makeJsf({
+        type: 'object',
+        properties: { outer: { type: 'object', properties: { inner: { type: 'number' } } } },
+      });
+      buildFormGroupTemplate(jsf);
+
+      expect([...jsf.dataMap.keys()]).toEqual(['', '/outer', '/outer/inner']);
+      expect(jsf.dataMap.get('/outer/inner').get('schemaPointer'))
+        .toBe('/properties/outer/properties/inner');
+      expect(jsf.dataMap.get('/outer/inner').get('templatePointer'))
+        .toBe('/controls/outer/controls/inner');
+    });
+
+    it('records the generic /- pointer for a list array item', () => {
+      const jsf = makeJsf({ type: 'array', items: { type: 'string' } });
+      buildFormGroupTemplate(jsf);
+
+      expect([...jsf.dataMap.keys()]).toEqual(['', '/-']);
+      expect(jsf.dataMap.get('/-').get('schemaPointer')).toBe('/items');
+      expect(jsf.dataMap.get('').get('templateType')).toBe('FormArray');
+    });
+
+    it('records an undefined schemaType for a schema with no type', () => {
+      const jsf = makeJsf({});
+      buildFormGroupTemplate(jsf);
+
+      expect(jsf.dataMap.get('').get('schemaType')).toBeUndefined();
+      expect(jsf.dataMap.get('').get('templateType')).toBe('FormControl');
+    });
+
+    it('infers a string schemaType from a format when no type is given', () => {
+      const jsf = makeJsf({ format: 'date-time' });
+      buildFormGroupTemplate(jsf);
+
+      expect(jsf.dataMap.get('').get('schemaType')).toBe('string');
+      expect(jsf.dataMap.get('').get('schemaFormat')).toBe('date-time');
+    });
+
+    it('leaves an existing dataMap entry alone when it already carries a schemaType', () => {
+      const dataMap = new Map<string, any>();
+      dataMap.set('', new Map<string, any>([['schemaType', 'preset']]));
+      const jsf = makeJsf({ type: 'string', format: 'date' }, { dataMap });
+      buildFormGroupTemplate(jsf);
+
+      expect([...jsf.dataMap.get('')]).toEqual([['schemaType', 'preset']]);
+    });
+  });
+
+  describe('buildFormGroupTemplate: defensive inputs', () => {
+
+    it('throws when jsf is null', () => {
+      expect(() => buildFormGroupTemplate(null)).toThrowError(TypeError);
+    });
+
+    it('throws when jsf has no formOptions', () => {
+      expect(() => buildFormGroupTemplate({})).toThrowError(TypeError);
+    });
+
+    it('throws when the schema is undefined', () => {
+      expect(() => buildFormGroupTemplate(makeJsf(undefined))).toThrowError(TypeError);
+    });
+
+    it('throws when the schema is null', () => {
+      expect(() => buildFormGroupTemplate(makeJsf(null))).toThrowError(TypeError);
+    });
+
+    it('throws when the schemaPointer does not resolve', () => {
+      const jsf = makeJsf({ type: 'object', properties: { a: { type: 'string' } } });
+
+      expect(() => buildFormGroupTemplate(jsf, null, true, '/properties/nope'))
+        .toThrowError(TypeError);
+    });
+  });
+
+  describe('buildFormGroup', () => {
+
+    it('returns null for null', () => {
+      expect(buildFormGroup(null)).toBeNull();
+    });
+
+    it('returns null for undefined', () => {
+      expect(buildFormGroup(undefined)).toBeNull();
+    });
+
+    it('returns null for a string', () => {
+      expect(buildFormGroup('nope')).toBeNull();
+    });
+
+    it('returns null for an empty template', () => {
+      expect(buildFormGroup({})).toBeNull();
+    });
+
+    it('returns null for an unrecognised controlType', () => {
+      expect(buildFormGroup({ controlType: 'Nope', validators: {} })).toBeNull();
+    });
+
+    it('builds a FormControl carrying the template value', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: false }, validators: {},
+      });
+
+      expect(control instanceof UntypedFormControl).toBe(true);
+      expect(control.value).toBe('x');
+      expect(control.valid).toBe(true);
+    });
+
+    it('builds a disabled FormControl from the value object', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: true }, validators: {},
+      });
+
+      expect(control.value).toBe('x');
+      expect(control.disabled).toBe(true);
+    });
+
+    it('tolerates a template with no validators key', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: false },
+      });
+
+      expect(control.value).toBe('x');
+    });
+
+    it('tolerates a null validators object', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: false }, validators: null,
+      });
+
+      expect(control.value).toBe('x');
+    });
+
+    it('applies a required validator to a FormControl', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: '', disabled: false },
+        validators: { required: [] },
+      });
+
+      expect(control.valid).toBe(false);
+      expect(control.errors).toEqual({ required: true });
+    });
+
+    it('ignores a validator name that is not on JsonValidators', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: false },
+        validators: { notARealValidator: [1] },
+      });
+
+      expect(control.valid).toBe(true);
+    });
+
+    it('applies a failing minLength validator to a FormControl', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'x', disabled: false },
+        validators: { minLength: [3] },
+      });
+
+      expect(control.errors).toEqual({ minLength: { minimumLength: 3, currentLength: 1 } });
+    });
+
+    it('applies several validators to a FormControl', () => {
+      const control: any = buildFormGroup({
+        controlType: 'FormControl', value: { value: 'xxxxx', disabled: false },
+        validators: { minLength: [2], maxLength: [3] },
+      });
+
+      expect(control.errors).toEqual({ maxLength: { maximumLength: 3, currentLength: 5 } });
+    });
+
+    it('builds a FormGroup from a controls object', () => {
+      const group: any = buildFormGroup({
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: { value: 'A', disabled: false }, validators: {} },
+          b: { controlType: 'FormControl', value: { value: 2, disabled: false }, validators: {} },
+        },
+        validators: {},
+      });
+
+      expect(group instanceof UntypedFormGroup).toBe(true);
+      expect(group.value).toEqual({ a: 'A', b: 2 });
+    });
+
+    it('drops a child template that builds to null', () => {
+      const group: any = buildFormGroup({
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: { value: 'A', disabled: false }, validators: {} },
+          b: null,
+        },
+        validators: {},
+      });
+
+      expect(Object.keys(group.controls)).toEqual(['a']);
+      expect(group.value).toEqual({ a: 'A' });
+    });
+
+    it('applies a single group-level validator', () => {
+      const group: any = buildFormGroup({
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: { value: null, disabled: false }, validators: {} },
+        },
+        validators: { minProperties: [3] },
+      });
+
+      expect(group.valid).toBe(false);
+      expect(group.errors).toEqual({ minProperties: { minimumProperties: 3, currentProperties: 1 } });
+    });
+
+    it('composes two group-level validators', () => {
+      const group: any = buildFormGroup({
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: { value: 'x', disabled: false }, validators: {} },
+          b: { controlType: 'FormControl', value: { value: 'y', disabled: false }, validators: {} },
+        },
+        validators: { minProperties: [5], maxProperties: [9] },
+      });
+
+      expect(group.valid).toBe(false);
+      expect(group.errors).toEqual({ minProperties: { minimumProperties: 5, currentProperties: 2 } });
+    });
+
+    it('builds a FormArray from a controls array', () => {
+      const array: any = buildFormGroup({
+        controlType: 'FormArray',
+        controls: [
+          { controlType: 'FormControl', value: { value: 'x', disabled: false }, validators: {} },
+          { controlType: 'FormControl', value: { value: 'y', disabled: false }, validators: {} },
+        ],
+        validators: {},
+      });
+
+      expect(array instanceof UntypedFormArray).toBe(true);
+      expect(array.length).toBe(2);
+      expect(array.value).toEqual(['x', 'y']);
+    });
+
+    it('filters out array children that build to null', () => {
+      const array: any = buildFormGroup({
+        controlType: 'FormArray',
+        controls: [
+          null,
+          { controlType: 'FormControl', value: { value: 'y', disabled: false }, validators: {} },
+          {},
+        ],
+        validators: {},
+      });
+
+      expect(array.length).toBe(1);
+      expect(array.value).toEqual(['y']);
+    });
+
+    it('applies an array-level minItems validator', () => {
+      const array: any = buildFormGroup({
+        controlType: 'FormArray',
+        controls: [
+          { controlType: 'FormControl', value: { value: 'x', disabled: false }, validators: {} },
+        ],
+        validators: { minItems: [3] },
+      });
+
+      expect(array.valid).toBe(false);
+      expect(array.errors).toEqual({ minItems: { minimumItems: 3, currentItems: 1 } });
+    });
+
+    it('builds nested groups and arrays', () => {
+      const group: any = buildFormGroup({
+        controlType: 'FormGroup',
+        controls: {
+          outer: {
+            controlType: 'FormGroup',
+            controls: {
+              inner: { controlType: 'FormControl', value: { value: 1, disabled: false }, validators: {} },
+            },
+            validators: {},
+          },
+          list: {
+            controlType: 'FormArray',
+            controls: [
+              { controlType: 'FormControl', value: { value: 'a', disabled: false }, validators: {} },
+            ],
+            validators: {},
+          },
+        },
+        validators: {},
+      });
+
+      expect(group.value).toEqual({ outer: { inner: 1 }, list: ['a'] });
+    });
+
+    it('builds a working FormGroup straight from buildFormGroupTemplate', () => {
+      const jsf = makeJsf({
+        type: 'object',
+        required: ['a'],
+        properties: { a: { type: 'string' }, b: { type: 'array', items: { type: 'number' } } },
+      });
+      const template = buildFormGroupTemplate(jsf, { a: 'hello', b: [1, 2] });
+      const group: any = buildFormGroup(template);
+
+      expect(group instanceof UntypedFormGroup).toBe(true);
+      expect(group.value).toEqual({ a: 'hello', b: [1, 2] });
+      expect(group.valid).toBe(true);
+    });
+  });
+
+  describe('mergeValues', () => {
+
+    it('returns null when called with no arguments', () => {
+      expect(mergeValues()).toBeNull();
+    });
+
+    it('returns null when every argument is empty', () => {
+      expect(mergeValues(null, undefined, '')).toBeNull();
+    });
+
+    it('returns a lone primitive unchanged', () => {
+      expect(mergeValues('a')).toBe('a');
+    });
+
+    it('lets a later primitive overwrite an earlier one', () => {
+      expect(mergeValues(1, 2)).toBe(2);
+    });
+
+    it('skips empty values such as 0 and keeps the last non-empty one', () => {
+      expect(mergeValues(0, false)).toBe(false);
+    });
+
+    it('lets a primitive overwrite an object', () => {
+      expect(mergeValues({ a: 1 }, 5)).toBe(5);
+    });
+
+    it('lets an object overwrite a primitive', () => {
+      expect(mergeValues(5, { a: 1 })).toEqual({ a: 1 });
+    });
+
+    it('copies a single object rather than returning it', () => {
+      const source: any = { a: 1 };
+      const result: any = mergeValues(source);
+
+      expect(result).toEqual({ a: 1 });
+      expect(result).not.toBe(source);
+    });
+
+    it('merges two objects key by key', () => {
+      expect(mergeValues({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+    });
+
+    it('lets the later object win on a shared key', () => {
+      expect(mergeValues({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+    });
+
+    it('merges only the top level, replacing nested objects wholesale', () => {
+      expect(mergeValues({ a: { x: 1 } }, { a: { y: 2 } })).toEqual({ a: { y: 2 } });
+    });
+
+    it('overlays a shorter array onto a longer one', () => {
+      expect(mergeValues([1, 2], [3])).toEqual([3, 2]);
+    });
+
+    it('overlays a longer array onto a shorter one', () => {
+      expect(mergeValues([1], [2, 3])).toEqual([2, 3]);
+    });
+
+    it('overlays arrays of arrays without merging their contents', () => {
+      expect(mergeValues([[1], [2]], [[3]])).toEqual([[3], [2]]);
+    });
+
+    it('copies array indexes onto an object as numeric keys', () => {
+      // BUG: isObject() is true for arrays, so the object + array case never
+      // reaches the dedicated array branches and Object.assign copies the array
+      // indexes across as plain keys instead.
+      expect(mergeValues({ a: 1 }, [{ b: 2 }, { c: 3 }]))
+        .toEqual({ 0: { b: 2 }, 1: { c: 3 }, a: 1 } as any);
+    });
+
+    it('assigns object keys onto an array instead of merging into each entry', () => {
+      // BUG: same root cause. The array is kept and the object's keys are pasted
+      // onto it as non-index properties, so lines 336 to 359 are unreachable.
+      const result: any = mergeValues([{ a: 1 }], { c: 3 });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0]).toEqual({ a: 1 });
+      expect(result.c).toBe(3);
+    });
+
+    it('ignores an empty object argument', () => {
+      expect(mergeValues([1, 2], {})).toEqual([1, 2]);
+    });
+
+    it('ignores an empty array argument', () => {
+      expect(mergeValues({}, [1, 2])).toEqual([1, 2]);
+    });
+  });
+
+  describe('setRequiredFields', () => {
+
+    it('sets a required validator for each name in the required array', () => {
+      const template: any = {};
+
+      expect(setRequiredFields({ required: ['a', 'b'] }, template)).toBe(true);
+      expect(template).toEqual({
+        a: { validators: { required: [] } },
+        b: { validators: { required: [] } },
+      });
+    });
+
+    it('writes the validator next to an existing control entry', () => {
+      const template: any = { controls: { a: {} } };
+      setRequiredFields({ required: ['a'] }, template);
+
+      expect(template.a).toEqual({ validators: { required: [] } });
+    });
+
+    it('wraps a bare string required value in an array', () => {
+      const template: any = {};
+
+      expect(setRequiredFields({ required: 'a' }, template)).toBe(true);
+      expect(template).toEqual({ a: { validators: { required: [] } } });
+    });
+
+    it('stringifies a boolean required value into a key', () => {
+      // BUG: `required: true` is a draft-3 style flag, but it is wrapped in an
+      // array and used as a property name, producing a control called "true".
+      const template: any = {};
+
+      expect(setRequiredFields({ required: true }, template)).toBe(true);
+      expect(template).toEqual({ true: { validators: { required: [] } } });
+    });
+
+    it('returns false and changes nothing when there is no required key', () => {
+      const template: any = {};
+
+      expect(setRequiredFields({ type: 'object' }, template)).toBe(false);
+      expect(template).toEqual({});
+    });
+
+    it('returns false for an empty required array', () => {
+      const template: any = {};
+
+      expect(setRequiredFields({ required: [] }, template)).toBe(false);
+      expect(template).toEqual({});
+    });
+
+    it('returns false for a null schema', () => {
+      expect(setRequiredFields(null, {})).toBe(false);
+    });
+
+    it('returns false for an undefined schema', () => {
+      expect(setRequiredFields(undefined, {})).toBe(false);
+    });
+
+    it('throws when the template is null and there are required fields', () => {
+      expect(() => setRequiredFields({ required: ['a'] }, null)).toThrowError(TypeError);
+    });
+  });
+
+  describe('formatFormData', () => {
+
+    let errorSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      errorSpy = spyOn(console, 'error');
+    });
+
+    it('returns a non-object input unchanged', () => {
+      expect(formatFormData('str', noMap, noMap, noMap)).toBe('str');
+      expect(formatFormData(7, noMap, noMap, noMap)).toBe(7);
+      expect(formatFormData(null, noMap, noMap, noMap)).toBeNull();
+      expect(formatFormData(undefined, noMap, noMap, noMap)).toBeUndefined();
+    });
+
+    it('converts a string to an integer', () => {
+      const dataMap = makeDataMap({ '/n': { schemaType: 'integer' } });
+
+      expect(formatFormData({ n: '42' }, dataMap, noMap, noMap)).toEqual({ n: 42 });
+    });
+
+    it('converts a string to a number', () => {
+      const dataMap = makeDataMap({ '/n': { schemaType: 'number' } });
+
+      expect(formatFormData({ n: '4.5' }, dataMap, noMap, noMap)).toEqual({ n: 4.5 });
+    });
+
+    it('converts a string to a boolean', () => {
+      const dataMap = makeDataMap({ '/b': { schemaType: 'boolean' } });
+
+      expect(formatFormData({ b: 'true' }, dataMap, noMap, noMap)).toEqual({ b: true });
+    });
+
+    it('converts a number to a string', () => {
+      const dataMap = makeDataMap({ '/s': { schemaType: 'string' } });
+
+      expect(formatFormData({ s: 12 }, dataMap, noMap, noMap)).toEqual({ s: '12' });
+    });
+
+    it('accepts an array of schema types', () => {
+      const dataMap = makeDataMap({ '/a': { schemaType: ['string', 'null'] } });
+
+      expect(formatFormData({ a: 5 }, dataMap, noMap, noMap)).toEqual({ a: '5' });
+    });
+
+    it('keeps a false boolean and a zero number', () => {
+      const dataMap = makeDataMap({ '/a': { schemaType: 'boolean' }, '/b': { schemaType: 'number' } });
+
+      expect(formatFormData({ a: false, b: 0 }, dataMap, noMap, noMap)).toEqual({ a: false, b: 0 });
+    });
+
+    it('forces a null schemaType to null whatever the value was', () => {
+      const dataMap = makeDataMap({ '/z': { schemaType: 'null' } });
+
+      expect(formatFormData({ z: 'anything' }, dataMap, noMap, noMap)).toEqual({ z: null });
+    });
+
+    it('drops a value that cannot be converted when fixErrors is off', () => {
+      const dataMap = makeDataMap({ '/n': { schemaType: 'integer' } });
+
+      expect(formatFormData({ n: 'abc' }, dataMap, noMap, noMap)).toEqual({});
+    });
+
+    it('coerces a value that cannot be converted when fixErrors is on', () => {
+      const dataMap = makeDataMap({ '/n': { schemaType: 'integer' } });
+
+      expect(formatFormData({ n: 'abc' }, dataMap, noMap, noMap, false, true)).toEqual({ n: 0 });
+    });
+
+    it('drops an empty string by default', () => {
+      const dataMap = makeDataMap({ '/s': { schemaType: 'string' } });
+
+      expect(formatFormData({ s: '' }, dataMap, noMap, noMap)).toEqual({});
+    });
+
+    it('keeps an empty string when returnEmptyFields is on', () => {
+      const dataMap = makeDataMap({ '/s': { schemaType: 'string' } });
+
+      expect(formatFormData({ s: '' }, dataMap, noMap, noMap, true)).toEqual({ s: '' });
+    });
+
+    it('turns a null string field into an empty string when returnEmptyFields is on', () => {
+      const dataMap = makeDataMap({ '/s': { schemaType: 'string' } });
+
+      expect(formatFormData({ s: null }, dataMap, noMap, noMap, true)).toEqual({ s: '' });
+    });
+
+    it('drops empty arrays and objects by default', () => {
+      const dataMap = makeDataMap({
+        '/arr': { schemaType: 'array' }, '/obj': { schemaType: 'object' },
+      });
+
+      expect(formatFormData({ arr: [], obj: {} }, dataMap, noMap, noMap)).toEqual({});
+    });
+
+    it('keeps empty arrays and objects when returnEmptyFields is on', () => {
+      const dataMap = makeDataMap({
+        '/arr': { schemaType: 'array' }, '/obj': { schemaType: 'object' },
+      });
+
+      expect(formatFormData({ arr: [], obj: {} }, dataMap, noMap, noMap, true))
+        .toEqual({ arr: [], obj: {} });
+    });
+
+    it('drops a value whose schemaType is a container type', () => {
+      const dataMap = makeDataMap({ '/a': { schemaType: 'array' } });
+
+      expect(formatFormData({ a: ['x'] }, dataMap, noMap, noMap)).toEqual({});
+    });
+
+    it('drops a value whose dataMap entry has no schemaType', () => {
+      const dataMap = makeDataMap({ '/a': { schemaPointer: '/properties/a' } });
+
+      expect(formatFormData({ a: 'v' }, dataMap, noMap, noMap)).toEqual({});
+    });
+
+    it('walks into nested objects', () => {
+      const dataMap = makeDataMap({
+        '/o': { schemaType: 'object' }, '/o/n': { schemaType: 'integer' },
+      });
+
+      expect(formatFormData({ o: { n: '3' } }, dataMap, noMap, noMap)).toEqual({ o: { n: 3 } });
+    });
+
+    it('returns an array when the form data is an array', () => {
+      const dataMap = makeDataMap({
+        '/0': { schemaType: 'integer' }, '/1': { schemaType: 'integer' },
+      });
+      const result: any = formatFormData(['1', '2'], dataMap, noMap, noMap);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([1, 2]);
+    });
+
+    it('uses the arrayMap to find the generic pointer of an array item', () => {
+      const dataMap = makeDataMap({
+        '': { schemaType: 'object' },
+        '/list': { schemaType: 'array' },
+        '/list/-': { schemaType: 'object' },
+        '/list/-/n': { schemaType: 'integer' },
+      });
+      const arrayMap: any = new Map([['/list', 0]]);
+
+      expect(formatFormData({ list: [{ n: '1' }, { n: '2' }] }, dataMap, noMap, arrayMap))
+        .toEqual({ list: [{ n: 1 }, { n: 2 }] });
+    });
+
+    it('serialises a Date value through the string schema type', () => {
+      // Built from local date parts, because toIsoString reads getFullYear,
+      // getMonth and getDate, all of which are timezone dependent.
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string' } });
+      const result: any = formatFormData({ d: new Date(2000, 2, 14) }, dataMap, noMap, noMap);
+
+      expect(result.d).toBe('2000-03-14');
+    });
+
+    it('appends Z to a date-time missing its timezone', () => {
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14T01:59:26.535' }, dataMap, noMap, noMap))
+        .toEqual({ d: '2000-03-14T01:59:26.535Z' });
+    });
+
+    it('appends :00Z to a date-time missing its seconds', () => {
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14T01:59' }, dataMap, noMap, noMap))
+        .toEqual({ d: '2000-03-14T01:59:00Z' });
+    });
+
+    it('accepts a space instead of T as the date-time separator', () => {
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14 01:59' }, dataMap, noMap, noMap))
+        .toEqual({ d: '2000-03-14 01:59:00Z' });
+    });
+
+    it('leaves a complete date-time alone', () => {
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14T01:59:26.535Z' }, dataMap, noMap, noMap))
+        .toEqual({ d: '2000-03-14T01:59:26.535Z' });
+    });
+
+    it('leaves a bare date alone when fixErrors is off', () => {
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14' }, dataMap, noMap, noMap))
+        .toEqual({ d: '2000-03-14' });
+    });
+
+    it('builds an invalid date-time when fixing a bare date', () => {
+      // BUG: the comment above the branch says it should append 'T00:00:00Z', but
+      // the template literal appends ':00:00:00Z', producing '2000-03-14:00:00:00Z'.
+      const dataMap = makeDataMap({ '/d': { schemaType: 'string', schemaFormat: 'date-time' } });
+
+      expect(formatFormData({ d: '2000-03-14' }, dataMap, noMap, noMap, false, true))
+        .toEqual({ d: '2000-03-14:00:00:00Z' });
+    });
+
+    it('logs an error and drops a primitive with no dataMap entry', () => {
+      expect(formatFormData({ x: 'y' }, noMap, noMap, noMap)).toEqual({});
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('logs only for the leaf value when a nested object has no dataMap entry', () => {
+      // The containing object skips the error branch (its value is an object),
+      // so only the leaf number reaches the console.error block.
+      expect(formatFormData({ x: { y: 1 } }, noMap, noMap, noMap)).toEqual({});
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getControl', () => {
+
+    let errorSpy: jasmine.Spy;
+    let group: UntypedFormGroup;
+    let template: any;
+
+    beforeEach(() => {
+      errorSpy = spyOn(console, 'error');
+      group = new UntypedFormGroup({
+        a: new UntypedFormControl('A'),
+        g: new UntypedFormGroup({ b: new UntypedFormControl('B') }),
+        arr: new UntypedFormArray([
+          new UntypedFormControl('one'), new UntypedFormControl('two'),
+        ]),
+      });
+      template = {
+        controlType: 'FormGroup',
+        controls: {
+          a: { controlType: 'FormControl', value: 'A' },
+          g: {
+            controlType: 'FormGroup',
+            controls: { b: { controlType: 'FormControl', value: 'B' } },
+          },
+          arr: {
+            controlType: 'FormArray',
+            controls: [{ controlType: 'FormControl', value: 'one' }],
+          },
+        },
+      };
+    });
+
+    it('returns a top level control of a real FormGroup', () => {
+      const control: any = getControl(group, '/a');
+
+      expect(control instanceof UntypedFormControl).toBe(true);
+      expect(control.value).toBe('A');
+    });
+
+    it('returns a nested control of a real FormGroup', () => {
+      expect(getControl(group, '/g/b').value).toBe('B');
+    });
+
+    it('returns the containing group when returnGroup is true', () => {
+      const control: any = getControl(group, '/g/b', true);
+
+      expect(control instanceof UntypedFormGroup).toBe(true);
+      expect(control.value).toEqual({ b: 'B' });
+    });
+
+    it('returns the root group when returnGroup is used on a top level control', () => {
+      expect(getControl(group, '/a', true)).toBe(group as any);
+    });
+
+    it('returns the group itself for the empty root pointer', () => {
+      expect(getControl(group, '')).toBe(group as any);
+    });
+
+    it('accepts an array pointer', () => {
+      expect(getControl(group, ['g', 'b']).value).toBe('B');
+    });
+
+    it('returns the group itself for an empty array pointer', () => {
+      expect(getControl(group, [])).toBe(group as any);
+    });
+
+    it('falls back to dot notation when the pointer is not a JSON pointer', () => {
+      expect(getControl(group, 'g.b').value).toBe('B');
+    });
+
+    it('returns null for a dot path that matches nothing', () => {
+      expect(getControl(group, 'nope.nope')).toBeNull();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('resolves an indexed FormArray item', () => {
+      expect(getControl(group, '/arr/0').value).toBe('one');
+    });
+
+    it('resolves the last FormArray item for the - key', () => {
+      expect(getControl(group, '/arr/-').value).toBe('two');
+    });
+
+    it('works when the root is a FormArray', () => {
+      const array = new UntypedFormArray([new UntypedFormControl('z')]);
+
+      expect(getControl(array, '/0').value).toBe('z');
+      expect(getControl(array, '/-').value).toBe('z');
+    });
+
+    it('returns undefined and logs when a key is missing', () => {
+      // BUG: the failure path ends in a bare `return;`, so a missing control comes
+      // back as undefined here while the invalid-input paths return null.
+      expect(getControl(group, '/missing')).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('walks a key that contains a dot instead of using formGroup.get', () => {
+      const dotted: any = { controls: { 'a.b': { controlType: 'FormControl', value: 1 } } };
+
+      expect(getControl(dotted, ['a.b'])).toEqual({ controlType: 'FormControl', value: 1 });
+    });
+
+    it('reads a control out of a formGroup template', () => {
+      expect(getControl(template, '/a')).toEqual({ controlType: 'FormControl', value: 'A' });
+    });
+
+    it('reads a nested control out of a formGroup template', () => {
+      expect(getControl(template, '/g/b')).toEqual({ controlType: 'FormControl', value: 'B' });
+    });
+
+    it('reads the containing group out of a formGroup template', () => {
+      expect(getControl(template, '/g/b', true)).toEqual({
+        controlType: 'FormGroup',
+        controls: { b: { controlType: 'FormControl', value: 'B' } },
+      });
+    });
+
+    it('reads the last entry of a template FormArray', () => {
+      expect(getControl(template, '/arr/-')).toEqual({ controlType: 'FormControl', value: 'one' });
+    });
+
+    it('reads the last entry when the template controls are a bare array', () => {
+      const bare: any = {
+        controls: [
+          { controlType: 'FormControl', value: 1 },
+          { controlType: 'FormControl', value: 2 },
+        ],
+      };
+
+      expect(getControl(bare, '/-')).toEqual({ controlType: 'FormControl', value: 2 });
+    });
+
+    it('returns undefined and logs for a missing key in a template', () => {
+      expect(getControl(template, '/zzz')).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('returns null when the formGroup is not an object', () => {
+      expect(getControl(null, '/a')).toBeNull();
+      expect(getControl(undefined, '/a')).toBeNull();
+      expect(getControl('nope', '/a')).toBeNull();
+    });
+
+    it('returns null for a pointer that is neither a JSON pointer nor a matching path', () => {
+      expect(getControl(group, 'not a pointer')).toBeNull();
+    });
+
+    it('returns null for a non-string, non-array pointer', () => {
+      expect(getControl(group, 5 as any)).toBeNull();
+      expect(getControl(group, undefined)).toBeNull();
+    });
+
+    it('throws on a dot path when the subject has no get method', () => {
+      // BUG: formGroup.get is called before checking that it exists, so passing a
+      // formGroup template plus a dot path throws instead of logging and
+      // returning null the way the invalid-pointer path is meant to.
+      expect(() => getControl(template, 'a.b')).toThrowError(TypeError);
+    });
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
@@ -1,0 +1,1493 @@
+import {
+  buildSchemaFromData,
+  buildSchemaFromLayout,
+  checkInlineType,
+  combineAllOf,
+  fixRequiredArrayProperties,
+  getControlValidators,
+  getFromSchema,
+  getInputType,
+  getSubSchema,
+  getTitleMapFromOneOf,
+  isInputRequired,
+  removeRecursiveReferences,
+  resolveSchemaReferences,
+  updateInputOptions,
+} from './json-schema.functions';
+
+/**
+ * Characterization tests for the JSON Schema function library.
+ * These pin the behaviour the functions have today, including several results
+ * that are almost certainly bugs (see the comments marked BUG).
+ */
+describe('JSON Schema functions', () => {
+
+  describe('buildSchemaFromLayout', () => {
+    it('returns undefined for a layout array (the function body is commented out)', () => {
+      expect(buildSchemaFromLayout([{ key: 'name' }, 'address'])).toBeUndefined();
+    });
+
+    it('returns undefined for null and undefined layouts', () => {
+      expect(buildSchemaFromLayout(null)).toBeUndefined();
+      expect(buildSchemaFromLayout(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('buildSchemaFromData', () => {
+    const draft6 = 'http://json-schema.org/draft-06/schema#';
+
+    it('builds a string schema from a string, adding $schema at the root', () => {
+      expect(buildSchemaFromData('hello')).toEqual({ $schema: draft6, type: 'string' });
+    });
+
+    it('builds a number schema from a float', () => {
+      expect(buildSchemaFromData(4.5)).toEqual({ $schema: draft6, type: 'number' });
+    });
+
+    it('reports an integer as type number', () => {
+      expect(buildSchemaFromData(7)).toEqual({ $schema: draft6, type: 'number' });
+    });
+
+    it('reports a numeric string as type string (getType is called in strict mode)', () => {
+      expect(buildSchemaFromData('10')).toEqual({ $schema: draft6, type: 'string' });
+    });
+
+    it('builds a boolean schema from a boolean', () => {
+      expect(buildSchemaFromData(true)).toEqual({ $schema: draft6, type: 'boolean' });
+      expect(buildSchemaFromData(false)).toEqual({ $schema: draft6, type: 'boolean' });
+    });
+
+    it('reports null as type string', () => {
+      expect(buildSchemaFromData(null)).toEqual({ $schema: draft6, type: 'string' });
+    });
+
+    it('reports undefined as type string', () => {
+      expect(buildSchemaFromData(undefined)).toEqual({ $schema: draft6, type: 'string' });
+    });
+
+    it('omits $schema when isRoot is false', () => {
+      expect(buildSchemaFromData('hello', false, false)).toEqual({ type: 'string' });
+    });
+
+    it('builds an object schema with empty properties from an empty object', () => {
+      expect(buildSchemaFromData({})).toEqual({ $schema: draft6, type: 'object', properties: {} });
+    });
+
+    it('recurses into nested objects without repeating $schema', () => {
+      expect(buildSchemaFromData({ a: 'x', b: { c: 1 } })).toEqual({
+        $schema: draft6,
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'object', properties: { c: { type: 'number' } } },
+        },
+      });
+    });
+
+    it('adds a required list holding every key when requireAllFields is true', () => {
+      expect(buildSchemaFromData({ a: 'x', b: 2 }, true)).toEqual({
+        $schema: draft6,
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'number' } },
+        required: ['a', 'b'],
+      });
+    });
+
+    it('collapses items to a single schema when every array entry has the same type', () => {
+      expect(buildSchemaFromData(['a', 'b'])).toEqual({
+        $schema: draft6, type: 'array', items: { type: 'string' },
+      });
+    });
+
+    it('collapses integers and floats together because both map to number', () => {
+      expect(buildSchemaFromData([1, 2.5])).toEqual({
+        $schema: draft6, type: 'array', items: { type: 'number' },
+      });
+    });
+
+    it('collapses null together with strings because null maps to string', () => {
+      expect(buildSchemaFromData([null, 'a'])).toEqual({
+        $schema: draft6, type: 'array', items: { type: 'string' },
+      });
+    });
+
+    it('keeps an items tuple when the array entries have different types', () => {
+      expect(buildSchemaFromData(['a', 1])).toEqual({
+        $schema: draft6, type: 'array', items: [{ type: 'string' }, { type: 'number' }],
+      });
+    });
+
+    it('leaves items as an empty array for an empty array', () => {
+      expect(buildSchemaFromData([])).toEqual({ $schema: draft6, type: 'array', items: [] });
+    });
+
+    it('adds minItems 1 to an array when requireAllFields is true', () => {
+      expect(buildSchemaFromData(['a'], true)).toEqual({
+        $schema: draft6, type: 'array', items: { type: 'string' }, minItems: 1,
+      });
+    });
+
+    it('passes requireAllFields down into nested values', () => {
+      expect(buildSchemaFromData({ list: [1, 2] }, true)).toEqual({
+        $schema: draft6,
+        type: 'object',
+        properties: { list: { type: 'array', items: { type: 'number' }, minItems: 1 } },
+        required: ['list'],
+      });
+    });
+
+    it('loses the properties of earlier entries when merging same typed object items', () => {
+      // BUG: the item schemas are combined with a shallow spread reduce, so the
+      // properties object of the last entry replaces all the earlier ones.
+      expect(buildSchemaFromData([{ a: 1 }, { b: 2 }])).toEqual({
+        $schema: draft6,
+        type: 'array',
+        items: { type: 'object', properties: { b: { type: 'number' } } },
+      });
+    });
+
+    it('treats a Date as an object with no properties', () => {
+      expect(buildSchemaFromData(new Date(0))).toEqual({
+        $schema: draft6, type: 'object', properties: {},
+      });
+    });
+  });
+
+  describe('getFromSchema', () => {
+    const objectSchema: any = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        address: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    };
+
+    it('returns the whole schema for an empty pointer', () => {
+      expect(getFromSchema(objectSchema, '')).toBe(objectSchema);
+    });
+
+    it('walks object properties by data pointer', () => {
+      expect(getFromSchema(objectSchema, '/name')).toEqual({ type: 'string' });
+    });
+
+    it('walks nested object properties', () => {
+      expect(getFromSchema(objectSchema, '/address/city')).toEqual({ type: 'string' });
+    });
+
+    it('accepts a pointer written as an array of keys', () => {
+      expect(getFromSchema(objectSchema, ['address', 'city'])).toEqual({ type: 'string' });
+    });
+
+    it('accepts a pointer with a leading hash', () => {
+      expect(getFromSchema(objectSchema, '#/name')).toEqual({ type: 'string' });
+    });
+
+    it('returns the schema pointer as an array of keys for returnType schemaPointer', () => {
+      expect(getFromSchema(objectSchema, '/name', 'schemaPointer'))
+        .toEqual(['properties', 'name']);
+    });
+
+    it('returns a nested schema pointer as an array of keys', () => {
+      expect(getFromSchema(objectSchema, '/address/city', 'schemaPointer'))
+        .toEqual(['properties', 'address', 'properties', 'city']);
+    });
+
+    it('returns an empty schema pointer array for an empty data pointer', () => {
+      expect(getFromSchema(objectSchema, '', 'schemaPointer')).toEqual([]);
+    });
+
+    it('returns an empty object instead of the parent schema for returnType parentSchema', () => {
+      // BUG: `length` is read before `dataPointerArray.length--`, so the loop runs
+      // one iteration past the shortened pointer with key === undefined, which falls
+      // through to the additionalProperties fallback and returns an empty object.
+      expect(getFromSchema(objectSchema, '/address/city', 'parentSchema')).toEqual({});
+      expect(getFromSchema(objectSchema, '/name', 'parentSchema')).toEqual({});
+    });
+
+    it('appends additionalProperties to the pointer for returnType parentSchemaPointer', () => {
+      // BUG: same off by one as parentSchema above.
+      expect(getFromSchema(objectSchema, '/address/city', 'parentSchemaPointer'))
+        .toEqual(['properties', 'address', 'additionalProperties']);
+      expect(getFromSchema(objectSchema, '/name', 'parentSchemaPointer'))
+        .toEqual(['additionalProperties']);
+    });
+
+    it('throws a RangeError for an empty pointer with a parent returnType', () => {
+      // BUG: `dataPointerArray.length--` on an empty array sets the length to -1.
+      expect(() => getFromSchema(objectSchema, '', 'parentSchema')).toThrow();
+    });
+
+    it('returns an empty object rather than the items schema for an array index', () => {
+      // BUG: the `else if (subSchema.additionalItems !== false)` fallback is not
+      // guarded by `!subSchemaFound`, so the items schema that was just found is
+      // immediately overwritten with an empty object.
+      expect(getFromSchema({ type: 'array', items: { type: 'string' } }, '/0')).toEqual({});
+    });
+
+    it('appends additionalItems to the schema pointer of an array item', () => {
+      expect(getFromSchema({ type: 'array', items: { type: 'string' } }, '/0', 'schemaPointer'))
+        .toEqual(['items', 'additionalItems']);
+    });
+
+    it('treats the "-" key as an array index', () => {
+      expect(getFromSchema({ type: 'array', items: { type: 'string' } }, '/-')).toEqual({});
+    });
+
+    it('never reaches the tuple branch because isObject is true for arrays', () => {
+      // BUG: `isObject(subSchema.items)` matches an items array as well, so the
+      // `isArray(subSchema.items)` tuple branch below it is dead code and a tuple
+      // index resolves to the same empty additionalItems object.
+      const tupleSchema: any = { type: 'array', items: [{ type: 'string' }, { type: 'number' }] };
+
+      expect(getFromSchema(tupleSchema, '/1')).toEqual({});
+      expect(getFromSchema(tupleSchema, '/1', 'schemaPointer')).toEqual(['items', 'additionalItems']);
+    });
+
+    it('returns an empty object for an out of range tuple index', () => {
+      expect(getFromSchema({ type: 'array', items: [{ type: 'string' }] }, '/5')).toEqual({});
+    });
+
+    it('returns an empty object for an array with no items at all', () => {
+      expect(getFromSchema({ type: 'array' }, '/0')).toEqual({});
+    });
+
+    it('uses the additionalItems schema when there is no items keyword', () => {
+      expect(getFromSchema({ type: 'array', additionalItems: { type: 'number' } }, '/0'))
+        .toEqual({ type: 'number' });
+      expect(getFromSchema(
+        { type: 'array', additionalItems: { type: 'number' } }, '/0', 'schemaPointer'
+      )).toEqual(['additionalItems']);
+    });
+
+    it('uses the additionalItems schema when items is not an object', () => {
+      expect(getFromSchema(
+        { type: 'array', items: 'nope', additionalItems: { type: 'number' } }, '/0'
+      )).toEqual({ type: 'number' });
+    });
+
+    it('returns undefined when an array key is neither numeric nor "-"', () => {
+      expect(getFromSchema({ type: 'array', items: { type: 'string' } }, '/abc')).toBeUndefined();
+    });
+
+    it('falls back to additionalProperties when the key is not a declared property', () => {
+      expect(getFromSchema({ type: 'object', additionalProperties: { type: 'number' } }, '/any'))
+        .toEqual({ type: 'number' });
+      expect(getFromSchema(
+        { type: 'object', additionalProperties: { type: 'number' } }, '/any', 'schemaPointer'
+      )).toEqual(['additionalProperties']);
+    });
+
+    it('returns an empty object when the key is missing and additionalProperties is absent', () => {
+      expect(getFromSchema({ type: 'object', properties: { a: { type: 'string' } } }, '/b'))
+        .toEqual({});
+    });
+
+    it('returns undefined when the key is missing and additionalProperties is false', () => {
+      expect(getFromSchema(
+        { type: 'object', properties: { a: { type: 'string' } }, additionalProperties: false }, '/b'
+      )).toBeUndefined();
+    });
+
+    it('returns undefined when the schema has no type keyword', () => {
+      expect(getFromSchema({ properties: { a: { type: 'string' } } }, '/a')).toBeUndefined();
+    });
+
+    it('returns undefined when the pointer walks past a leaf schema', () => {
+      expect(getFromSchema(objectSchema, '/name/deeper')).toBeUndefined();
+    });
+
+    it('returns null for an invalid JSON Pointer', () => {
+      expect(getFromSchema(objectSchema, 'not-a-pointer')).toBeNull();
+    });
+
+    it('returns null when the schema is not an object', () => {
+      expect(getFromSchema('nope', '/a')).toBeNull();
+    });
+
+    it('returns null for a null schema with an empty pointer', () => {
+      expect(getFromSchema(null, '')).toBeNull();
+    });
+
+    it('throws for a null schema with a non empty pointer', () => {
+      // BUG: `typeof null === 'object'`, so the guard above does not catch null
+      // and reading `subSchema.type` throws.
+      expect(() => getFromSchema(null, '/a')).toThrow();
+    });
+  });
+
+  describe('removeRecursiveReferences', () => {
+    it('returns an empty string for a falsy pointer', () => {
+      expect(removeRecursiveReferences('', new Map())).toEqual('');
+      expect(removeRecursiveReferences(null, new Map())).toEqual('');
+      expect(removeRecursiveReferences(undefined, new Map())).toEqual('');
+    });
+
+    it('returns an empty string for an empty pointer array', () => {
+      expect(removeRecursiveReferences([], new Map())).toEqual('');
+    });
+
+    it('returns the pointer unchanged when the reference map is empty', () => {
+      expect(removeRecursiveReferences('/a/b', new Map())).toEqual('/a/b');
+    });
+
+    it('compiles an array pointer into a string pointer', () => {
+      expect(removeRecursiveReferences(['a', 'b'], new Map())).toEqual('/a/b');
+      expect(removeRecursiveReferences(['a'], new Map())).toEqual('/a');
+    });
+
+    it('strips a leading hash', () => {
+      expect(removeRecursiveReferences('#/a/b', new Map())).toEqual('/a/b');
+    });
+
+    it('ignores map entries that are not recursive', () => {
+      expect(removeRecursiveReferences('/a/b/c', new Map([['/x', '/y']]))).toEqual('/a/b/c');
+    });
+
+    it('shortens a pointer back to its shallowest recursive equivalent', () => {
+      expect(removeRecursiveReferences(
+        '/stuff/and/more/and/more/and/more/stuff',
+        new Map([['/stuff/and/more/and/more', '/stuff/and/more']])
+      )).toEqual('/stuff/and/more/stuff');
+    });
+
+    it('leaves the pointer alone when the map target carries a trailing slash', () => {
+      // BUG: this is the example from the function docstring, which promises
+      // '/stuff/and/more/stuff'. The trailing slash on the map target stops
+      // isSubPointer from recognising the recursion, so nothing is shortened.
+      expect(removeRecursiveReferences(
+        '/stuff/and/more/and/more/and/more/and/more/stuff',
+        new Map([['/stuff/and/more/and/more', '/stuff/and/more/']])
+      )).toEqual('/stuff/and/more/and/more/and/more/and/more/stuff');
+    });
+
+    it('replaces a list array index with "-" using the array map', () => {
+      expect(removeRecursiveReferences('/list/2/name', new Map(), new Map([['/list', 0]])))
+        .toEqual('/list/-/name');
+    });
+
+    it('keeps a tuple index that is inside the declared tuple length', () => {
+      expect(removeRecursiveReferences('/list/2/name', new Map(), new Map([['/list', 5]])))
+        .toEqual('/list/2/name');
+    });
+
+    it('throws for a truthy string that is not a JSON Pointer', () => {
+      // BUG: JsonPointer.compile returns null for 'abc', toGenericPointer then
+      // returns undefined, and reading .indexOf on it throws.
+      expect(() => removeRecursiveReferences('abc', new Map())).toThrow();
+    });
+  });
+
+  describe('getInputType', () => {
+    it('maps a plain string to text', () => {
+      expect(getInputType({ type: 'string' })).toEqual('text');
+    });
+
+    it('maps known string formats to their widgets', () => {
+      expect(getInputType({ type: 'string', format: 'color' })).toEqual('color');
+      expect(getInputType({ type: 'string', format: 'date' })).toEqual('date');
+      expect(getInputType({ type: 'string', format: 'date-time' })).toEqual('datetime-local');
+      expect(getInputType({ type: 'string', format: 'email' })).toEqual('email');
+      expect(getInputType({ type: 'string', format: 'uri' })).toEqual('url');
+    });
+
+    it('falls back to text for an unrecognised string format', () => {
+      expect(getInputType({ type: 'string', format: 'password' })).toEqual('text');
+    });
+
+    it('maps a string with an enum to select', () => {
+      expect(getInputType({ type: 'string', enum: ['a', 'b'] })).toEqual('select');
+    });
+
+    it('maps a boolean to checkbox', () => {
+      expect(getInputType({ type: 'boolean' })).toEqual('checkbox');
+    });
+
+    it('still maps a boolean with an enum to checkbox', () => {
+      // The boolean check runs before the enum check, unlike for numbers.
+      expect(getInputType({ type: 'boolean', enum: [true, false] })).toEqual('checkbox');
+    });
+
+    it('maps integer and number to their own names', () => {
+      expect(getInputType({ type: 'integer' })).toEqual('integer');
+      expect(getInputType({ type: 'number' })).toEqual('number');
+    });
+
+    it('maps an integer with both bounds to range', () => {
+      expect(getInputType({ type: 'integer', minimum: 0, maximum: 10 })).toEqual('range');
+    });
+
+    it('keeps integer when only one bound is present', () => {
+      expect(getInputType({ type: 'integer', maximum: 10 })).toEqual('integer');
+    });
+
+    it('keeps number for a bounded number without multipleOf', () => {
+      expect(getInputType({ type: 'number', minimum: 0, maximum: 5 })).toEqual('number');
+    });
+
+    it('maps a bounded number with multipleOf to range', () => {
+      expect(getInputType({ type: 'number', multipleOf: 2, minimum: 0, maximum: 5 }))
+        .toEqual('range');
+    });
+
+    it('maps a numeric schema with an enum to select', () => {
+      expect(getInputType({ type: 'integer', enum: [1, 2] })).toEqual('select');
+      expect(getInputType({ type: 'number', enum: [1, 2] })).toEqual('select');
+    });
+
+    it('maps type null to none', () => {
+      expect(getInputType({ type: 'null' })).toEqual('none');
+    });
+
+    it('maps an object with properties or additionalProperties to section', () => {
+      expect(getInputType({ type: 'object', properties: { a: {} } })).toEqual('section');
+      expect(getInputType({ type: 'object', additionalProperties: true })).toEqual('section');
+    });
+
+    it('maps a typed object holding only a $ref to $ref', () => {
+      expect(getInputType({ type: 'object', $ref: '#/definitions/a' })).toEqual('$ref');
+    });
+
+    it('prefers section over $ref when the object also has properties', () => {
+      expect(getInputType({ type: 'object', properties: {}, $ref: '#/a' })).toEqual('section');
+    });
+
+    it('maps a bare object to none', () => {
+      expect(getInputType({ type: 'object' })).toEqual('none');
+    });
+
+    it('maps an array to array', () => {
+      expect(getInputType({ type: 'array', items: { type: 'string' } })).toEqual('array');
+      expect(getInputType({ type: 'array' })).toEqual('array');
+    });
+
+    it('maps an array of enum items to checkboxes', () => {
+      expect(getInputType({ type: 'array', items: { enum: ['a', 'b'] } })).toEqual('checkboxes');
+    });
+
+    it('reads the enum from additionalItems when items is absent', () => {
+      expect(getInputType({ type: 'array', additionalItems: { enum: ['a'] } })).toEqual('checkboxes');
+    });
+
+    it('keeps array when maxItems is exactly 1', () => {
+      expect(getInputType({ type: 'array', items: { enum: ['a'] }, maxItems: 1 })).toEqual('array');
+    });
+
+    it('converts checkboxes to checkboxes-inline when the schema is inline', () => {
+      expect(getInputType({ type: 'array', items: { enum: ['a'] }, inline: true }))
+        .toEqual('checkboxes-inline');
+    });
+
+    it('picks the most inclusive type from a type array', () => {
+      expect(getInputType({ type: ['object', 'null'], properties: { a: {} } })).toEqual('section');
+      expect(getInputType({ type: ['array', 'null'], items: { type: 'string' } })).toEqual('array');
+      expect(getInputType({ type: ['array', 'null'], additionalItems: { type: 'string' } }))
+        .toEqual('array');
+      expect(getInputType({ type: ['string', 'number'] })).toEqual('text');
+      expect(getInputType({ type: ['number', 'boolean'] })).toEqual('number');
+      expect(getInputType({ type: ['integer', 'boolean'] })).toEqual('integer');
+      expect(getInputType({ type: ['boolean'] })).toEqual('checkbox');
+    });
+
+    it('maps an unresolvable type array to none', () => {
+      expect(getInputType({ type: ['foo'] })).toEqual('none');
+      expect(getInputType({ type: ['object'] })).toEqual('none');
+      expect(getInputType({ type: ['array'] })).toEqual('none');
+    });
+
+    it('reads the control type from the x-schema-form extensions', () => {
+      expect(getInputType({ 'x-schema-form': { type: 'textarea' }, type: 'string' }))
+        .toEqual('textarea');
+      expect(getInputType({ 'x-schema-form': { widget: { component: 'radios' } }, type: 'string' }))
+        .toEqual('radios');
+      expect(getInputType({ 'x-schema-form': { widget: 'checkboxes' }, type: 'string' }))
+        .toEqual('checkboxes');
+    });
+
+    it('reads the control type from the widget keyword', () => {
+      expect(getInputType({ widget: { component: 'radios' }, type: 'string' })).toEqual('radios');
+      expect(getInputType({ widget: 'date', type: 'string' })).toEqual('date');
+    });
+
+    it('inlines a widget control type when the schema is inline', () => {
+      expect(getInputType({ widget: 'radios', inline: true, type: 'string' }))
+        .toEqual('radios-inline');
+    });
+
+    it('inlines a widget control type from the layout node options', () => {
+      expect(getInputType({ widget: 'radios', type: 'string' }, { options: { inline: true } }))
+        .toEqual('radios-inline');
+    });
+
+    it('ignores a widget that is not a string', () => {
+      expect(getInputType({ widget: { foo: 1 }, type: 'string' })).toEqual('text');
+      expect(getInputType({ widget: '', type: 'string' })).toEqual('text');
+    });
+
+    it('maps an untyped schema with a $ref to $ref', () => {
+      expect(getInputType({ $ref: '#/definitions/a' })).toEqual('$ref');
+    });
+
+    it('maps an untyped schema with oneOf or anyOf to one-of', () => {
+      expect(getInputType({ oneOf: [{ type: 'string' }] })).toEqual('one-of');
+      expect(getInputType({ anyOf: [{ type: 'string' }] })).toEqual('one-of');
+    });
+
+    it('maps an empty schema to none', () => {
+      expect(getInputType({})).toEqual('none');
+    });
+
+    it('still returns none for an undeterminable type when a layout node is supplied', () => {
+      expect(getInputType({ type: 'object' }, { name: 'x' })).toEqual('none');
+    });
+
+    it('maps a schema with a layout node titleMap to select', () => {
+      expect(getInputType({ type: 'string' }, { options: { titleMap: [{ name: 'a', value: 1 }] } }))
+        .toEqual('select');
+    });
+
+    it('maps a schema with a usable oneOf titleMap to select', () => {
+      expect(getInputType({ type: 'string', oneOf: [{ title: 'A', enum: ['a'] }] }))
+        .toEqual('select');
+      expect(getInputType({ type: 'string', oneOf: [{ title: 'A', const: 'a' }] }))
+        .toEqual('select');
+    });
+
+    it('throws for a null or undefined schema', () => {
+      // BUG: schema.type is read without any guard once getFirst returns nothing.
+      expect(() => getInputType(null)).toThrow();
+      expect(() => getInputType(undefined)).toThrow();
+    });
+  });
+
+  describe('checkInlineType', () => {
+    it('returns the control type unchanged when it is not a radio or checkbox', () => {
+      expect(checkInlineType('text', { inline: true })).toEqual('text');
+      expect(checkInlineType('select', { inline: true })).toEqual('select');
+    });
+
+    it('returns a non string control type unchanged', () => {
+      expect(checkInlineType(null, { inline: true })).toBeNull();
+      expect(checkInlineType(5, {})).toEqual(5);
+    });
+
+    it('leaves radios and checkboxes alone when nothing is inline', () => {
+      expect(checkInlineType('radios', {})).toEqual('radios');
+      expect(checkInlineType('checkboxes', {})).toEqual('checkboxes');
+      expect(checkInlineType('radios', null)).toEqual('radios');
+      expect(checkInlineType('radios', undefined)).toEqual('radios');
+    });
+
+    it('converts radios to radios-inline and checkboxes to checkboxes-inline', () => {
+      expect(checkInlineType('radios', { inline: true })).toEqual('radios-inline');
+      expect(checkInlineType('checkboxes', { inline: true })).toEqual('checkboxes-inline');
+    });
+
+    it('matches any control type starting with "checkbox"', () => {
+      expect(checkInlineType('checkbox', { inline: true })).toEqual('checkboxes-inline');
+    });
+
+    it('reads inline from the layout node first', () => {
+      expect(checkInlineType('radios', {}, { inline: true })).toEqual('radios-inline');
+      expect(checkInlineType('radios', {}, { options: { inline: true } })).toEqual('radios-inline');
+    });
+
+    it('reads inline from each of the supported schema locations', () => {
+      expect(checkInlineType('radios', { 'x-schema-form': { inline: true } }))
+        .toEqual('radios-inline');
+      expect(checkInlineType('radios', { 'x-schema-form': { options: { inline: true } } }))
+        .toEqual('radios-inline');
+      expect(checkInlineType('radios', { 'x-schema-form': { widget: { inline: true } } }))
+        .toEqual('radios-inline');
+      expect(checkInlineType('radios', { widget: { component: { inline: true } } }))
+        .toEqual('radios-inline');
+      expect(checkInlineType('radios', { widget: { component: { options: { inline: true } } } }))
+        .toEqual('radios-inline');
+    });
+
+    it('requires inline to be exactly true, not merely truthy', () => {
+      expect(checkInlineType('radios', { inline: 'yes' })).toEqual('radios');
+    });
+  });
+
+  describe('isInputRequired', () => {
+    const buildSchema = (): any => ({
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        address: {
+          type: 'object',
+          required: ['city'],
+          properties: { city: { type: 'string' }, zip: { type: 'string' } },
+        },
+        tags: { type: 'array', minItems: 2, items: { type: 'string' } },
+      },
+    });
+
+    it('returns true for a key listed in the parent required array', () => {
+      expect(isInputRequired(buildSchema(), '/properties/name')).toBe(true);
+    });
+
+    it('returns true for a nested key listed in its own parent required array', () => {
+      expect(isInputRequired(buildSchema(), '/properties/address/properties/city')).toBe(true);
+    });
+
+    it('returns false for a key that is not listed as required', () => {
+      expect(isInputRequired(buildSchema(), '/properties/address/properties/zip')).toBe(false);
+      expect(isInputRequired(buildSchema(), '/properties/address')).toBe(false);
+    });
+
+    it('accepts a pointer written as an array of keys', () => {
+      expect(isInputRequired(buildSchema(), ['properties', 'name'])).toBe(true);
+    });
+
+    it('empties the caller pointer array while walking it', () => {
+      // BUG: JsonPointer.parse returns the same array instance for an array
+      // pointer, and isInputRequired pops keys off it in place.
+      const pointer = ['properties', 'name'];
+
+      isInputRequired(buildSchema(), pointer);
+
+      expect(pointer).toEqual([]);
+    });
+
+    it('checks schema.required === true for an empty pointer', () => {
+      expect(isInputRequired({ required: true }, '')).toBe(true);
+      expect(isInputRequired(buildSchema(), '')).toBe(false);
+    });
+
+    it('uses minItems to decide whether an array item is required', () => {
+      expect(isInputRequired(buildSchema(), '/properties/tags/items/0')).toBe(true);
+      expect(isInputRequired(buildSchema(), '/properties/tags/items/5')).toBe(false);
+    });
+
+    it('returns false for an array with no minItems', () => {
+      expect(isInputRequired(
+        { type: 'object', properties: { t: { type: 'array', items: {} } } },
+        '/properties/t/items/0'
+      )).toBe(false);
+    });
+
+    it('returns false for a non numeric array item key', () => {
+      expect(isInputRequired(
+        { type: 'object', properties: { t: { type: 'array', minItems: 2, items: {} } } },
+        '/properties/t/items/abc'
+      )).toBe(false);
+    });
+
+    it('also strips additionalProperties and patternProperties from the pointer', () => {
+      expect(isInputRequired(
+        { type: 'object', required: ['a'], additionalProperties: { type: 'string' } },
+        '/additionalProperties/a'
+      )).toBe(true);
+      expect(isInputRequired(
+        { type: 'object', required: ['a'], patternProperties: { a: {} } },
+        '/patternProperties/a'
+      )).toBe(true);
+    });
+
+    it('returns false when the parent schema cannot be found', () => {
+      expect(isInputRequired(buildSchema(), '/properties/nothere/properties/x')).toBe(false);
+    });
+
+    it('returns false when the parent has neither a required list nor an array type', () => {
+      expect(isInputRequired({ type: 'object', properties: { a: {} } }, '/properties/a')).toBe(false);
+    });
+
+    it('returns false when the schema is not an object', () => {
+      expect(isInputRequired(null, '/properties/name')).toBe(false);
+      expect(isInputRequired(undefined, '/properties/name')).toBe(false);
+      expect(isInputRequired('nope', '/properties/name')).toBe(false);
+    });
+
+    it('returns false for an invalid JSON Pointer', () => {
+      expect(isInputRequired(buildSchema(), 'name')).toBe(false);
+    });
+  });
+
+  describe('updateInputOptions', () => {
+    const jsfWith = (defaults: any = {}): any =>
+      ({ formOptions: { defautWidgetOptions: defaults } });
+
+    it('does nothing when the layout node is not an object', () => {
+      expect(() => updateInputOptions(null, { type: 'string' }, jsfWith())).not.toThrow();
+      expect(() => updateInputOptions('nope', { type: 'string' }, jsfWith())).not.toThrow();
+    });
+
+    it('does nothing when the layout node has no options object', () => {
+      const layoutNode: any = { type: 'text' };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode).toEqual({ type: 'text' });
+    });
+
+    it('copies schema keys into options, skipping the structural ones', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode,
+        { type: 'string', title: 'T', minLength: 2, properties: {}, required: ['x'], $ref: '#/a' },
+        jsfWith()
+      );
+
+      expect(layoutNode.options).toEqual({ title: 'T', minLength: 2 });
+    });
+
+    it('merges the global default widget options and strips ui: prefixes', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith({ addable: true, 'ui:foo': 'bar' }));
+
+      expect(layoutNode.options).toEqual({ addable: true, foo: 'bar' });
+    });
+
+    it('merges the ui:widget options and keeps the renamed widget key as well', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode,
+        { type: 'string', 'ui:widget': { options: { placeholder: 'p' }, extra: 1 } },
+        jsfWith()
+      );
+
+      expect(layoutNode.options.placeholder).toEqual('p');
+      expect(layoutNode.options.extra).toEqual(1);
+      expect(layoutNode.options.widget).toEqual({ options: { placeholder: 'p' }, extra: 1 });
+    });
+
+    it('merges the x-schema-form options and skips its items and options keys', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode,
+        { type: 'string', 'x-schema-form': { options: { notitle: true }, items: [1], other: 2 } },
+        jsfWith()
+      );
+
+      expect(layoutNode.options).toEqual({ notitle: true, other: 2 });
+    });
+
+    it('does not copy the reserved layout node keys into options', () => {
+      const layoutNode: any = { _id: 1, dataPointer: '/a', name: 'a', options: { keep: true } };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode.options).toEqual({ keep: true });
+    });
+
+    it('forces multipleOf to 1 for an integer schema', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(layoutNode, { type: 'integer' }, jsfWith());
+
+      expect(layoutNode.options.multipleOf).toEqual(1);
+    });
+
+    it('keeps an existing multipleOf on an integer schema', () => {
+      const layoutNode: any = { options: { multipleOf: 5 } };
+
+      updateInputOptions(layoutNode, { type: 'integer' }, jsfWith());
+
+      expect(layoutNode.options.multipleOf).toEqual(5);
+    });
+
+    it('builds a titleMap from a schema oneOf', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode,
+        { type: 'string', oneOf: [{ title: 'A', enum: ['a'] }, { title: 'B', enum: ['b'] }] },
+        jsfWith()
+      );
+
+      expect(layoutNode.options.titleMap)
+        .toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('keeps a titleMap that is already set on the layout node options', () => {
+      const layoutNode: any = { options: { titleMap: [{ name: 'x', value: 1 }] } };
+
+      updateInputOptions(
+        layoutNode, { type: 'string', oneOf: [{ title: 'A', enum: ['a'] }] }, jsfWith()
+      );
+
+      expect(layoutNode.options.titleMap).toEqual([{ name: 'x', value: 1 }]);
+    });
+
+    it('copies a titleMap out of the items schema', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode, { type: 'array', items: { titleMap: [{ name: 'a', value: 1 }] } }, jsfWith()
+      );
+
+      expect(layoutNode.options.titleMap).toEqual([{ name: 'a', value: 1 }]);
+    });
+
+    it('copies enum and enumNames out of the items schema', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode, { type: 'array', items: { enum: ['a'], enumNames: ['A'] } }, jsfWith()
+      );
+
+      expect(layoutNode.options).toEqual({ enum: ['a'], enumNames: ['A'] });
+    });
+
+    it('builds a titleMap from the items oneOf', () => {
+      const layoutNode: any = { options: {} };
+
+      updateInputOptions(
+        layoutNode,
+        { type: 'array', items: { oneOf: [{ title: 'A', enum: ['a'] }, { title: 'B', enum: ['b'] }] } },
+        jsfWith()
+      );
+
+      expect(layoutNode.options.titleMap)
+        .toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('copies an autocomplete word list to options.typeahead', () => {
+      const layoutNode: any = { options: { autocomplete: { source: ['a'] } } };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode.options.typeahead).toEqual({ source: ['a'] });
+    });
+
+    it('copies a tagsinput word list to options.typeahead', () => {
+      const layoutNode: any = { options: { tagsinput: { source: ['a'] } } };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode.options.typeahead).toEqual({ source: ['a'] });
+    });
+
+    it('copies a nested tagsinput typeahead word list to options.typeahead', () => {
+      const layoutNode: any = { options: { tagsinput: { typeahead: { source: ['a'] } } } };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode.options.typeahead).toEqual({ source: ['a'] });
+    });
+
+    it('renames ui: prefixed option keys on the layout node options', () => {
+      const layoutNode: any = { options: { 'ui:order': ['a'] } };
+
+      updateInputOptions(layoutNode, { type: 'string' }, jsfWith());
+
+      expect(layoutNode.options).toEqual({ order: ['a'] });
+    });
+
+    it('throws for a null schema', () => {
+      // BUG: getTitleMapFromOneOf reads schema.oneOf, and the default parameter
+      // only kicks in for undefined, not for null.
+      expect(() => updateInputOptions({ options: {} }, null, jsfWith())).toThrow();
+    });
+  });
+
+  describe('getTitleMapFromOneOf', () => {
+    it('returns null when called with no arguments', () => {
+      expect(getTitleMapFromOneOf()).toBeNull();
+    });
+
+    it('returns null for a schema without oneOf or anyOf', () => {
+      expect(getTitleMapFromOneOf({})).toBeNull();
+      expect(getTitleMapFromOneOf({ type: 'string' })).toBeNull();
+    });
+
+    it('builds a title map from single value enums', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'A', enum: ['a'] }, { title: 'B', enum: ['b'] }] }
+      )).toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('reads anyOf when oneOf is absent', () => {
+      expect(getTitleMapFromOneOf(
+        { anyOf: [{ title: 'A', enum: ['a'] }, { title: 'B', enum: ['b'] }] }
+      )).toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('builds a title map from const values', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'A', const: 'a' }, { title: 'B', const: 'b' }] }
+      )).toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('returns null when any entry is missing a title', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ enum: ['a'] }, { title: 'B', enum: ['b'] }] }
+      )).toBeNull();
+    });
+
+    it('returns null when an enum holds more than one value', () => {
+      expect(getTitleMapFromOneOf({ oneOf: [{ title: 'A', enum: ['a', 'x'] }] })).toBeNull();
+    });
+
+    it('returns null when the entries have neither an enum nor a const', () => {
+      expect(getTitleMapFromOneOf({ oneOf: [{ title: 'A', type: 'string' }] })).toBeNull();
+    });
+
+    it('returns null when oneOf is not an array', () => {
+      expect(getTitleMapFromOneOf({ oneOf: 'nope' })).toBeNull();
+    });
+
+    it('returns true or false instead of a map when validateOnly is set', () => {
+      expect(getTitleMapFromOneOf({ oneOf: [{ title: 'A', enum: ['a'] }] }, null, true)).toBe(true);
+      expect(getTitleMapFromOneOf({ oneOf: [{ title: 'A', const: 'a' }] }, null, true)).toBe(true);
+      expect(getTitleMapFromOneOf({ type: 'string' }, null, true)).toBe(false);
+      expect(getTitleMapFromOneOf({ oneOf: [{ enum: ['a'] }] }, null, true)).toBe(false);
+    });
+
+    it('splits names on the first colon to build a grouped map', () => {
+      expect(getTitleMapFromOneOf({ oneOf: [
+        { title: 'G: one', enum: ['1'] },
+        { title: 'G: two', enum: ['2'] },
+        { title: 'H: three', enum: ['3'] },
+      ] })).toEqual([
+        { name: 'one', value: '1', group: 'G' },
+        { name: 'two', value: '2', group: 'G' },
+        { name: 'three', value: '3', group: 'H' },
+      ]);
+    });
+
+    it('leaves the names untouched when flatList is false', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'G: one', enum: ['1'] }, { title: 'G: two', enum: ['2'] }] }, false
+      )).toEqual([{ name: 'G: one', value: '1' }, { name: 'G: two', value: '2' }]);
+    });
+
+    it('groups single entry groups when flatList is true', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'G: one', enum: ['1'] }, { title: 'H: two', enum: ['2'] }] }, true
+      )).toEqual([
+        { name: 'one', value: '1', group: 'G' },
+        { name: 'two', value: '2', group: 'H' },
+      ]);
+    });
+
+    it('never groups a map with only one entry', () => {
+      expect(getTitleMapFromOneOf({ oneOf: [{ title: 'G: one', enum: ['1'] }] }))
+        .toEqual([{ name: 'G: one', value: '1' }]);
+    });
+
+    it('leaves colon free names alone even though they pass the colon filter', () => {
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'One', enum: ['1'] }, { title: 'Two', enum: ['2'] }] }
+      )).toEqual([{ name: 'One', value: '1' }, { name: 'Two', value: '2' }]);
+    });
+
+    it('counts colon free names towards the grouping threshold', () => {
+      // BUG: the colon filter is `name.indexOf(': ')`, whose -1 result is truthy,
+      // so names WITHOUT a colon pass the filter and push the count over 1.
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: 'A', enum: ['1'] }, { title: 'G: x', enum: ['2'] }] }, true
+      )).toEqual([{ name: 'A', value: '1' }, { name: 'x', value: '2', group: 'G' }]);
+    });
+
+    it('drops a name whose colon sits at index 0 from the grouping count', () => {
+      // BUG: same filter, the other way round: indexOf returns 0 for a leading
+      // colon, which is falsy, so this entry is not counted and no grouping runs.
+      expect(getTitleMapFromOneOf(
+        { oneOf: [{ title: ': a', enum: ['1'] }, { title: 'G: b', enum: ['2'] }] }, true
+      )).toEqual([{ name: ': a', value: '1' }, { name: 'G: b', value: '2' }]);
+    });
+
+    it('throws for a null schema', () => {
+      // BUG: the default parameter only applies to undefined, so null reaches
+      // schema.oneOf and throws.
+      expect(() => getTitleMapFromOneOf(null)).toThrow();
+    });
+  });
+
+  describe('getControlValidators', () => {
+    it('returns null when the schema is not an object', () => {
+      expect(getControlValidators(null)).toBeNull();
+      expect(getControlValidators('nope')).toBeNull();
+      expect(getControlValidators(undefined)).toBeNull();
+    });
+
+    it('returns an empty object for a schema with no type and no enum', () => {
+      expect(getControlValidators({})).toEqual({});
+      expect(getControlValidators([])).toEqual({});
+    });
+
+    it('collects the string validators', () => {
+      expect(getControlValidators(
+        { type: 'string', pattern: '^a', format: 'email', minLength: 1, maxLength: 5 }
+      )).toEqual({ pattern: ['^a'], format: ['email'], minLength: [1], maxLength: [5] });
+    });
+
+    it('collects the number validators with an exclusive flag and the type itself', () => {
+      expect(getControlValidators({ type: 'number', minimum: 0, maximum: 10, multipleOf: 2 }))
+        .toEqual({ minimum: [0, false], maximum: [10, false], multipleOf: [2], type: ['number'] });
+    });
+
+    it('marks the limits exclusive when the exclusive keywords are true', () => {
+      expect(getControlValidators({
+        type: 'number', minimum: 0, exclusiveMinimum: true, maximum: 9, exclusiveMaximum: true,
+      })).toEqual({ minimum: [0, true], maximum: [9, true], type: ['number'] });
+    });
+
+    it('handles the integer type the same way as number', () => {
+      expect(getControlValidators({ type: 'integer', minimum: 1 }))
+        .toEqual({ minimum: [1, false], type: ['integer'] });
+    });
+
+    it('collects the object validators', () => {
+      expect(getControlValidators(
+        { type: 'object', minProperties: 1, maxProperties: 3, dependencies: { a: ['b'] } }
+      )).toEqual({ minProperties: [1], maxProperties: [3], dependencies: [{ a: ['b'] }] });
+    });
+
+    it('collects the array validators', () => {
+      expect(getControlValidators({ type: 'array', minItems: 1, maxItems: 3, uniqueItems: true }))
+        .toEqual({ minItems: [1], maxItems: [3], uniqueItems: [true] });
+    });
+
+    it('returns an empty object for a boolean or unrecognised type', () => {
+      expect(getControlValidators({ type: 'boolean' })).toEqual({});
+      expect(getControlValidators({ type: 'weird', minLength: 2 })).toEqual({});
+    });
+
+    it('adds the enum validator whatever the type is', () => {
+      expect(getControlValidators({ enum: ['a', 'b'] })).toEqual({ enum: [['a', 'b']] });
+      expect(getControlValidators({ type: 'string', minLength: 2, enum: ['a'] }))
+        .toEqual({ minLength: [2], enum: [['a']] });
+    });
+  });
+
+  describe('resolveSchemaReferences', () => {
+    const buildTree = (): any => ({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        children: { type: 'array', items: { $ref: '#' } },
+      },
+    });
+
+    it('returns undefined and touches nothing when the schema is not an object', () => {
+      const refLibrary: any = {};
+      const schemaRecursiveRefMap = new Map<string, string>();
+      const dataRecursiveRefMap = new Map<string, string>();
+      const arrayMap = new Map<string, number>();
+
+      expect(resolveSchemaReferences(
+        null, refLibrary, schemaRecursiveRefMap, dataRecursiveRefMap, arrayMap
+      )).toBeUndefined();
+      expect(resolveSchemaReferences(
+        'nope', refLibrary, schemaRecursiveRefMap, dataRecursiveRefMap, arrayMap
+      )).toBeUndefined();
+      expect(Object.keys(refLibrary)).toEqual([]);
+      expect(arrayMap.size).toEqual(0);
+    });
+
+    it('returns a copy of a schema that has no references', () => {
+      const schema: any = { type: 'object', properties: { a: { type: 'string' } } };
+      const result: any = resolveSchemaReferences(
+        schema, {}, new Map(), new Map(), new Map()
+      );
+
+      expect(result).toEqual({ type: 'object', properties: { a: { type: 'string' } } });
+      expect(result).not.toBe(schema);
+    });
+
+    it('returns an empty object for an empty schema', () => {
+      expect(resolveSchemaReferences({}, {}, new Map(), new Map(), new Map())).toEqual({});
+    });
+
+    it('inlines non recursive definitions and removes the definitions block', () => {
+      const schema: any = {
+        type: 'object',
+        definitions: { name: { type: 'string', minLength: 2 } },
+        properties: {
+          first: { $ref: '#/definitions/name' },
+          last: { $ref: '#/definitions/name' },
+        },
+      };
+      const refLibrary: any = {};
+      const schemaRecursiveRefMap = new Map<string, string>();
+      const result: any = resolveSchemaReferences(
+        schema, refLibrary, schemaRecursiveRefMap, new Map(), new Map()
+      );
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          first: { type: 'string', minLength: 2 },
+          last: { type: 'string', minLength: 2 },
+        },
+      });
+      expect(schema.definitions).toBeDefined();
+      expect(Object.keys(refLibrary)).toEqual([]);
+      expect(schemaRecursiveRefMap.size).toEqual(0);
+    });
+
+    it('records list arrays in the array map with a tuple count of 0', () => {
+      const arrayMap = new Map<string, number>();
+
+      resolveSchemaReferences(
+        { type: 'object', properties: { list: { type: 'array', items: { type: 'string' } } } },
+        {}, new Map(), new Map(), arrayMap
+      );
+
+      expect(arrayMap.get('/list')).toEqual(0);
+    });
+
+    it('records the number of tuple items for a tuple array', () => {
+      const arrayMap = new Map<string, number>();
+
+      resolveSchemaReferences(
+        {
+          type: 'object',
+          properties: { list: { type: 'array', items: [{ type: 'string' }, { type: 'number' }] } },
+        },
+        {}, new Map(), new Map(), arrayMap
+      );
+
+      expect(arrayMap.get('/list')).toEqual(2);
+    });
+
+    it('keeps a self recursive $ref and maps it in every output map', () => {
+      const refLibrary: any = {};
+      const schemaRecursiveRefMap = new Map<string, string>();
+      const dataRecursiveRefMap = new Map<string, string>();
+      const arrayMap = new Map<string, number>();
+      const result: any = resolveSchemaReferences(
+        buildTree(), refLibrary, schemaRecursiveRefMap, dataRecursiveRefMap, arrayMap
+      );
+
+      expect(result.properties.children.items).toEqual({ $ref: '#' });
+      expect(Object.keys(refLibrary)).toEqual(['']);
+      expect(refLibrary['']).toBe(result);
+      expect(schemaRecursiveRefMap.get('/properties/children/items')).toEqual('');
+      expect(dataRecursiveRefMap.get('/children/-')).toEqual('');
+      expect(arrayMap.get('/children')).toEqual(0);
+    });
+
+    it('rewrites a recursive definition ref to point at its first use', () => {
+      const refLibrary: any = {};
+      const schemaRecursiveRefMap = new Map<string, string>();
+      const dataRecursiveRefMap = new Map<string, string>();
+      const result: any = resolveSchemaReferences({
+        type: 'object',
+        definitions: {
+          node: {
+            type: 'object',
+            properties: { value: { type: 'string' }, next: { $ref: '#/definitions/node' } },
+          },
+        },
+        properties: { root: { $ref: '#/definitions/node' } },
+      }, refLibrary, schemaRecursiveRefMap, dataRecursiveRefMap, new Map());
+
+      expect(result.properties.root.properties.next).toEqual({ $ref: '#/properties/root' });
+      expect(Object.keys(refLibrary)).toEqual(['/properties/root']);
+      expect(schemaRecursiveRefMap.get('/properties/root/properties/next'))
+        .toEqual('/properties/root');
+      expect(dataRecursiveRefMap.get('/root/next')).toEqual('/root');
+    });
+
+    it('follows chained references between two definitions that point at each other', () => {
+      const refLibrary: any = {};
+      const schemaRecursiveRefMap = new Map<string, string>();
+      const dataRecursiveRefMap = new Map<string, string>();
+      const result: any = resolveSchemaReferences({
+        type: 'object',
+        definitions: {
+          a: { type: 'object', properties: { b: { $ref: '#/definitions/b' } } },
+          b: { type: 'object', properties: { a: { $ref: '#/definitions/a' } } },
+        },
+        properties: { start: { $ref: '#/definitions/a' } },
+      }, refLibrary, schemaRecursiveRefMap, dataRecursiveRefMap, new Map());
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          start: {
+            type: 'object',
+            properties: {
+              b: { type: 'object', properties: { a: { $ref: '#/properties/start' } } },
+            },
+          },
+        },
+      });
+      expect(Object.keys(refLibrary)).toEqual(['/properties/start']);
+      expect(schemaRecursiveRefMap.get('/properties/start/properties/b/properties/a'))
+        .toEqual('/properties/start');
+      expect(dataRecursiveRefMap.get('/start/b/a')).toEqual('/start');
+    });
+
+    it('combines allOf sub schemas while compiling', () => {
+      expect(resolveSchemaReferences(
+        { type: 'object', properties: { a: { allOf: [{ type: 'string' }, { minLength: 2 }] } } },
+        {}, new Map(), new Map(), new Map()
+      )).toEqual({ type: 'object', properties: { a: { type: 'string', minLength: 2 } } });
+    });
+
+    it('moves a misplaced array required list into the items schema', () => {
+      expect(resolveSchemaReferences({
+        type: 'object',
+        properties: {
+          list: { type: 'array', required: ['a'], items: { properties: { a: { type: 'string' } } } },
+        },
+      }, {}, new Map(), new Map(), new Map())).toEqual({
+        type: 'object',
+        properties: {
+          list: { type: 'array', items: { properties: { a: { type: 'string' } }, required: ['a'] } },
+        },
+      });
+    });
+
+    it('keeps entries already present in the recursive maps and the array map', () => {
+      const schemaRecursiveRefMap = new Map<string, string>([
+        ['/properties/children/items', '/preset'],
+      ]);
+      const arrayMap = new Map<string, number>([['/children', 99]]);
+
+      resolveSchemaReferences(buildTree(), {}, schemaRecursiveRefMap, new Map(), arrayMap);
+
+      expect(schemaRecursiveRefMap.get('/properties/children/items')).toEqual('/preset');
+      expect(schemaRecursiveRefMap.size).toEqual(1);
+      expect(arrayMap.get('/children')).toEqual(99);
+    });
+
+    it('overwrites an existing entry in the schema ref library', () => {
+      // BUG: the guard is `hasOwn(schemaRefLibrary, 'refPointer')`, a string
+      // literal instead of the refPointer variable, so real keys never match it.
+      const refLibrary: any = { '': { sentinel: true } };
+
+      resolveSchemaReferences(buildTree(), refLibrary, new Map(), new Map(), new Map());
+
+      expect(refLibrary[''].sentinel).toBeUndefined();
+      expect(refLibrary[''].type).toEqual('object');
+    });
+
+    it('skips the library write entirely when a literal refPointer key exists', () => {
+      // BUG: the same string literal, seen from the other side.
+      const refLibrary: any = { refPointer: 'anything' };
+
+      resolveSchemaReferences(buildTree(), refLibrary, new Map(), new Map(), new Map());
+
+      expect(Object.keys(refLibrary)).toEqual(['refPointer']);
+    });
+  });
+
+  describe('getSubSchema', () => {
+    const buildRefSchema = (): any => ({
+      type: 'object',
+      definitions: { thing: { type: 'string', minLength: 2 } },
+      properties: {
+        a: { $ref: '#/definitions/thing' },
+        b: { $ref: '#/definitions/thing', title: 'B' },
+      },
+    });
+
+    it('returns a plain copy when no ref library is supplied', () => {
+      expect(getSubSchema(buildRefSchema(), '/properties/a'))
+        .toEqual({ $ref: '#/definitions/thing' });
+    });
+
+    it('returns a copy of the whole schema for an empty pointer and no library', () => {
+      const schema = buildRefSchema();
+      const result: any = getSubSchema(schema, '');
+
+      expect(result).toEqual(schema);
+      expect(result).not.toBe(schema);
+    });
+
+    it('returns undefined for a null schema', () => {
+      expect(getSubSchema(null, '')).toBeUndefined();
+    });
+
+    it('returns null for a pointer that does not exist', () => {
+      expect(getSubSchema(buildRefSchema(), '/nope', {}, new Map())).toBeNull();
+    });
+
+    it('resolves $ref links throughout the schema when a library is supplied', () => {
+      expect(getSubSchema(buildRefSchema(), '', {}, new Map())).toEqual({
+        type: 'object',
+        definitions: { thing: { type: 'string', minLength: 2 } },
+        properties: {
+          a: { type: 'string', minLength: 2 },
+          b: { type: 'string', minLength: 2, title: 'B' },
+        },
+      });
+    });
+
+    it('resolves a $ref at the requested pointer', () => {
+      expect(getSubSchema(buildRefSchema(), '/properties/a', {}, new Map()))
+        .toEqual({ type: 'string', minLength: 2 });
+    });
+
+    it('merges the extra keys of a node that has both a $ref and other keys', () => {
+      expect(getSubSchema(buildRefSchema(), '/properties/b', {}, new Map()))
+        .toEqual({ type: 'string', minLength: 2, title: 'B' });
+    });
+
+    it('accepts a pointer written as an array of keys', () => {
+      expect(getSubSchema(buildRefSchema(), ['properties', 'a'], {}, new Map()))
+        .toEqual({ type: 'string', minLength: 2 });
+    });
+
+    it('leaves a self recursive $ref in place', () => {
+      const schema: any = {
+        type: 'object',
+        properties: { children: { type: 'array', items: { $ref: '#' } } },
+      };
+
+      expect(getSubSchema(schema, '', {}, new Map([['/properties/children/items', '']])))
+        .toEqual(schema);
+    });
+
+    it('combines allOf sub schemas', () => {
+      expect(getSubSchema({ allOf: [{ type: 'string' }, { minLength: 1 }] }, '', {}, new Map()))
+        .toEqual({ type: 'string', minLength: 1 });
+    });
+
+    it('leaves a $ref alone when the shortened pointer already covers it', () => {
+      const schema: any = {
+        type: 'object',
+        properties: {
+          root: {
+            type: 'object',
+            properties: { value: { type: 'string' }, next: { $ref: '#/properties/root' } },
+          },
+        },
+      };
+
+      expect(getSubSchema(
+        schema,
+        '/properties/root/properties/next',
+        {},
+        new Map([['/properties/root/properties/next', '/properties/root']])
+      )).toEqual({ $ref: '#/properties/root' });
+    });
+
+    it('prefers the ref library entry for the shortened pointer', () => {
+      const schema: any = {
+        type: 'object',
+        properties: {
+          root: {
+            type: 'object',
+            properties: { value: { type: 'string' }, next: { $ref: '#/properties/root' } },
+          },
+        },
+      };
+
+      expect(getSubSchema(
+        schema,
+        '/properties/root/properties/next',
+        { '/properties/root': { fromLibrary: true } },
+        new Map([['/properties/root/properties/next', '/properties/root']])
+      )).toEqual({ fromLibrary: true });
+    });
+
+    it('fixes a misplaced array required list', () => {
+      expect(getSubSchema(
+        { type: 'array', required: ['a'], items: { properties: { a: {} } } }, '', {}, new Map()
+      )).toEqual({ type: 'array', items: { properties: { a: {} }, required: ['a'] } });
+    });
+  });
+
+  describe('combineAllOf', () => {
+    it('returns the input unchanged when it is not an object', () => {
+      expect(combineAllOf(null)).toBeNull();
+      expect(combineAllOf('nope')).toEqual('nope');
+    });
+
+    it('returns the schema unchanged when there is no allOf array', () => {
+      expect(combineAllOf({ type: 'string' })).toEqual({ type: 'string' });
+      expect(combineAllOf({ allOf: { type: 'string' } })).toEqual({ allOf: { type: 'string' } });
+    });
+
+    it('merges the members of an allOf array', () => {
+      expect(combineAllOf({ allOf: [{ type: 'string' }, { minLength: 2 }] }))
+        .toEqual({ type: 'string', minLength: 2 });
+    });
+
+    it('merges the remaining keys of the schema back in', () => {
+      expect(combineAllOf({ title: 'T', allOf: [{ type: 'string' }] }))
+        .toEqual({ type: 'string', title: 'T' });
+    });
+
+    it('keeps an allOf array when the members cannot be merged', () => {
+      expect(combineAllOf({ allOf: [{ type: 'string' }, { type: 'number' }] }))
+        .toEqual({ allOf: [{ type: 'string' }, { type: 'number' }] });
+    });
+
+    it('returns an empty object for an empty allOf array', () => {
+      expect(combineAllOf({ allOf: [] })).toEqual({});
+    });
+  });
+
+  describe('fixRequiredArrayProperties', () => {
+    it('moves the required list into items.properties', () => {
+      expect(fixRequiredArrayProperties({
+        type: 'array', required: ['a'], items: { type: 'object', properties: { a: {}, b: {} } },
+      })).toEqual({
+        type: 'array', items: { type: 'object', properties: { a: {}, b: {} }, required: ['a'] },
+      });
+    });
+
+    it('moves the required list into additionalItems.properties', () => {
+      expect(fixRequiredArrayProperties({
+        type: 'array', required: ['a'], additionalItems: { type: 'object', properties: { a: {} } },
+      })).toEqual({
+        type: 'array', additionalItems: { type: 'object', properties: { a: {} }, required: ['a'] },
+      });
+    });
+
+    it('moves the required list when the items schema allows additional properties', () => {
+      expect(fixRequiredArrayProperties({
+        type: 'array', required: ['z'], items: { properties: { a: {} }, additionalProperties: true },
+      })).toEqual({
+        type: 'array',
+        items: { properties: { a: {} }, additionalProperties: true, required: ['z'] },
+      });
+    });
+
+    it('returns a copy and leaves the original schema untouched', () => {
+      const schema: any = { type: 'array', required: ['a'], items: { properties: { a: {} } } };
+      const result: any = fixRequiredArrayProperties(schema);
+
+      expect(result).not.toBe(schema);
+      expect(schema.required).toEqual(['a']);
+      expect(result.required).toBeUndefined();
+    });
+
+    it('leaves the schema alone when a required key is not a declared item property', () => {
+      const schema: any = {
+        type: 'array', required: ['z'], items: { type: 'object', properties: { a: {} } },
+      };
+
+      expect(fixRequiredArrayProperties(schema)).toBe(schema);
+    });
+
+    it('leaves the schema alone when the items schema already has a required list', () => {
+      const schema: any = {
+        type: 'array', required: ['a'], items: { properties: { a: {} }, required: ['b'] },
+      };
+
+      expect(fixRequiredArrayProperties(schema)).toBe(schema);
+    });
+
+    it('leaves the schema alone when there is no items or additionalItems object', () => {
+      const schema: any = { type: 'array', required: ['a'] };
+
+      expect(fixRequiredArrayProperties(schema)).toBe(schema);
+    });
+
+    it('leaves a non array schema and a non array required alone', () => {
+      expect(fixRequiredArrayProperties({ type: 'object', required: ['a'] }))
+        .toEqual({ type: 'object', required: ['a'] });
+      expect(fixRequiredArrayProperties({ type: 'array', required: true }))
+        .toEqual({ type: 'array', required: true });
+    });
+
+    it('throws for a null schema', () => {
+      // BUG: schema.type is read with no guard.
+      expect(() => fixRequiredArrayProperties(null)).toThrow();
+    });
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1,0 +1,1477 @@
+import {
+  buildLayout,
+  buildLayoutFromSchema,
+  buildTitleMap,
+  getLayoutNode,
+  mapLayout,
+} from './layout.functions';
+
+/**
+ * Characterization tests for the layout function library.
+ *
+ * These pin the behaviour these functions have today, including several results
+ * that are almost certainly wrong (see the comments marked BUG). Nothing here is
+ * an aspiration: every expectation was produced by running the real code.
+ *
+ * The `jsf` argument is a plain object literal carrying only the properties the
+ * functions actually read, so no Angular service has to be instantiated.
+ */
+
+/** Minimal stand-in for JsonSchemaFormService. */
+function makeJsf(overrides: any = {}): any {
+  return {
+    schema: {},
+    layout: [],
+    formValues: {},
+    dataMap: new Map(),
+    arrayMap: new Map(),
+    schemaRefLibrary: {},
+    layoutRefLibrary: {},
+    templateRefLibrary: {},
+    schemaRecursiveRefMap: new Map(),
+    dataRecursiveRefMap: new Map(),
+    formOptions: {
+      addSubmit: false,
+      // NOTE: 'defautWidgetOptions' really is spelled that way in the source.
+      defautWidgetOptions: {},
+      setSchemaDefaults: 'auto',
+    },
+    fieldsRequired: false,
+    hasRootReference: false,
+    ...overrides,
+  };
+}
+
+/** Minimal stand-in for WidgetLibraryService. */
+const widgetLibrary: any = {
+  hasWidget: (type: any) => type !== 'no-such-widget',
+  getWidget: (type: any) => 'widget:' + type,
+};
+
+/**
+ * Removes every '_id' key, at any depth. Layout node ids come from lodash
+ * uniqueId(), whose counter is global across the whole test bundle, so their
+ * values can never be asserted.
+ */
+function stripIds(node: any): any {
+  if (Array.isArray(node)) { return node.map(stripIds); }
+  if (node !== null && typeof node === 'object') {
+    const copied: any = {};
+    Object.keys(node)
+      .filter(key => key !== '_id')
+      .forEach(key => copied[key] = stripIds(node[key]));
+    return copied;
+  }
+  return node;
+}
+
+const objectSchema: any = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'integer' },
+  },
+};
+
+const arrayOfObjectsSchema: any = {
+  type: 'object',
+  properties: {
+    people: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { first: { type: 'string' }, last: { type: 'string' } },
+      },
+    },
+  },
+};
+
+describe('buildTitleMap', () => {
+
+  describe('no titleMap and no enum list', () => {
+    it('returns the default boolean map', () => {
+      expect(buildTitleMap(null, null)).toEqual([
+        { name: 'True', value: true },
+        { name: 'False', value: false },
+      ]);
+    });
+
+    it('returns the default boolean map for undefined arguments too', () => {
+      expect(buildTitleMap(undefined, undefined)).toEqual([
+        { name: 'True', value: true },
+        { name: 'False', value: false },
+      ]);
+    });
+
+    it('prepends a None entry to the default boolean map when not required', () => {
+      // Neither default value is null, so hasEmptyValue stays false and the
+      // None entry is added.
+      expect(buildTitleMap(null, null, false)).toEqual([
+        { name: '<em>None</em>', value: null },
+        { name: 'True', value: true },
+        { name: 'False', value: false },
+      ]);
+    });
+  });
+
+  describe('enum list alone', () => {
+    it('uses each enum value as both name and value', () => {
+      expect(buildTitleMap(null, ['a', 'b'])).toEqual([
+        { name: 'a', value: 'a' },
+        { name: 'b', value: 'b' },
+      ]);
+    });
+
+    it('prepends a None entry when the field is not required', () => {
+      expect(buildTitleMap(null, ['a', 'b'], false)).toEqual([
+        { name: '<em>None</em>', value: null },
+        { name: 'a', value: 'a' },
+        { name: 'b', value: 'b' },
+      ]);
+    });
+
+    it('does not prepend None when the enum list already contains null', () => {
+      expect(buildTitleMap(null, [null, 'b'], false)).toEqual([
+        { name: null, value: null },
+        { name: 'b', value: 'b' },
+      ]);
+    });
+
+    it('accepts an object as the enum list and walks its values', () => {
+      expect(buildTitleMap(null, { x: 'ex', y: 'why' })).toEqual([
+        { name: 'ex', value: 'ex' },
+        { name: 'why', value: 'why' },
+      ]);
+    });
+
+    it('returns an empty map for an empty enum list', () => {
+      // An empty array is still truthy, so the enum branch is taken and the
+      // default boolean map is never reached.
+      expect(buildTitleMap(null, [])).toEqual([]);
+    });
+  });
+
+  describe('array titleMap with an enum list', () => {
+    it('keeps only the JSON Form entries whose value is in the enum list', () => {
+      expect(buildTitleMap(
+        [{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }, { name: 'C', value: 'c' }],
+        ['a', 'c']
+      )).toEqual([{ name: 'A', value: 'a' }, { name: 'C', value: 'c' }]);
+    });
+
+    it('pairs React Jsonschema Form style string names with enum values by index', () => {
+      expect(buildTitleMap(['A', 'B', 'C'], ['a', 'b']))
+        .toEqual([{ name: 'A', value: 'a' }, { name: 'B', value: 'b' }]);
+    });
+
+    it('drops string names past the end of the enum list', () => {
+      expect(buildTitleMap(['A', 'B', 'C'], ['a']))
+        .toEqual([{ name: 'A', value: 'a' }]);
+    });
+
+    it('skips entries that are neither an object nor a string', () => {
+      expect(buildTitleMap([5, true], ['a'])).toEqual([]);
+    });
+
+    it('keeps an undefined value and does not add a None entry for it', () => {
+      expect(buildTitleMap([{ name: 'A' }], [undefined]))
+        .toEqual([{ name: 'A', value: undefined }]);
+    });
+  });
+
+  describe('array titleMap without an enum list', () => {
+    it('returns the titleMap unchanged', () => {
+      expect(buildTitleMap([{ name: 'A', value: 'a' }], null))
+        .toEqual([{ name: 'A', value: 'a' }]);
+    });
+
+    it('returns the very same array instance, not a copy', () => {
+      // BUG: newTitleMap is assigned the caller's array by reference, so later
+      // group processing can mutate the caller's own titleMap.
+      const titleMap: any = [{ name: 'A', value: 'a' }];
+
+      expect(buildTitleMap(titleMap, null)).toBe(titleMap);
+    });
+
+    it('prepends a None entry when the field is not required', () => {
+      expect(buildTitleMap([{ name: 'A', value: 'a' }], null, false)).toEqual([
+        { name: '<em>None</em>', value: null },
+        { name: 'A', value: 'a' },
+      ]);
+    });
+
+    it('does not prepend None when an entry already has a null value', () => {
+      expect(buildTitleMap(
+        [{ name: 'None', value: null }, { name: 'A', value: 'a' }], null, false
+      )).toEqual([{ name: 'None', value: null }, { name: 'A', value: 'a' }]);
+    });
+
+    it('returns an empty array for an empty array titleMap', () => {
+      expect(buildTitleMap([], null)).toEqual([]);
+    });
+  });
+
+  describe('object titleMap', () => {
+    it('maps enum values through the object when an enum list is given', () => {
+      expect(buildTitleMap({ a: 'Apple', b: 'Banana' }, ['a', 'b']))
+        .toEqual([{ name: 'Apple', value: 'a' }, { name: 'Banana', value: 'b' }]);
+    });
+
+    it('skips enum values that are not keys of the object', () => {
+      expect(buildTitleMap({ a: 'Apple' }, ['a', 'z']))
+        .toEqual([{ name: 'Apple', value: 'a' }]);
+    });
+
+    it('walks the object keys when no enum list is given', () => {
+      expect(buildTitleMap({ a: 'Apple', b: 'Banana' }, null))
+        .toEqual([{ name: 'Apple', value: 'a' }, { name: 'Banana', value: 'b' }]);
+    });
+
+    it('returns an empty array for an empty object titleMap', () => {
+      expect(buildTitleMap({}, null)).toEqual([]);
+    });
+  });
+
+  describe('grouped titleMap, flatList true', () => {
+    it('flattens a group entry into "group: name"', () => {
+      expect(buildTitleMap([
+        { group: 'G', name: 'n', value: 1 },
+        { name: 'plain', value: 2 },
+      ], null)).toEqual([{ name: 'G: n', value: 1 }, { name: 'plain', value: 2 }]);
+    });
+
+    it('expands the items of a group entry and prefixes each name', () => {
+      expect(buildTitleMap(
+        [{ group: 'G', items: [{ name: 'x', value: 1 }, { name: 'y', value: 2 }] }], null
+      )).toEqual([{ name: 'G: x', value: 1 }, { name: 'G: y', value: 2 }]);
+    });
+
+    it('drops a group entry that has neither items nor a name and value pair', () => {
+      expect(buildTitleMap([{ group: 'G' }], null)).toEqual([]);
+    });
+
+    it('emits a group entry twice when it has items as well as a name and value', () => {
+      // BUG: the two `if` blocks are not exclusive, so an entry carrying both
+      // shapes contributes its items and then itself, keeping the stale
+      // `items` array on the second copy.
+      expect(buildTitleMap(
+        [{ group: 'G', items: [{ name: 'x', value: 1 }], name: 'n', value: 2 }], null
+      )).toEqual([
+        { name: 'G: x', value: 1 },
+        { items: [{ name: 'x', value: 1 }], name: 'G: n', value: 2 },
+      ]);
+    });
+
+    it('prepends a None entry when grouped and not required', () => {
+      expect(buildTitleMap([{ group: 'G', name: 'n', value: 1 }], null, false))
+        .toEqual([{ name: '<em>None</em>', value: null }, { name: 'G: n', value: 1 }]);
+    });
+
+    it('does not prepend None when a grouped entry carries a null value', () => {
+      expect(buildTitleMap([{ group: 'G', name: 'n', value: null }], null, false))
+        .toEqual([{ name: 'G: n', value: null }]);
+    });
+
+    it('mutates the caller titleMap entries in place', () => {
+      // BUG: the array branch keeps the caller's own entry objects, and the
+      // group reducer rewrites `name` and deletes `group` on them.
+      const titleMap: any = [{ group: 'G', name: 'n', value: 1 }];
+      buildTitleMap(titleMap, null);
+
+      expect(titleMap).toEqual([{ name: 'G: n', value: 1 }]);
+    });
+  });
+
+  describe('grouped titleMap, flatList false', () => {
+    it('collects entries of one group into a single group object', () => {
+      expect(buildTitleMap([
+        { group: 'G', name: 'n', value: 1 },
+        { group: 'G', name: 'm', value: 2 },
+        { name: 'p', value: 3 },
+      ], null, true, false)).toEqual([
+        { group: 'G', items: [{ name: 'n', value: 1 }, { name: 'm', value: 2 }] },
+        { name: 'p', value: 3 },
+      ]);
+    });
+
+    it('keeps an existing items array on a group entry', () => {
+      expect(buildTitleMap(
+        [{ group: 'G', items: [{ name: 'x', value: 1 }] }], null, true, false
+      )).toEqual([{ group: 'G', items: [{ name: 'x', value: 1 }] }]);
+    });
+
+    it('starts a new group object for each distinct group name', () => {
+      expect(buildTitleMap([
+        { group: 'A', name: 'a', value: 1 },
+        { group: 'B', name: 'b', value: 2 },
+      ], null, true, false)).toEqual([
+        { group: 'A', items: [{ name: 'a', value: 1 }] },
+        { group: 'B', items: [{ name: 'b', value: 2 }] },
+      ]);
+    });
+
+    it('prepends a None entry when grouped, unflattened and not required', () => {
+      expect(buildTitleMap([{ group: 'G', name: 'n', value: 1 }], null, false, false))
+        .toEqual([
+          { name: '<em>None</em>', value: null },
+          { group: 'G', items: [{ name: 'n', value: 1 }] },
+        ]);
+    });
+
+    it('does not prepend None when a grouped item carries a null value', () => {
+      expect(buildTitleMap([{ group: 'G', name: 'n', value: null }], null, false, false))
+        .toEqual([{ group: 'G', items: [{ name: 'n', value: null }] }]);
+    });
+  });
+});
+
+describe('mapLayout', () => {
+
+  it('returns an empty array for an empty layout', () => {
+    expect(mapLayout([], (item: any) => item)).toEqual([]);
+  });
+
+  it('returns an empty array for a null layout', () => {
+    expect(mapLayout(null, (item: any) => item)).toEqual([]);
+  });
+
+  it('returns an empty array for an undefined layout', () => {
+    expect(mapLayout(undefined, (item: any) => item)).toEqual([]);
+  });
+
+  it('runs the iteratee over every element', () => {
+    expect(mapLayout(['a', 'b', 'c'], (item: any) => item.toUpperCase()))
+      .toEqual(['A', 'B', 'C']);
+  });
+
+  it('copies object nodes rather than passing the originals through', () => {
+    const layout: any = [{ key: 'a' }];
+
+    expect(mapLayout(layout, (item: any) => item)[0]).not.toBe(layout[0]);
+  });
+
+  it('passes the running index and the layout pointer to the iteratee', () => {
+    expect(mapLayout(['a', 'b'], (item: any, index: any, pointer: any) => pointer))
+      .toEqual(['/0', '/1']);
+  });
+
+  it('passes the root layout as the fourth argument', () => {
+    const layout: any = ['a'];
+    let seenRoot: any = null;
+    mapLayout(layout, (item: any, i: any, p: any, root: any) => {
+      seenRoot = root;
+      return item;
+    });
+
+    expect(seenRoot).toBe(layout);
+  });
+
+  it('honours an explicit layoutPointer prefix', () => {
+    expect(mapLayout(['a'], (item: any, i: any, pointer: any) => pointer, '/base'))
+      .toEqual(['/base/0']);
+  });
+
+  it('drops null results and shifts the indexes of later items', () => {
+    expect(mapLayout(
+      ['a', 'b', 'c'],
+      (item: any, index: any) => item === 'b' ? null : item + index
+    )).toEqual(['a0', 'c1']);
+  });
+
+  it('drops undefined results as well', () => {
+    expect(mapLayout(['a', 'b'], (item: any) => item === 'a' ? undefined : item))
+      .toEqual(['b']);
+  });
+
+  it('keeps a zero result because zero is defined', () => {
+    expect(mapLayout(['a'], () => 0)).toEqual([0]);
+  });
+
+  it('keeps a false result because false is defined', () => {
+    expect(mapLayout(['a'], () => false)).toEqual([false]);
+  });
+
+  it('splices an array result inline and pads the following indexes', () => {
+    expect(mapLayout(['a', 'b'], (item: any) => item === 'a' ? ['x', 'y'] : item))
+      .toEqual(['x', 'y', 'b']);
+  });
+
+  it('recurses into an items array before calling the iteratee on the parent', () => {
+    expect(mapLayout(
+      [{ items: ['inner'] }],
+      (item: any) => typeof item === 'string' ? item.toUpperCase() : item
+    )).toEqual([{ items: ['INNER'] }]);
+  });
+
+  it('wraps a single items object into an array', () => {
+    expect(mapLayout([{ items: { key: 'z' } }], (item: any) => item))
+      .toEqual([{ items: [{ key: 'z' }] }]);
+  });
+
+  it('builds nested layout pointers through items', () => {
+    expect(mapLayout(
+      [{ items: [{ items: ['deep'] }] }],
+      (item: any, i: any, pointer: any) => typeof item === 'string' ? pointer : item
+    )).toEqual([{ items: [{ items: ['/0/items/0/items/0'] }] }]);
+  });
+
+  it('leaves a node without items untouched', () => {
+    expect(mapLayout([{ key: 'a' }], (item: any) => item)).toEqual([{ key: 'a' }]);
+  });
+
+  it('copies tabs into items but leaves the stale tabs key on the result', () => {
+    // BUG: copy(item) runs before `item.items = item.tabs; delete item.tabs`,
+    // so the shallow copy that becomes the result still carries `tabs`.
+    expect(mapLayout([{ tabs: [{ key: 'a' }] }], (item: any) => item))
+      .toEqual([{ tabs: [{ key: 'a' }], items: [{ key: 'a' }] }]);
+  });
+
+  it('rewrites tabs to items on the caller layout in place', () => {
+    // BUG: mapLayout is documented as creating a new layout, but it mutates
+    // the input node when converting tabs.
+    const layout: any = [{ tabs: [{ key: 'a' }] }];
+    mapLayout(layout, (item: any) => item);
+
+    expect(layout).toEqual([{ items: [{ key: 'a' }] }]);
+  });
+
+  it('produces NaN pointers when the layout is a plain object', () => {
+    // BUG: realIndex is `+index + indexPad`, and the keys of a plain object
+    // are not numeric, so every pointer becomes '/NaN'.
+    expect(mapLayout(
+      { x: 'a', y: 'b' },
+      (item: any, i: any, pointer: any) => item + pointer
+    )).toEqual(['a/NaN', 'b/NaN']);
+  });
+});
+
+describe('getLayoutNode', () => {
+
+  describe('recursive reference with a widget library', () => {
+    it('returns an Add button node naming the reference', () => {
+      expect(stripIds(getLayoutNode(
+        { $ref: '/a', dataPointer: '/x', recursiveReference: true },
+        makeJsf(),
+        widgetLibrary
+      ))).toEqual({
+        $ref: '/a',
+        dataPointer: '/x',
+        recursiveReference: true,
+        widget: 'widget:$ref',
+        options: { removable: false, title: 'Add /a' },
+      });
+    });
+
+    it('keeps any options already present on the reference node', () => {
+      const result: any = getLayoutNode(
+        { $ref: '/a', recursiveReference: true, options: { fieldStyle: 'boxed' } },
+        makeJsf(),
+        widgetLibrary
+      );
+
+      expect(result.options)
+        .toEqual({ fieldStyle: 'boxed', removable: false, title: 'Add /a' });
+    });
+
+    it('returns an Add button even when the reference is not in the library', () => {
+      // This branch returns before layoutRefLibrary is ever consulted.
+      const result: any = getLayoutNode(
+        { $ref: '/never-registered', recursiveReference: true },
+        makeJsf(),
+        widgetLibrary
+      );
+
+      expect(stripIds(result)).toEqual({
+        $ref: '/never-registered',
+        recursiveReference: true,
+        widget: 'widget:$ref',
+        options: { removable: false, title: 'Add /never-registered' },
+      });
+    });
+  });
+
+  describe('copy from layoutRefLibrary', () => {
+    it('deep copies the stored node and gives every subnode a fresh id', () => {
+      const jsf: any = makeJsf({
+        layoutRefLibrary: {
+          '/a': {
+            _id: null,
+            dataPointer: '/inner',
+            options: {},
+            type: 'text',
+            items: [{ _id: null, dataPointer: '/inner/deep', options: {} }],
+          },
+        },
+      });
+      const result: any = getLayoutNode({ $ref: '/a', dataPointer: '/pre' }, jsf, widgetLibrary);
+
+      expect(stripIds(result)).toEqual({
+        dataPointer: '/inner',
+        options: {},
+        type: 'text',
+        items: [{ dataPointer: '/inner/deep', options: {} }],
+      });
+      expect(result._id).not.toBeNull();
+      expect(typeof result._id).toBe('string');
+      expect(result.items[0]._id).not.toBeNull();
+      expect(result).not.toBe(jsf.layoutRefLibrary['/a']);
+    });
+
+    it('leaves the stored library node untouched', () => {
+      const jsf: any = makeJsf({
+        layoutRefLibrary: { '/a': { _id: null, dataPointer: '/inner', options: {} } },
+      });
+      getLayoutNode({ $ref: '/a', dataPointer: '/pre', recursiveReference: true }, jsf, null);
+
+      expect(jsf.layoutRefLibrary['/a'].dataPointer).toEqual('/inner');
+      expect(jsf.layoutRefLibrary['/a']._id).toBeNull();
+    });
+
+    it('prefixes every dataPointer when copying a recursive reference', () => {
+      const jsf: any = makeJsf({
+        layoutRefLibrary: { '/a': { _id: null, dataPointer: '/inner', options: {} } },
+      });
+
+      expect(stripIds(getLayoutNode(
+        { $ref: '/a', dataPointer: '/pre', recursiveReference: true }, jsf, null
+      ))).toEqual({ dataPointer: '/pre/inner', options: {} });
+    });
+
+    it('returns undefined for a reference that is not in the library', () => {
+      expect(getLayoutNode({ $ref: '/missing' }, makeJsf(), widgetLibrary)).toBeUndefined();
+    });
+  });
+
+  describe('rebuild from schema when a node value is supplied', () => {
+    it('throws when the reference is not in the library', () => {
+      // BUG: line 907 reads jsf.layoutRefLibrary[refNode.$ref] with no guard,
+      // then dereferences `.arrayItem` on the undefined result.
+      expect(() => getLayoutNode(
+        { $ref: '/missing' }, makeJsf(), widgetLibrary, 'a value'
+      )).toThrow();
+    });
+
+    it('rebuilds the referenced node from the schema', () => {
+      const jsf: any = makeJsf({
+        schema: arrayOfObjectsSchema,
+        arrayMap: new Map([['/people', 0]]),
+      });
+      buildLayoutFromSchema(jsf, widgetLibrary, null, '/properties/people', '/people');
+      const result: any = getLayoutNode(
+        { $ref: '/people/-', dataPointer: '/people/-' },
+        jsf,
+        widgetLibrary,
+        { first: 'Bob' }
+      );
+
+      expect(result.type).toEqual('section');
+      expect(result.dataPointer).toEqual('/people/-');
+      expect(result.arrayItem).toBe(true);
+      expect(result.arrayItemType).toEqual('list');
+      expect(result.items.map((item: any) => item.dataPointer))
+        .toEqual(['/people/-/first', '/people/-/last']);
+    });
+  });
+});
+
+describe('buildLayoutFromSchema', () => {
+
+  describe('defensive branches', () => {
+    it('returns null for an empty schema', () => {
+      expect(buildLayoutFromSchema(makeJsf(), widgetLibrary)).toBeNull();
+    });
+
+    it('returns null when the schema pointer resolves to nothing', () => {
+      expect(buildLayoutFromSchema(
+        makeJsf({ schema: objectSchema }), widgetLibrary, null, '/properties/nope', '/nope'
+      )).toBeNull();
+    });
+
+    it('builds a node from an x-schema-form block with no type and no $ref', () => {
+      expect(stripIds(buildLayoutFromSchema(
+        makeJsf({ schema: { 'x-schema-form': { type: 'help' } } }), widgetLibrary
+      ))).toEqual({
+        arrayItem: false,
+        dataPointer: '',
+        dataType: null,
+        name: '',
+        options: { type: 'help', required: false },
+        required: false,
+        type: 'help',
+        widget: 'widget:help',
+      });
+    });
+  });
+
+  describe('scalar properties', () => {
+    it('builds a text node for a string property', () => {
+      expect(stripIds(buildLayoutFromSchema(
+        makeJsf({ schema: { type: 'object', properties: { name: { type: 'string', title: 'Full Name' } } } }),
+        widgetLibrary, null, '/properties/name', '/name'
+      ))).toEqual({
+        arrayItem: false,
+        dataPointer: '/name',
+        dataType: 'string',
+        name: 'name',
+        options: { title: 'Full Name', required: false },
+        required: false,
+        type: 'text',
+        widget: 'widget:text',
+      });
+    });
+
+    it('derives a title from the property name when the schema has none', () => {
+      const result: any = buildLayoutFromSchema(
+        makeJsf({ schema: { type: 'object', properties: { first_name: { type: 'string' } } } }),
+        widgetLibrary, null, '/properties/first_name', '/first_name'
+      );
+
+      expect(result.options.title).toEqual('First Name');
+    });
+
+    it('uses a checkbox for a boolean and a select for an enum', () => {
+      const result: any = buildLayoutFromSchema(makeJsf({
+        schema: {
+          type: 'object',
+          properties: { ok: { type: 'boolean' }, pick: { type: 'string', enum: ['x', 'y'] } },
+        },
+      }), widgetLibrary);
+
+      expect(result.map((item: any) => [item.name, item.type]))
+        .toEqual([['ok', 'checkbox'], ['pick', 'select']]);
+      expect(result[1].options.enum).toEqual(['x', 'y']);
+    });
+
+    it('sets a null _id when building for the reference library', () => {
+      const result: any = buildLayoutFromSchema(
+        makeJsf({ schema: objectSchema }), widgetLibrary,
+        null, '/properties/name', '/name', false, null, null, true
+      );
+
+      expect(result._id).toBeNull();
+    });
+
+    it('records arrayItem, arrayItemType and removable for an array item node', () => {
+      expect(stripIds(buildLayoutFromSchema(
+        makeJsf({ schema: { type: 'object', properties: { n: { type: 'string' } } } }),
+        widgetLibrary, null, '/properties/n', '/n', true, 'tuple', false
+      ))).toEqual({
+        arrayItem: true,
+        arrayItemType: 'tuple',
+        dataPointer: '/n',
+        dataType: 'string',
+        name: 'n',
+        options: { required: false, removable: false, title: 'N' },
+        required: false,
+        type: 'text',
+        widget: 'widget:text',
+      });
+    });
+  });
+
+  describe('object schemas', () => {
+    it('returns a bare array of item nodes for the root data pointer', () => {
+      const jsf: any = makeJsf({ schema: objectSchema });
+      const result: any = buildLayoutFromSchema(jsf, widgetLibrary);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.map((item: any) => item.name)).toEqual(['name', 'age']);
+    });
+
+    it('nests the item nodes under items when the data pointer is not the root', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { group: objectSchema } },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/group', '/group'
+      );
+
+      expect(result.type).toEqual('section');
+      expect(result.items.map((item: any) => item.dataPointer))
+        .toEqual(['/group/name', '/group/age']);
+    });
+
+    it('marks required properties and flips jsf.fieldsRequired', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', required: ['a'], properties: { a: { type: 'string' }, b: { type: 'string' } } },
+      });
+      const result: any = buildLayoutFromSchema(jsf, widgetLibrary);
+
+      expect(result[0].options.required).toBe(true);
+      expect(result[1].options.required).toBe(false);
+      expect(jsf.fieldsRequired).toBe(true);
+    });
+
+    it('registers a dataMap entry for every node it builds', () => {
+      const jsf: any = makeJsf({ schema: objectSchema });
+      buildLayoutFromSchema(jsf, widgetLibrary);
+
+      expect(Array.from(jsf.dataMap.keys())).toEqual(['', '/name', '/age']);
+      expect(jsf.dataMap.get('/name').get('inputType')).toEqual('text');
+      expect(jsf.dataMap.get('/name').get('widget')).toEqual('widget:text');
+      expect(jsf.dataMap.get('/name').get('schemaPointer')).toEqual('/properties/name');
+      expect(jsf.dataMap.get('').get('required')).toEqual(undefined);
+    });
+
+    it('stores the schema required list in the parent dataMap entry', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', required: ['name'], properties: { name: { type: 'string' } } },
+      });
+      buildLayoutFromSchema(jsf, widgetLibrary);
+
+      expect(jsf.dataMap.get('').get('required')).toEqual(['name']);
+    });
+
+    it('orders the properties by ui:order', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          'ui:order': ['b', 'a'],
+          properties: { a: { type: 'string' }, b: { type: 'string' } },
+        },
+      });
+
+      expect(buildLayoutFromSchema(jsf, widgetLibrary).map((item: any) => item.name))
+        .toEqual(['b', 'a']);
+    });
+
+    it('expands a * placeholder in ui:order into the unnamed properties', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          'ui:order': ['b', '*'],
+          properties: { a: { type: 'string' }, b: { type: 'string' }, c: { type: 'string' } },
+        },
+      });
+
+      expect(buildLayoutFromSchema(jsf, widgetLibrary).map((item: any) => item.name))
+        .toEqual(['b', 'a', 'c']);
+    });
+
+    it('builds an unknown ui:order key from additionalProperties', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          'ui:order': ['a', 'extra'],
+          properties: { a: { type: 'string' } },
+          additionalProperties: { type: 'number' },
+        },
+      });
+
+      expect(buildLayoutFromSchema(jsf, widgetLibrary)
+        .map((item: any) => [item.name, item.dataPointer, item.type]))
+        .toEqual([['a', '/a', 'text'], ['extra', '/extra', 'number']]);
+    });
+
+    it('skips a ui:order key that matches neither properties nor additionalProperties', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', 'ui:order': ['a', 'ghost'], properties: { a: { type: 'string' } } },
+      });
+
+      expect(buildLayoutFromSchema(jsf, widgetLibrary).map((item: any) => item.name))
+        .toEqual(['a']);
+    });
+
+    it('returns a node with no items for an object schema with no properties', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { blank: { type: 'object' } } },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/blank', '/blank'
+      );
+
+      expect(result.dataType).toEqual('object');
+      expect(result.items).toBeUndefined();
+    });
+  });
+
+  describe('array schemas', () => {
+    const listSchema: any = {
+      type: 'object',
+      properties: { tags: { type: 'array', title: 'Tags', items: { type: 'string' } } },
+    };
+
+    it('builds one list item plus an Add button', () => {
+      const jsf: any = makeJsf({ schema: listSchema });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/tags', '/tags'
+      );
+
+      expect(result.type).toEqual('array');
+      expect(result.options)
+        .toEqual({ title: 'Tags', required: false, maxItems: 1000, minItems: 0, listItems: 1, tupleItems: 0 });
+      expect(result.items.map((item: any) => item.type)).toEqual(['text', '$ref']);
+      expect(stripIds(result.items[1])).toEqual({
+        arrayItem: true,
+        arrayItemType: 'list',
+        dataPointer: '/tags/-',
+        options: {
+          listItems: 1,
+          maxItems: 1000,
+          minItems: 0,
+          removable: false,
+          title: 'Add to Tags',
+          tupleItems: 0,
+        },
+        recursiveReference: false,
+        type: '$ref',
+        widget: 'widget:$ref',
+        $ref: '/tags/-',
+      });
+    });
+
+    it('registers the item template in layoutRefLibrary and the array in arrayMap', () => {
+      const jsf: any = makeJsf({ schema: listSchema });
+      buildLayoutFromSchema(jsf, widgetLibrary, null, '/properties/tags', '/tags');
+
+      expect(Object.keys(jsf.layoutRefLibrary)).toEqual(['/tags/-']);
+      expect(jsf.layoutRefLibrary['/tags/-'].type).toEqual('text');
+      expect(Array.from(jsf.arrayMap)).toEqual([['/tags', 0]]);
+      expect(jsf.dataMap.get('/tags').get('maxItems')).toEqual(1000);
+      expect(jsf.dataMap.get('/tags').get('tupleItems')).toEqual(0);
+    });
+
+    it('builds one node per tuple entry when items is an array', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          properties: { pair: { type: 'array', items: [{ type: 'string' }, { type: 'number' }] } },
+        },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/pair', '/pair'
+      );
+
+      expect(result.options.tupleItems).toEqual(2);
+      expect(result.items.map((item: any) => [item.type, item.arrayItemType, item.dataPointer]))
+        .toEqual([['text', 'tuple', '/pair/0'], ['number', 'tuple', '/pair/1']]);
+      expect(Object.keys(jsf.layoutRefLibrary)).toEqual(['/pair/0', '/pair/1']);
+    });
+
+    it('clamps tupleItems to maxItems and zeroes listItems', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          properties: { pair: { type: 'array', maxItems: 1, items: [{ type: 'string' }, { type: 'number' }] } },
+        },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/pair', '/pair'
+      );
+
+      expect(result.options.maxItems).toEqual(1);
+      expect(result.options.tupleItems).toEqual(1);
+      expect(result.options.listItems).toEqual(0);
+      expect(result.items.map((item: any) => item.type)).toEqual(['text']);
+    });
+
+    it('raises listItems to satisfy minItems and pre-builds that many items', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          properties: { p: { type: 'array', minItems: 3, items: { type: 'string' } } },
+        },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/p', '/p'
+      );
+
+      expect(result.options.minItems).toEqual(3);
+      expect(result.options.listItems).toEqual(3);
+      expect(result.items.map((item: any) => item.type))
+        .toEqual(['text', 'text', 'text', '$ref']);
+    });
+
+    it('sets minItems to 1 for a required array', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          required: ['p'],
+          properties: { p: { type: 'array', items: { type: 'string' } } },
+        },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/p', '/p'
+      );
+
+      expect(result.options.minItems).toEqual(1);
+      expect(result.options.required).toBe(true);
+    });
+
+    it('adds one item node per entry in the supplied node value', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { p: { type: 'array', items: { type: 'string' } } } },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, ['x', 'y', 'z'], '/properties/p', '/p'
+      );
+
+      expect(result.items.map((item: any) => item.type))
+        .toEqual(['text', 'text', 'text', '$ref']);
+    });
+
+    it('takes the array length from the schema default when setSchemaDefaults is true', () => {
+      const schema: any = {
+        type: 'object',
+        properties: { p: { type: 'array', items: { type: 'string' }, default: ['a', 'b'] } },
+      };
+      const withDefaults: any = makeJsf({
+        schema,
+        formOptions: { addSubmit: false, defautWidgetOptions: {}, setSchemaDefaults: true },
+      });
+      const withoutDefaults: any = makeJsf({
+        schema,
+        formOptions: { addSubmit: false, defautWidgetOptions: {}, setSchemaDefaults: false },
+      });
+
+      expect(buildLayoutFromSchema(withDefaults, widgetLibrary, null, '/properties/p', '/p')
+        .items.map((item: any) => item.type)).toEqual(['text', 'text', '$ref']);
+      expect(buildLayoutFromSchema(withoutDefaults, widgetLibrary, null, '/properties/p', '/p')
+        .items.map((item: any) => item.type)).toEqual(['text', '$ref']);
+    });
+
+    it('omits the Add button when addable is false', () => {
+      const jsf: any = makeJsf({
+        schema: {
+          type: 'object',
+          properties: {
+            p: { type: 'array', items: { type: 'string' }, 'x-schema-form': { addable: false } },
+          },
+        },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/p', '/p'
+      );
+
+      expect(result.options.addable).toBe(false);
+      expect(result.items.map((item: any) => item.type)).toEqual(['text']);
+    });
+
+    it('builds an empty items array for an array schema with no items', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { p: { type: 'array', maxItems: 3 } } },
+      });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/p', '/p'
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.options.maxItems).toEqual(3);
+    });
+
+    it('does not throw when the data pointer is listed in dataRecursiveRefMap', () => {
+      const jsf: any = makeJsf({
+        schema: arrayOfObjectsSchema,
+        arrayMap: new Map([['/people', 0]]),
+        dataRecursiveRefMap: new Map([['/people/-/kids', '/people']]),
+      });
+
+      expect(() => buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/people', '/people'
+      )).not.toThrow();
+    });
+  });
+
+  describe('$ref schemas', () => {
+    const refSchema: any = {
+      type: 'object',
+      title: 'Root',
+      properties: { a: { type: 'string' }, b: { $ref: '#/properties/a' } },
+    };
+
+    it('builds an Add button node and stores the target in layoutRefLibrary', () => {
+      const jsf: any = makeJsf({ schema: refSchema });
+      const result: any = buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/b', '/b'
+      );
+
+      expect(stripIds(result)).toEqual({
+        arrayItem: false,
+        dataPointer: '/b',
+        dataType: '$ref',
+        name: 'b',
+        options: { required: false, title: 'Add B', removable: false },
+        required: false,
+        recursiveReference: true,
+        type: '$ref',
+        widget: 'widget:$ref',
+        $ref: '/a',
+      });
+      expect(Object.keys(jsf.layoutRefLibrary)).toEqual(['/a']);
+      expect(jsf.layoutRefLibrary['/a'].recursiveReference).toBe(true);
+    });
+
+    it('produces "Add to undefined" when the node name is numeric', () => {
+      // BUG: the fallback reads pointerArray[length - 2], which is out of range
+      // for a one segment pointer, so fixTitle() is handed undefined.
+      const result: any = buildLayoutFromSchema(
+        makeJsf({ schema: refSchema }), widgetLibrary, null, '/properties/b', '/0'
+      );
+
+      expect(result.options.title).toEqual('Add to undefined');
+    });
+
+    it('throws on a schema whose $ref points at itself', () => {
+      // BUG: layoutRefLibrary[dataRef] is set to null as a recursion guard, but
+      // hasOwn() then reports the key as present, and line 816 dereferences null.
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { child: { $ref: '#/properties/child' } } },
+      });
+
+      expect(() => buildLayoutFromSchema(
+        jsf, widgetLibrary, null, '/properties/child', '/child'
+      )).toThrow();
+    });
+  });
+});
+
+describe('buildLayout', () => {
+
+  describe('layout element shapes', () => {
+    it('turns a plain string key into a data pointer', () => {
+      expect(stripIds(buildLayout(
+        makeJsf({ schema: objectSchema, layout: ['name'] }), widgetLibrary
+      ))).toEqual([{
+        arrayItem: false,
+        dataPointer: '/name',
+        dataType: 'string',
+        name: 'name',
+        options: { title: 'Name' },
+        type: 'text',
+        widget: 'widget:text',
+      }]);
+    });
+
+    it('accepts a JSON pointer as the layout element', () => {
+      const result: any = buildLayout(
+        makeJsf({ schema: objectSchema, layout: ['/name'] }), widgetLibrary
+      );
+
+      expect(result[0].dataPointer).toEqual('/name');
+      expect(result[0].type).toEqual('text');
+    });
+
+    it('accepts an object with a key property', () => {
+      const result: any = buildLayout(
+        makeJsf({ schema: objectSchema, layout: [{ key: 'age' }] }), widgetLibrary
+      );
+
+      expect(result[0].dataPointer).toEqual('/age');
+      expect(result[0].type).toEqual('integer');
+      expect(result[0].options.multipleOf).toEqual(1);
+    });
+
+    it('accepts an object that already carries a dataPointer', () => {
+      const result: any = buildLayout(
+        makeJsf({ schema: objectSchema, layout: [{ dataPointer: '/name' }] }), widgetLibrary
+      );
+
+      expect(result[0].dataPointer).toEqual('/name');
+      expect(result[0].name).toEqual('name');
+    });
+
+    it('skips an element that is neither an object nor a string', () => {
+      const result: any = buildLayout(
+        makeJsf({ schema: objectSchema, layout: [42, 'name'] }), widgetLibrary
+      );
+
+      expect(result.length).toEqual(1);
+      expect(result[0].dataPointer).toEqual('/name');
+    });
+
+    it('returns an empty layout for an empty input layout', () => {
+      expect(buildLayout(makeJsf({ schema: objectSchema, layout: [] }), widgetLibrary))
+        .toEqual([]);
+    });
+  });
+
+  describe('option normalisation', () => {
+    it('moves unrecognised keys into options', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', placeholder: 'hi', notify: true }],
+      }), widgetLibrary);
+
+      expect(result[0].options.placeholder).toEqual('hi');
+      expect(result[0].options.notify).toBe(true);
+      expect(result[0].placeholder).toBeUndefined();
+    });
+
+    it('renames legend to title', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', legend: 'Legend Title' }],
+      }), widgetLibrary);
+
+      expect(result[0].options.title).toEqual('Legend Title');
+      expect(result[0].options.legend).toBeUndefined();
+    });
+
+    it('renames errorMessages to validationMessages', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', errorMessages: { required: 'req' } }],
+      }), widgetLibrary);
+
+      expect(result[0].options.validationMessages).toEqual({ required: 'req' });
+      expect(result[0].options.errorMessages).toBeUndefined();
+    });
+
+    it('copies a string validationMessage straight across', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', validationMessage: 'oops' }],
+      }), widgetLibrary);
+
+      expect(result[0].options.validationMessages).toEqual('oops');
+    });
+
+    it('translates TV4 numeric validationMessage codes into keyword names', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{
+          key: 'name',
+          validationMessage: {
+            0: 'c0', 1: 'c1', 100: 'c100', 101: 'c101', 102: 'c102', 103: 'c103',
+            104: 'c104', 200: 'c200', 201: 'c201', 202: 'c202', 300: 'c300',
+            301: 'c301', 302: 'c302', 304: 'c304', 400: 'c400', 401: 'c401',
+            402: 'c402', 500: 'c500', 999: 'unknown',
+          },
+        }],
+      }), widgetLibrary);
+
+      expect(result[0].options.validationMessages).toEqual({
+        type: 'c0', enum: 'c1', multipleOf: 'c100', minimum: 'c101',
+        exclusiveMinimum: 'c102', maximum: 'c103', exclusiveMaximum: 'c104',
+        minLength: 'c200', maxLength: 'c201', pattern: 'c202',
+        minProperties: 'c300', maxProperties: 'c301', required: 'c302',
+        dependencies: 'c304', minItems: 'c400', maxItems: 'c401',
+        uniqueItems: 'c402', format: 'c500', 999: 'unknown',
+      });
+      expect(result[0].options.validationMessage).toBeUndefined();
+    });
+
+    it('keeps an existing validationMessages object over errorMessages', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', validationMessages: { a: 'keep' }, errorMessages: { b: 'drop' } }],
+      }), widgetLibrary);
+
+      expect(result[0].options.validationMessages).toEqual({ a: 'keep' });
+      expect(result[0].options.errorMessages).toEqual({ b: 'drop' });
+    });
+
+    it('compiles a string copyValueTo into an array of pointers', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', copyValueTo: 'age' }],
+      }), widgetLibrary);
+
+      expect(result[0].options.copyValueTo).toEqual(['/age']);
+    });
+
+    it('compiles every entry of an array copyValueTo', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', copyValueTo: ['age', 'name'] }],
+      }), widgetLibrary);
+
+      expect(result[0].options.copyValueTo).toEqual(['/age', '/name']);
+    });
+  });
+
+  describe('widget and type resolution', () => {
+    it('promotes a string widget to the node type', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', widget: 'textarea' }],
+      }), widgetLibrary);
+
+      expect(result[0].type).toEqual('textarea');
+      expect(result[0].widget).toEqual('widget:textarea');
+    });
+
+    it('replaces a type the widget library does not know', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', type: 'no-such-widget' }],
+      }), widgetLibrary);
+
+      expect(result[0].type).toEqual('text');
+      expect(result[0].widget).toEqual('widget:text');
+    });
+
+    it('keeps a known type from the layout', () => {
+      const result: any = buildLayout(makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', type: 'password' }],
+      }), widgetLibrary);
+
+      expect(result[0].type).toEqual('password');
+    });
+
+    it('leaves the node without a type when the key is missing from the schema', () => {
+      // BUG: when the schema lookup fails, `type` is never assigned, so the
+      // node ends up with widget 'widget:undefined'.
+      const result: any = buildLayout(makeJsf({
+        schema: { type: 'object', properties: { a: { type: 'string' } }, additionalProperties: false },
+        layout: ['zzz'],
+      }), widgetLibrary);
+
+      expect(result[0].type).toBeUndefined();
+      expect(result[0].widget).toEqual('widget:undefined');
+      expect(result[0].options.title).toEqual('Zzz');
+    });
+  });
+
+  describe('the submit button', () => {
+    it('appends a submit button when formOptions.addSubmit is truthy', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: ['name'],
+        formOptions: { addSubmit: 'auto', defautWidgetOptions: {}, setSchemaDefaults: 'auto' },
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result.map((item: any) => item.type)).toEqual(['text', 'submit']);
+      expect(stripIds(result[1]))
+        .toEqual({ options: { title: 'Submit' }, type: 'submit', widget: 'widget:submit' });
+    });
+
+    it('appends no submit button when formOptions.addSubmit is falsy', () => {
+      const result: any = buildLayout(
+        makeJsf({ schema: objectSchema, layout: ['name'] }), widgetLibrary
+      );
+
+      expect(result.map((item: any) => item.type)).toEqual(['text']);
+    });
+
+    it('does not duplicate a submit button already present in the layout', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: ['name', { type: 'submit' }],
+        formOptions: { addSubmit: 'auto', defautWidgetOptions: {}, setSchemaDefaults: 'auto' },
+      });
+
+      expect(buildLayout(jsf, widgetLibrary).map((item: any) => item.type))
+        .toEqual(['text', 'submit']);
+    });
+  });
+
+  describe('the * wildcard', () => {
+    it('replaces * with one node per schema property, inline', () => {
+      const jsf: any = makeJsf({ schema: objectSchema, layout: ['*'] });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result.map((item: any) => item.dataPointer)).toEqual(['/name', '/age']);
+    });
+
+    it('keeps the surrounding layout items around an expanded *', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ type: 'help', helpvalue: 'x' }, '*'],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result.map((item: any) => item.type)).toEqual(['help', 'text', 'integer']);
+    });
+  });
+
+  describe('container nodes', () => {
+    it('builds a fieldset from a node with a type and items', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ type: 'fieldset', items: ['name', 'age'] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result.length).toEqual(1);
+      expect(result[0].type).toEqual('fieldset');
+      expect(result[0].widget).toEqual('widget:fieldset');
+      expect(result[0].arrayItem).toBe(false);
+      expect(result[0].items.map((item: any) => item.dataPointer)).toEqual(['/name', '/age']);
+    });
+
+    it('defaults an untyped container inside tabs to a tab', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ type: 'tabs', items: [{ items: ['name'] }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].items[0].type).toEqual('tab');
+    });
+
+    it('defaults an untyped container outside tabs to an array', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ type: 'fieldset', items: [{ items: ['name'] }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].items[0].type).toEqual('array');
+    });
+
+    it('leaves the stale tabs key inside options when a layout uses tabs', () => {
+      // BUG: mapLayout copies `tabs` to `items` on the source node only after
+      // taking its shallow copy, so buildLayout sees both and files `tabs`
+      // under options as an unrecognised key.
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ type: 'tabs', tabs: [{ type: 'tab', items: ['name'] }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].type).toEqual('tabs');
+      expect(result[0].options.tabs).toEqual([{ type: 'tab', items: ['name'] }]);
+      expect(result[0].items.map((item: any) => item.type)).toEqual(['tab']);
+      expect(result[0].items[0].items.map((item: any) => item.dataPointer)).toEqual(['/name']);
+    });
+  });
+
+  describe('array nodes', () => {
+    it('finds the array data pointer from its child nodes and groups them', () => {
+      const jsf: any = makeJsf({
+        schema: arrayOfObjectsSchema,
+        arrayMap: new Map([['/people', 0]]),
+        layout: [{ type: 'array', items: [{ key: 'people[].first' }, { key: 'people[].last' }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].dataPointer).toEqual('/people');
+      expect(result[0].name).toEqual('people');
+      expect(result[0].dataType).toEqual('array');
+      expect(result[0].items.map((item: any) => item.type)).toEqual(['section', '$ref']);
+      expect(result[0].items[0].dataPointer).toEqual('/people/-');
+      expect(result[0].items[0].arrayItem).toBe(true);
+      expect(result[0].items[0].arrayItemType).toEqual('list');
+      expect(result[0].items[0].items.map((item: any) => item.dataPointer))
+        .toEqual(['/people/-/first', '/people/-/last']);
+      expect(Object.keys(jsf.layoutRefLibrary)).toEqual(['/people/-']);
+    });
+
+    it('names the Add button after the array title', () => {
+      const jsf: any = makeJsf({
+        schema: arrayOfObjectsSchema,
+        arrayMap: new Map([['/people', 0]]),
+        layout: [{ key: 'people', type: 'array', items: [{ key: 'people[].first' }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+      const addButton: any = result[0].items[result[0].items.length - 1];
+
+      expect(addButton.type).toEqual('$ref');
+      expect(addButton.$ref).toEqual('/people/-');
+      expect(addButton.options.title).toEqual('Add People');
+      expect(addButton.options.removable).toBe(false);
+      expect(addButton.recursiveReference).toBe(false);
+    });
+
+    it('marks a single array item as removable and typed list', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', properties: { tags: { type: 'array', items: { type: 'string' } } } },
+        arrayMap: new Map([['/tags', 0]]),
+        layout: [{ key: 'tags', type: 'array', items: [{ key: 'tags[]' }] }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].items[0].arrayItem).toBe(true);
+      expect(result[0].items[0].arrayItemType).toEqual('list');
+      expect(result[0].items[0].options.removable).toBe(true);
+      expect(result[0].items[0].dataPointer).toEqual('/tags/-');
+    });
+
+    it('never applies style.add to the Add button', () => {
+      // BUG: `style` is not on the preserved key list, so it is moved into
+      // options before the style.add lookup runs, making that branch dead code.
+      const jsf: any = makeJsf({
+        schema: arrayOfObjectsSchema,
+        arrayMap: new Map([['/people', 0]]),
+        layout: [{
+          key: 'people', type: 'array', style: { add: 'btn-add' },
+          items: [{ key: 'people[].first' }],
+        }],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+      const addButton: any = result[0].items[result[0].items.length - 1];
+
+      expect(result[0].style).toBeUndefined();
+      expect(result[0].options.style).toEqual({ add: 'btn-add' });
+      expect(addButton.options.fieldStyle).toBeUndefined();
+    });
+  });
+
+  describe('root reference', () => {
+    it('stores the whole layout under the empty key of layoutRefLibrary', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: ['name'],
+        hasRootReference: true,
+        formOptions: {
+          addSubmit: 'auto',
+          defautWidgetOptions: { htmlClass: 'row' },
+          setSchemaDefaults: 'auto',
+        },
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+      const rootRef: any = jsf.layoutRefLibrary[''];
+
+      expect(result.map((item: any) => item.type)).toEqual(['text', 'submit']);
+      expect(rootRef._id).toBeNull();
+      expect(rootRef.type).toEqual('section');
+      expect(rootRef.widget).toEqual('widget:section');
+      expect(rootRef.dataPointer).toEqual('');
+      expect(rootRef.dataType).toEqual('object');
+      expect(rootRef.name).toEqual('');
+      expect(rootRef.recursiveReference).toBe(true);
+      expect(rootRef.required).toBe(false);
+      expect(rootRef.options).toEqual({ htmlClass: 'row' });
+      // The submit button is popped off the stored copy.
+      expect(rootRef.items.map((item: any) => item.type)).toEqual(['text']);
+    });
+
+    it('throws for a root reference over an empty layout', () => {
+      // BUG: fullLayout[fullLayout.length - 1] is undefined for an empty
+      // layout, and `.type` is read from it without a guard.
+      const jsf: any = makeJsf({ schema: objectSchema, layout: [], hasRootReference: true });
+
+      expect(() => buildLayout(jsf, widgetLibrary)).toThrow();
+    });
+  });
+
+  describe('data map side effects', () => {
+    it('records the input type, widget and disabled flag per data pointer', () => {
+      const jsf: any = makeJsf({
+        schema: objectSchema,
+        layout: [{ key: 'name', disabled: true }],
+      });
+      buildLayout(jsf, widgetLibrary);
+      const nodeDataMap: any = jsf.dataMap.get('/name');
+
+      expect(nodeDataMap.get('inputType')).toEqual('text');
+      expect(nodeDataMap.get('widget')).toEqual('widget:text');
+      expect(nodeDataMap.get('disabled')).toBe(true);
+      expect(nodeDataMap.get('schemaPointer')).toEqual('/properties/name');
+    });
+
+    it('reuses a schemaPointer that is already in the data map', () => {
+      const jsf: any = makeJsf({ schema: objectSchema, layout: ['name'] });
+      jsf.dataMap.set('/name', new Map([['schemaPointer', '/properties/age']]));
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].type).toEqual('integer');
+      expect(jsf.dataMap.get('/name').get('schemaPointer')).toEqual('/properties/age');
+    });
+
+    it('sets jsf.fieldsRequired for a required layout key', () => {
+      const jsf: any = makeJsf({
+        schema: { type: 'object', required: ['name'], properties: { name: { type: 'string' } } },
+        layout: ['name'],
+      });
+      const result: any = buildLayout(jsf, widgetLibrary);
+
+      expect(result[0].options.required).toBe(true);
+      expect(jsf.fieldsRequired).toBe(true);
+      expect(jsf.dataMap.get('/name').get('required')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds core tests for layout generation, form groups, JSON Schema handling, and `JsonSchemaFormService`.

## Testing approach

The tests use focused service stubs and import the Angular module from source to avoid loading a second copy from `dist`. They record current behavior, including known bugs. The 62 `BUG:` comments identify cases that need separate behavior fixes.

## Release impact

Only test files changed, so there is no package release.

## Validation

Coverage rose from 76.12 percent to 86.95 percent. Core specs increased from 1,395 to 2,076, with 2,332 specs passing across all four suites. The local 80 percent coverage check, both CI jobs, CodeQL, and both Codecov checks passed.
