### PR TITLE
fix(core): correct validator and locale message defects

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.0.0",
+    "@ajsf/core": "^17.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.0.0",
+    "@ajsf/core": "^17.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-core/src/lib/locale/de-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/de-validation-messages.ts
@@ -42,8 +42,8 @@ export const deValidationMessages: any = { // Default German error messages
   maximum: 'Darf maximal {{maximumValue}} sein',
   exclusiveMaximum: 'Muss kleiner als {{exclusiveMaximumValue}} sein',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Maximal ${decimals} Dezimalstellen erlaubt`;
     } else {
       return `Muss ein Vielfaches von ${error.multipleOfValue} sein`;

--- a/projects/ajsf-core/src/lib/locale/en-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/en-validation-messages.ts
@@ -42,8 +42,8 @@ export const enValidationMessages: any = { // Default English error messages
   maximum: 'Must be {{maximumValue}} or less',
   exclusiveMaximum: 'Must be less than {{exclusiveMaximumValue}}',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Must have ${decimals} or fewer decimal places.`;
     } else {
       return `Must be a multiple of ${error.multipleOfValue}.`;

--- a/projects/ajsf-core/src/lib/locale/es-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/es-validation-messages.ts
@@ -2,7 +2,7 @@ export const esValidationMessages: any = { // Default Spanish error messages
   required: 'Este campo está requerido.',
   minLength: 'Debe tener {{minimumLength}} caracteres o más longitud (longitud actual: {{currentLength}})',
   maxLength: 'Debe tener {{maximumLength}} caracteres o menos longitud (longitud actual: {{currentLength}})',
-  pattern: 'Must match pattern: {{requiredPattern}}',
+  pattern: 'Debe coincidir con el patrón: {{requiredPattern}}',
   format: function (error) {
     switch (error.requiredFormat) {
       case 'date':
@@ -40,8 +40,8 @@ export const esValidationMessages: any = { // Default Spanish error messages
   maximum: 'Debe ser {{maximumValue}} o menos',
   exclusiveMaximum: 'Debe ser menor que {{exclusiveMaximumValue}}',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Se permite un máximo de ${decimals} decimales`;
     } else {
       return `Debe ser múltiplo de ${error.multipleOfValue}.`;

--- a/projects/ajsf-core/src/lib/locale/fr-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/fr-validation-messages.ts
@@ -42,17 +42,17 @@ export const frValidationMessages: any = { // French error messages
   maximum: 'Doit être inférieur à {{maximumValue}}',
   exclusiveMaximum: 'Doit avoir maximum {{exclusiveMaximumValue}} charactères',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Doit comporter ${decimals} ou moins de decimales.`;
     } else {
       return `Doit être un multiple de ${error.multipleOfValue}.`;
     }
   },
-  minProperties: 'Doit comporter au minimum {{minimumProperties}} éléments',
-  maxProperties: 'Doit comporter au maximum {{maximumProperties}} éléments',
-  minItems: 'Doit comporter au minimum {{minimumItems}} éléments',
-  maxItems: 'Doit comporter au maximum {{minimumItems}} éléments',
+  minProperties: 'Doit comporter au minimum {{minimumProperties}} éléments (actuellement: {{currentProperties}})',
+  maxProperties: 'Doit comporter au maximum {{maximumProperties}} éléments (actuellement: {{currentProperties}})',
+  minItems: 'Doit comporter au minimum {{minimumItems}} éléments (actuellement: {{currentItems}})',
+  maxItems: 'Doit comporter au maximum {{maximumItems}} éléments (actuellement: {{currentItems}})',
   uniqueItems: 'Tous les éléments doivent être uniques',
   // Note: No default error messages for 'type', 'const', 'enum', or 'dependencies'
 };

--- a/projects/ajsf-core/src/lib/locale/it-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/it-validation-messages.ts
@@ -6,13 +6,13 @@ export const itValidationMessages: any = { // Default Italian error messages
   format: function (error) {
     switch (error.requiredFormat) {
       case 'date':
-        return 'Deve essere una data, come "31-12-2000"';
+        return 'Deve essere una data, come "2000-12-31"';
       case 'time':
         return 'Deve essere un orario, come "16:20" o "03:14:15.9265"';
       case 'date-time':
-        return 'Deve essere data-orario, come "14-03-2000T01:59" or "14-03-2000T01:59:26.535Z"';
+        return 'Deve essere data-orario, come "2000-03-14T01:59" or "2000-03-14T01:59:26.535Z"';
       case 'email':
-        return 'Deve essere un indirzzo email, come "name@example.com"';
+        return 'Deve essere un indirizzo email, come "name@example.com"';
       case 'hostname':
         return 'Deve essere un hostname, come "example.com"';
       case 'ipv4':
@@ -42,8 +42,8 @@ export const itValidationMessages: any = { // Default Italian error messages
   maximum: 'Deve essere {{maximumValue}} o meno',
   exclusiveMaximum: 'Deve essere minore di {{exclusiveMaximumValue}}',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Deve avere ${decimals} o meno decimali.`;
     } else {
       return `Deve essere multiplo di ${error.multipleOfValue}.`;

--- a/projects/ajsf-core/src/lib/locale/pt-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/pt-validation-messages.ts
@@ -1,7 +1,7 @@
 export const ptValidationMessages: any = { // Brazilian Portuguese error messages
   required: 'Este campo é obrigatório.',
   minLength: 'É preciso no mínimo {{minimumLength}} caracteres ou mais (tamanho atual: {{currentLength}})',
-  maxLength: 'É preciso no máximo  {{maximumLength}} caracteres ou menos (tamanho atual: {{currentLength}})',
+  maxLength: 'É preciso no máximo {{maximumLength}} caracteres ou menos (tamanho atual: {{currentLength}})',
   pattern: 'Tem que ajustar ao formato: {{requiredPattern}}',
   format: function (error) {
     switch (error.requiredFormat) {
@@ -42,15 +42,15 @@ export const ptValidationMessages: any = { // Brazilian Portuguese error message
   maximum: 'Tem que ser {{maximumValue}} ou menos',
   exclusiveMaximum: 'Tem que ser menor que {{exclusiveMaximumValue}}',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `Tem que ter ${decimals} ou menos casas decimais.`;
     } else {
       return `Tem que ser um múltiplo de ${error.multipleOfValue}.`;
     }
   },
   minProperties: 'Deve ter {{minimumProperties}} ou mais itens (itens até o momento: {{currentProperties}})',
-  maxProperties: 'Deve ter {{maximumProperties}} ou menos intens (itens até o momento: {{currentProperties}})',
+  maxProperties: 'Deve ter {{maximumProperties}} ou menos itens (itens até o momento: {{currentProperties}})',
   minItems: 'Deve ter {{minimumItems}} ou mais itens (itens até o momento: {{currentItems}})',
   maxItems: 'Deve ter {{maximumItems}} ou menos itens (itens até o momento: {{currentItems}})',
   uniqueItems: 'Todos os itens devem ser únicos',

--- a/projects/ajsf-core/src/lib/locale/validation-messages.spec.ts
+++ b/projects/ajsf-core/src/lib/locale/validation-messages.spec.ts
@@ -51,17 +51,20 @@ const knownFormats: string[] = [
   'regex',
 ];
 
-// multipleOfValue inputs where (1 / value) % 10 === 0, so the decimal places
-// branch runs and the message reports Math.log10(1 / value) instead of the value.
+// multipleOfValue inputs that are exact negative powers of ten, so the decimal
+// places branch runs and the message reports Math.log10(1 / value) instead of
+// the value.
 const decimalPlacesCases: { value: number, decimals: string }[] = [
   { value: 0.1, decimals: '1' },
   { value: 0.01, decimals: '2' },
   { value: 0.001, decimals: '3' },
   { value: 0.0001, decimals: '4' },
+  { value: 0.00001, decimals: '5' },
 ];
 
 // multipleOfValue inputs that fall through to the "multiple of" branch, which
-// interpolates the raw value.
+// interpolates the raw value. 1, 10 and 100 give an integer Math.log10(1 / value)
+// too, so the decimal places branch also has to require a count above zero.
 const multipleOfCases: number[] = [1, 2, 3, 0.5, 0.25, 10, 100, -1];
 
 function placeholdersOf(message: string): string[] {
@@ -120,7 +123,7 @@ describe('Validation messages', () => {
       expect(offenders).toEqual([]);
     });
 
-    it('placeholders match the English ones in every locale except French', () => {
+    it('placeholders match the English ones in every locale', () => {
       const reference: { [key: string]: string } = {};
       Object.keys(enValidationMessages)
         .filter(key => typeof enValidationMessages[key] !== 'function')
@@ -129,16 +132,13 @@ describe('Validation messages', () => {
         });
       const offenders: string[] = [];
 
-      // French is excluded on purpose: see the locale quirks block below.
-      locales
-        .filter(locale => locale.name !== 'fr')
-        .forEach(({ name, messages }) => {
-          Object.keys(reference).forEach(key => {
-            if (placeholdersOf(messages[key]).join(',') !== reference[key]) {
-              offenders.push(`${name}.${key}`);
-            }
-          });
+      locales.forEach(({ name, messages }) => {
+        Object.keys(reference).forEach(key => {
+          if (placeholdersOf(messages[key]).join(',') !== reference[key]) {
+            offenders.push(`${name}.${key}`);
+          }
         });
+      });
 
       expect(offenders).toEqual([]);
     });
@@ -252,37 +252,44 @@ describe('Validation messages', () => {
         expect(result).toEqual(messages.multipleOf({ multipleOfValue: 0.1 }));
       });
 
-      it('reports a fractional count of decimal places for 0.05', () => {
-        // 1 / 0.05 is 20, and 20 % 10 === 0, so Math.log10(20) leaks into the message.
+      it('reports a multiple of 0.05, which is not a power of ten', () => {
+        // 1 / 0.05 is 20, so Math.log10(20) is fractional and the decimal
+        // places branch must not run.
         const result = messages.multipleOf({ multipleOfValue: 0.05 });
 
-        expect(result).toContain('1.3010299956639813');
+        expect(result).toContain('0.05');
+        expect(result).not.toContain('1.3010299956639813');
       });
 
-      it('reports a fractional count of decimal places for 0.005', () => {
+      it('reports a multiple of 0.005, which is not a power of ten', () => {
         const result = messages.multipleOf({ multipleOfValue: 0.005 });
 
-        expect(result).toContain('2.3010299956639813');
+        expect(result).toContain('0.005');
+        expect(result).not.toContain('2.3010299956639813');
       });
 
-      it('reports 0.00001 as a multiple because 1 / 0.00001 is not exactly 100000', () => {
+      it('reports 5 decimal places for 0.00001, whose reciprocal is inexact', () => {
+        // 1 / 0.00001 is 99999.99999999999, but Math.log10 of it is exactly 5.
         const result = messages.multipleOf({ multipleOfValue: 0.00001 });
 
-        expect(result).toContain('0.00001');
+        expect(result).toContain('5');
+        expect(result).not.toContain('0.00001');
       });
 
-      it('reports NaN decimal places for a negative multipleOfValue', () => {
-        // 1 / -0.1 is -10 and -10 % 10 is -0, which equals 0, so the decimal
-        // places branch runs and Math.log10 of a negative number is NaN.
+      it('reports a multiple of a negative multipleOfValue', () => {
+        // Math.log10 of a negative number is NaN, so the decimal places branch
+        // must not run.
         const result = messages.multipleOf({ multipleOfValue: -0.1 });
 
-        expect(result).toContain('NaN');
+        expect(result).toContain('-0.1');
+        expect(result).not.toContain('NaN');
       });
 
-      it('reports minus Infinity decimal places for an infinite multipleOfValue', () => {
+      it('reports a multiple of an infinite multipleOfValue', () => {
         const result = messages.multipleOf({ multipleOfValue: Infinity });
 
-        expect(result).toContain('-Infinity');
+        expect(result).toContain('Infinity');
+        expect(result).not.toContain('-Infinity');
       });
 
       it('reports a multiple of 0 for a zero multipleOfValue', () => {
@@ -371,14 +378,22 @@ describe('Validation messages', () => {
         .toEqual('Must have 2 or fewer decimal places.');
       expect(enValidationMessages.multipleOf({ multipleOfValue: 0.0001 }))
         .toEqual('Must have 4 or fewer decimal places.');
+      expect(enValidationMessages.multipleOf({ multipleOfValue: 0.00001 }))
+        .toEqual('Must have 5 or fewer decimal places.');
       expect(enValidationMessages.multipleOf({ multipleOfValue: 5 }))
         .toEqual('Must be a multiple of 5.');
+      expect(enValidationMessages.multipleOf({ multipleOfValue: 1 }))
+        .toEqual('Must be a multiple of 1.');
+      expect(enValidationMessages.multipleOf({ multipleOfValue: 10 }))
+        .toEqual('Must be a multiple of 10.');
+      expect(enValidationMessages.multipleOf({ multipleOfValue: 100 }))
+        .toEqual('Must be a multiple of 100.');
       expect(enValidationMessages.multipleOf({ multipleOfValue: 0.05 }))
-        .toEqual('Must have 1.3010299956639813 or fewer decimal places.');
+        .toEqual('Must be a multiple of 0.05.');
       expect(enValidationMessages.multipleOf({ multipleOfValue: -0.1 }))
-        .toEqual('Must have NaN or fewer decimal places.');
+        .toEqual('Must be a multiple of -0.1.');
       expect(enValidationMessages.multipleOf({ multipleOfValue: Infinity }))
-        .toEqual('Must have -Infinity or fewer decimal places.');
+        .toEqual('Must be a multiple of Infinity.');
     });
 
     it('exposes the documented template messages', () => {
@@ -395,22 +410,22 @@ describe('Validation messages', () => {
 
   describe('locale quirks', () => {
 
-    it('Italian uses day first date examples', () => {
+    it('Italian no longer uses day first date examples', () => {
       expect(itValidationMessages.format({ requiredFormat: 'date' }))
-        .toContain('"31-12-2000"');
+        .toContain('"2000-12-31"');
       expect(itValidationMessages.format({ requiredFormat: 'date' }))
-        .not.toContain('2000-12-31');
+        .not.toContain('31-12-2000');
       expect(itValidationMessages.format({ requiredFormat: 'date-time' }))
-        .toContain('"14-03-2000T01:59"');
+        .toContain('"2000-03-14T01:59"');
+      expect(itValidationMessages.format({ requiredFormat: 'date-time' }))
+        .not.toContain('14-03-2000');
     });
 
-    it('every locale except Italian uses the ISO date example', () => {
-      locales
-        .filter(locale => locale.name !== 'it')
-        .forEach(({ messages }) => {
-          expect(messages.format({ requiredFormat: 'date' })).toContain('2000-12-31');
-          expect(messages.format({ requiredFormat: 'date-time' })).toContain('2000-03-14T01:59');
-        });
+    it('every locale uses the ISO date example', () => {
+      locales.forEach(({ messages }) => {
+        expect(messages.format({ requiredFormat: 'date' })).toContain('2000-12-31');
+        expect(messages.format({ requiredFormat: 'date-time' })).toContain('2000-03-14T01:59');
+      });
     });
 
     it('Portuguese uses Brazilian examples', () => {
@@ -439,21 +454,22 @@ describe('Validation messages', () => {
         });
     });
 
-    it('French maxItems interpolates minimumItems', () => {
-      // Pinned as is: this looks like a copy and paste slip in the source.
-      expect(frValidationMessages.maxItems).toContain('{{minimumItems}}');
-      expect(frValidationMessages.maxItems).not.toContain('{{maximumItems}}');
+    it('French maxItems interpolates maximumItems', () => {
+      expect(frValidationMessages.maxItems).toContain('{{maximumItems}}');
+      expect(frValidationMessages.maxItems).not.toContain('{{minimumItems}}');
     });
 
-    it('French item and property messages drop the current count placeholder', () => {
-      expect(frValidationMessages.minItems).not.toContain('{{currentItems}}');
-      expect(frValidationMessages.maxItems).not.toContain('{{currentItems}}');
-      expect(frValidationMessages.minProperties).not.toContain('{{currentProperties}}');
-      expect(frValidationMessages.maxProperties).not.toContain('{{currentProperties}}');
+    it('French item and property messages carry the current count placeholder', () => {
+      expect(frValidationMessages.minItems).toContain('{{currentItems}}');
+      expect(frValidationMessages.maxItems).toContain('{{currentItems}}');
+      expect(frValidationMessages.minProperties).toContain('{{currentProperties}}');
+      expect(frValidationMessages.maxProperties).toContain('{{currentProperties}}');
     });
 
-    it('Spanish leaves the pattern message untranslated', () => {
-      expect(esValidationMessages.pattern).toEqual(enValidationMessages.pattern);
+    it('Spanish translates the pattern message', () => {
+      expect(esValidationMessages.pattern).not.toEqual(enValidationMessages.pattern);
+      expect(esValidationMessages.pattern)
+        .toEqual('Debe coincidir con el patrón: {{requiredPattern}}');
     });
 
     it('the other message strings differ between English and Spanish', () => {

--- a/projects/ajsf-core/src/lib/locale/zh-validation-messages.ts
+++ b/projects/ajsf-core/src/lib/locale/zh-validation-messages.ts
@@ -42,8 +42,8 @@ export const zhValidationMessages: any = { // Chinese error messages
   maximum: '必须小于或者等于最大值: {{maximumValue}}',
   exclusiveMaximum: '必须小于最大值: {{exclusiveMaximumValue}}',
   multipleOf: function (error) {
-    if ((1 / error.multipleOfValue) % 10 === 0) {
-      const decimals = Math.log10(1 / error.multipleOfValue);
+    const decimals = Math.log10(1 / error.multipleOfValue);
+    if (error.multipleOfValue > 0 && Number.isInteger(decimals) && decimals > 0) {
       return `必须有 ${decimals} 位或更少的小数位`;
     } else {
       return `必须为 ${error.multipleOfValue} 的倍数`;

--- a/projects/ajsf-core/src/lib/shared/format-regex.constants.ts
+++ b/projects/ajsf-core/src/lib/shared/format-regex.constants.ts
@@ -49,7 +49,7 @@ export const jsonSchemaFormatTests = {
 
   // optimized https://gist.github.com/olmokramer/82ccce673f86db7cda5e
   // tslint:disable-next-line:max-line-length
-  'color': /^\s*(#(?:[\da-f]{3}){1,2}|rgb\((?:\d{1,3},\s*){2}\d{1,3}\)|rgba\((?:\d{1,3},\s*){3}\d*\.?\d+\)|hsl\(\d{1,3}(?:,\s*\d{1,3}%){2}\)|hsla\(\d{1,3}(?:,\s*\d{1,3}%){2},\s*\d*\.?\d+\))\s*$/gi,
+  'color': /^\s*(#(?:[\da-f]{3}){1,2}|rgb\((?:\d{1,3},\s*){2}\d{1,3}\)|rgba\((?:\d{1,3},\s*){3}\d*\.?\d+\)|hsl\(\d{1,3}(?:,\s*\d{1,3}%){2}\)|hsla\(\d{1,3}(?:,\s*\d{1,3}%){2},\s*\d*\.?\d+\))\s*$/i,
 
   // JSON-pointer: https://tools.ietf.org/html/rfc6901
   'json-pointer': /^(?:\/(?:[^~/]|~0|~1)*)*$|^#(?:\/(?:[a-z0-9_\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i,

--- a/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
@@ -1,5 +1,5 @@
 import { FormControl } from '@angular/forms';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { JsonValidators } from './json.validators';
 
 // Helper returning `any` so validators typed against AbstractControl accept it
@@ -407,14 +407,12 @@ describe('JsonValidators', () => {
         .toEqual({ format: { requiredFormat: 'email', currentValue: true } });
     });
 
-    it('is stateful for the color format because its RegExp carries the g flag', () => {
-      // jsonSchemaFormatTests['color'] is a shared RegExp with /g, so lastIndex
-      // persists between calls and identical inputs alternate pass and fail.
+    it('is stable for the color format across repeated checks of the same value', () => {
       const validator = JsonValidators.format('color');
-      const first = validator(ctrl('#fff'));
-      const second = validator(ctrl('#fff'));
 
-      expect(first === null).not.toEqual(second === null);
+      expect(validator(ctrl('#fff'))).toBeNull();
+      expect(validator(ctrl('#fff'))).toBeNull();
+      expect(validator(ctrl('#fff'))).toBeNull();
     });
 
     it('flips the result when inverted', () => {
@@ -449,7 +447,7 @@ describe('JsonValidators', () => {
       expect(JsonValidators.minimum(5)(ctrl('abc'))).toBeNull();
     });
 
-    it('compares numeric strings without converting them first', () => {
+    it('coerces numeric strings before comparing', () => {
       expect(JsonValidators.minimum(5)(ctrl('10'))).toBeNull();
       expect(JsonValidators.minimum(5)(ctrl('3')))
         .toEqual({ minimum: { minimumValue: 5, currentValue: '3' } });
@@ -473,15 +471,15 @@ describe('JsonValidators', () => {
       expect(JsonValidators.exclusiveMinimum(5)(ctrl(null))).toBeNull();
     });
 
-    it('behaves as an exclusive maximum: values below the bound pass', () => {
-      expect(JsonValidators.exclusiveMinimum(5)(ctrl(3))).toBeNull();
+    it('accepts a number strictly above the bound', () => {
+      expect(JsonValidators.exclusiveMinimum(5)(ctrl(10))).toBeNull();
     });
 
-    it('behaves as an exclusive maximum: values at or above the bound fail', () => {
+    it('rejects a number at or below the bound', () => {
       expect(JsonValidators.exclusiveMinimum(5)(ctrl(5)))
         .toEqual({ exclusiveMinimum: { exclusiveMinimumValue: 5, currentValue: 5 } });
-      expect(JsonValidators.exclusiveMinimum(5)(ctrl(10)))
-        .toEqual({ exclusiveMinimum: { exclusiveMinimumValue: 5, currentValue: 10 } });
+      expect(JsonValidators.exclusiveMinimum(5)(ctrl(3)))
+        .toEqual({ exclusiveMinimum: { exclusiveMinimumValue: 5, currentValue: 3 } });
     });
 
     it('accepts any non-numeric value', () => {
@@ -489,9 +487,9 @@ describe('JsonValidators', () => {
     });
 
     it('flips the result when inverted', () => {
-      expect(JsonValidators.exclusiveMinimum(5)(ctrl(3), true))
-        .toEqual({ exclusiveMinimum: { exclusiveMinimumValue: 5, currentValue: 3 } });
-      expect(JsonValidators.exclusiveMinimum(5)(ctrl(10), true)).toBeNull();
+      expect(JsonValidators.exclusiveMinimum(5)(ctrl(10), true))
+        .toEqual({ exclusiveMinimum: { exclusiveMinimumValue: 5, currentValue: 10 } });
+      expect(JsonValidators.exclusiveMinimum(5)(ctrl(3), true)).toBeNull();
     });
   });
 
@@ -654,10 +652,8 @@ describe('JsonValidators', () => {
         .toEqual({ maxProperties: { maximumProperties: 2, currentProperties: 3 } });
     });
 
-    it('throws on a null value because there is no empty guard', () => {
-      const validator = JsonValidators.maxProperties(2);
-
-      expect(() => validator(ctrl(null))).toThrow();
+    it('passes a null value through untested', () => {
+      expect(JsonValidators.maxProperties(2)(ctrl(null))).toBeNull();
     });
 
     it('counts string indices when given a string value', () => {
@@ -838,11 +834,11 @@ describe('JsonValidators', () => {
       expect(JsonValidators.uniqueItems()(ctrl(['a', 'a', 'a']))).toBeNull();
     });
 
-    it('throws on a non-array value', () => {
+    it('passes non-array values through untested', () => {
       const validator = JsonValidators.uniqueItems();
 
-      expect(() => validator(ctrl('abc'))).toThrow();
-      expect(() => validator(ctrl({ a: 1 }))).toThrow();
+      expect(validator(ctrl('abc'))).toBeNull();
+      expect(validator(ctrl({ a: 1 }))).toBeNull();
     });
 
     it('reports an empty duplicate list when inverted', () => {
@@ -903,11 +899,13 @@ describe('JsonValidators', () => {
       });
     });
 
-    it('counts undefined entries as passing validators', () => {
-      // The valid count uses validators.length, not the filtered length.
+    it('ignores undefined entries rather than counting them as passing validators', () => {
       const validator = JsonValidators.composeAnyOf([JsonValidators.minLength(5), null]);
 
-      expect(validator(ctrl('abc'))).toBeNull();
+      expect(validator(ctrl('abc'))).toEqual({
+        minLength: { minimumLength: 5, currentLength: 3 },
+        anyOf: true
+      });
     });
 
     it('reports anyOf false when inverted', () => {
@@ -946,6 +944,15 @@ describe('JsonValidators', () => {
       expect(validator(ctrl('abc'))).toEqual({
         minLength: { minimumLength: 5, currentLength: 3 },
         maxLength: { maximumLength: 2, currentLength: 3 },
+        oneOf: true
+      });
+    });
+
+    it('ignores undefined entries rather than counting them as valid', () => {
+      const validator = JsonValidators.composeOneOf([JsonValidators.minLength(5), null]);
+
+      expect(validator(ctrl('abc'))).toEqual({
+        minLength: { minimumLength: 5, currentLength: 3 },
         oneOf: true
       });
     });
@@ -1080,13 +1087,17 @@ describe('JsonValidators', () => {
       expect(JsonValidators.composeAsync([null])).toBeNull();
     });
 
-    it('builds a combined async validator without throwing', () => {
+    it('builds a combined async validator that returns an observable of the merged errors', () => {
       const asyncValidator: any = () => of(null);
       const validator = JsonValidators.composeAsync([asyncValidator]);
 
       expect(typeof validator).toEqual('function');
-      expect(() => validator(ctrl('abc'))).not.toThrow();
-      expect(validator(ctrl('abc'))).toBeDefined();
+      const result: any = validator(ctrl('abc'));
+      expect(result instanceof Observable).toBe(true);
+
+      let emitted: any = 'not emitted';
+      result.subscribe(value => emitted = value);
+      expect(emitted).toBeNull();
     });
   });
 
@@ -1155,9 +1166,9 @@ describe('JsonValidators', () => {
       expect(JsonValidators.requiredTrue(ctrl(null))).toEqual({ required: true });
     });
 
-    it('returns the no-op validator function when given no control', () => {
-      expect(typeof JsonValidators.requiredTrue(null)).toEqual('function');
-      expect(typeof JsonValidators.requiredTrue(undefined)).toEqual('function');
+    it('returns no error when given no control', () => {
+      expect(JsonValidators.requiredTrue(null)).toBeNull();
+      expect(JsonValidators.requiredTrue(undefined)).toBeNull();
     });
   });
 
@@ -1172,9 +1183,9 @@ describe('JsonValidators', () => {
       expect(JsonValidators.email(ctrl(null))).toEqual({ email: true });
     });
 
-    it('returns the no-op validator function when given no control', () => {
-      expect(typeof JsonValidators.email(null)).toEqual('function');
-      expect(typeof JsonValidators.email(undefined)).toEqual('function');
+    it('returns no error when given no control', () => {
+      expect(JsonValidators.email(null)).toBeNull();
+      expect(JsonValidators.email(undefined)).toBeNull();
     });
   });
 });

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -384,7 +384,7 @@ export class JsonValidators {
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value)) { return null; }
       const currentValue = control.value;
-      const isValid = !isNumber(currentValue) || currentValue >= minimumValue;
+      const isValid = !isNumber(currentValue) || +currentValue >= minimumValue;
       return xor(isValid, invert) ?
         null : { 'minimum': { minimumValue, currentValue } };
     };
@@ -393,13 +393,13 @@ export class JsonValidators {
   /**
    * 'exclusiveMinimum' validator
    *
-   * Requires a control's numeric value to be less than a maximum amount.
+   * Requires a control's numeric value to be greater than a minimum amount.
    *
    * Any non-numeric value is also valid (according to the HTML forms spec,
-   * a non-numeric value doesn't have a maximum).
+   * a non-numeric value doesn't have a minimum).
    * https://www.w3.org/TR/html5/forms.html#attr-input-max
    *
-   * // {number} exclusiveMinimumValue - maximum allowed value
+   * // {number} exclusiveMinimumValue - minimum allowed value
    * // {IValidatorFn}
    */
   static exclusiveMinimum(exclusiveMinimumValue: number): IValidatorFn {
@@ -407,7 +407,7 @@ export class JsonValidators {
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value)) { return null; }
       const currentValue = control.value;
-      const isValid = !isNumber(currentValue) || +currentValue < exclusiveMinimumValue;
+      const isValid = !isNumber(currentValue) || +currentValue > exclusiveMinimumValue;
       return xor(isValid, invert) ?
         null : { 'exclusiveMinimum': { exclusiveMinimumValue, currentValue } };
     };
@@ -516,6 +516,7 @@ export class JsonValidators {
   static maxProperties(maximumProperties: number): IValidatorFn {
     if (!hasValue(maximumProperties)) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
+      if (isEmpty(control.value)) { return null; }
       const currentProperties = Object.keys(control.value).length || 0;
       const isValid = currentProperties <= maximumProperties;
       return xor(isValid, invert) ?
@@ -637,7 +638,7 @@ export class JsonValidators {
   static uniqueItems(unique = true): IValidatorFn {
     if (!unique) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
-      if (isEmpty(control.value)) { return null; }
+      if (isEmpty(control.value) || !isArray(control.value)) { return null; }
       const sorted: any[] = control.value.slice().sort();
       const duplicateItems = [];
       for (let i = 1; i < sorted.length; i++) {
@@ -709,7 +710,7 @@ export class JsonValidators {
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       const arrayOfErrors =
         _executeValidators(control, presentValidators, invert).filter(isDefined);
-      const isValid = validators.length > arrayOfErrors.length;
+      const isValid = presentValidators.length > arrayOfErrors.length;
       return xor(isValid, invert) ?
         null : _mergeObjects(...arrayOfErrors, { 'anyOf': !invert });
     };
@@ -734,7 +735,7 @@ export class JsonValidators {
       const arrayOfErrors =
         _executeValidators(control, presentValidators);
       const validControls =
-        validators.length - arrayOfErrors.filter(isDefined).length;
+        presentValidators.length - arrayOfErrors.filter(isDefined).length;
       const isValid = validControls === 1;
       if (xor(isValid, invert)) { return null; }
       const arrayOfValids =
@@ -818,7 +819,7 @@ export class JsonValidators {
     return (control: AbstractControl) => {
       const observables =
         _executeAsyncValidators(control, presentValidators).map(toObservable);
-      return map.call(forkJoin(observables), _mergeErrors);
+      return forkJoin(observables).pipe(map(_mergeErrors));
     };
   }
 
@@ -861,7 +862,7 @@ export class JsonValidators {
    * Validator that requires control value to be true.
    */
   static requiredTrue(control: AbstractControl): ValidationErrors|null {
-    if (!control) { return JsonValidators.nullValidator; }
+    if (!control) { return null; }
     return control.value === true ? null : { 'required': true };
   }
 
@@ -869,7 +870,7 @@ export class JsonValidators {
    * Validator that performs email validation.
    */
   static email(control: AbstractControl): ValidationErrors|null {
-    if (!control) { return JsonValidators.nullValidator; }
+    if (!control) { return null; }
     const EMAIL_REGEXP =
       // tslint:disable-next-line:max-line-length
       /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.0.0",
+    "@ajsf/core": "^17.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fourteen defects, each confirmed beforehand by executing the real code, each with a test that pinned the old behaviour and now describes the new one. Releases `17.1.0`.

**Most visible: `multipleOf`.** Its decimal branch tested `(1 / value) % 10 === 0`, true for far more than powers of ten. All seven locales carried it:

| input | before | after |
| --- | --- | --- |
| `0.05` | `Must have 1.3010299956639813 or fewer decimal places.` | `Must be a multiple of 0.05.` |
| `0.00001` | `Must be a multiple of 0.00001.` | `Must have 5 or fewer decimal places.` |
| `-0.1` | `Must have NaN or fewer decimal places.` | `Must be a multiple of -0.1.` |
| `Infinity` | `Must have -Infinity or fewer decimal places.` | `Must be a multiple of Infinity.` |

**Also:** the `color` regex carried `/g`, so a valid colour flickered invalid on every second check; `maxProperties` and `uniqueItems` threw on null and non-arrays; `composeAsync` returned an operator instead of an Observable on rxjs 7, so it could not attach to a form at all; `composeAnyOf`/`composeOneOf` counted nulls as passes; `exclusiveMinimum` was an exclusive maximum; 7 locale strings, including a French `maxItems` interpolating the minimum.

⚠️ **`exclusiveMinimum` is a behaviour change** for direct callers: values below the bound now fail. Unreachable from the schema pipeline, so no schema-built form changes.

**Not fixed here:** `uniqueItems` duplicate detection. It never reports duplicates, and switching it on makes passing forms fail. Ships separately.

**Verification:** 2340 specs green. All 320 corpus cases match with **no baseline change**, which is the evidence none of this alters rendering.