### PR TITLE
fix(core): make the dependencies validator work

### DIFF
--- a/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
@@ -684,69 +684,86 @@ describe('JsonValidators', () => {
       expect(validator(ctrl(null))).toBeNull();
     });
 
-    it('reports a missing property dependency under a doubly nested key', () => {
+    it('reports a missing property dependency under the requiring field', () => {
       const validator = JsonValidators.dependencies({ credit_card: ['billing_address'] });
 
       expect(validator(ctrl({ credit_card: '1234' }))).toEqual({
-        credit_card: { credit_card: { billing_address: { required: true } } }
+        credit_card: { billing_address: { required: true } }
       });
     });
 
-    it('still returns a non-null object when the dependency is satisfied', () => {
+    it('returns null when the dependency is satisfied', () => {
       const validator = JsonValidators.dependencies({ credit_card: ['billing_address'] });
 
       expect(validator(ctrl({ credit_card: '1234', billing_address: '1 Main St' })))
-        .toEqual({ credit_card: null });
+        .toBeNull();
     });
 
-    it('still returns a non-null object when the requiring field is absent', () => {
+    it('returns null when the requiring field is absent', () => {
       const validator = JsonValidators.dependencies({ credit_card: ['billing_address'] });
 
-      expect(validator(ctrl({ other: 'x' }))).toEqual({ credit_card: null });
+      expect(validator(ctrl({ other: 'x' }))).toBeNull();
     });
 
-    it('walks the schema form with required and properties keys', () => {
+    it('merges required and properties errors under one requiring field', () => {
       const validator = JsonValidators.dependencies({
         credit_card: {
           required: ['billing_address'],
-          properties: { billing_address: { minLength: 5 } }
+          properties: { holder: { minLength: 5 } }
         }
       });
-      const result = validator(ctrl({ credit_card: '1234', billing_address: 'abc' }));
 
-      expect(result).not.toBeNull();
-      expect(result.credit_card).toBeDefined();
+      expect(validator(ctrl({ credit_card: '1234', holder: 'abc' }))).toEqual({
+        credit_card: {
+          billing_address: { required: true },
+          holder: { minLength: { minimumLength: 5, currentLength: 3 } }
+        }
+      });
     });
 
-    it('runs a named validator when a property requirement value is a validator name', () => {
-      // forEachCopy yields (value, key), so the requirement is taken from the
-      // value and the parameter from the key.
+    it('applies a schema dependency keyword to the named property', () => {
       const validator = JsonValidators.dependencies({
-        credit_card: {
-          properties: { billing_address: { 5: 'minLength' } }
-        }
+        credit_card: { properties: { billing_address: { minLength: 5 } } }
       });
-      const result = validator(ctrl({ credit_card: '1234', billing_address: 'abc' }));
 
-      expect(result).not.toBeNull();
+      expect(validator(ctrl({ credit_card: '1234', billing_address: 'abc' }))).toEqual({
+        credit_card: { billing_address: { minLength: { minimumLength: 5, currentLength: 3 } } }
+      });
+      expect(validator(ctrl({ credit_card: '1234', billing_address: '1 Main St' })))
+        .toBeNull();
     });
 
-    it('runs the maximum and minimum requirement branch', () => {
+    it('treats a boolean exclusiveMaximum as the draft 4 modifier of maximum', () => {
       const validator = JsonValidators.dependencies({
         credit_card: {
-          properties: { billing_address: { 10: 'maximum', exclusiveMaximum: true } }
+          properties: { amount: { maximum: 10, exclusiveMaximum: true } }
         }
       });
 
-      expect(() => validator(ctrl({ credit_card: '1234', billing_address: 5 }))).not.toThrow();
-      expect(validator(ctrl({ credit_card: '1234', billing_address: 5 }))).not.toBeNull();
+      // The bound is exclusive, so 10 fails and 9 passes. The boolean itself is
+      // not validated against, which would compare the value to `true`.
+      expect(validator(ctrl({ credit_card: '1234', amount: 10 }))).toEqual({
+        credit_card: { amount: { exclusiveMaximum: { exclusiveMaximumValue: 10, currentValue: 10 } } }
+      });
+      expect(validator(ctrl({ credit_card: '1234', amount: 9 }))).toBeNull();
+    });
+
+    it('applies a numeric exclusiveMaximum as its own draft 6 keyword', () => {
+      const validator = JsonValidators.dependencies({
+        credit_card: { properties: { amount: { exclusiveMaximum: 5 } } }
+      });
+
+      expect(validator(ctrl({ credit_card: '1234', amount: 9 }))).toEqual({
+        credit_card: { amount: { exclusiveMaximum: { exclusiveMaximumValue: 5, currentValue: 9 } } }
+      });
+      expect(validator(ctrl({ credit_card: '1234', amount: 1 }))).toBeNull();
     });
 
     it('does not throw when inverted', () => {
       const validator = JsonValidators.dependencies({ credit_card: ['billing_address'] });
 
       expect(() => validator(ctrl({ credit_card: '1234' }), true)).not.toThrow();
-      expect(validator(ctrl({ credit_card: '1234' }), true)).toEqual({ credit_card: null });
+      expect(validator(ctrl({ credit_card: '1234' }), true)).toBeNull();
     });
   });
 

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -27,6 +27,21 @@ import { JsonSchemaFormatNames, jsonSchemaFormatTests } from './format-regex.con
 import { map } from 'rxjs/operators';
 
 
+/**
+ * Drops keys whose value is null or undefined.
+ *
+ * forEachCopy keeps a key for every entry it visits, including the ones whose
+ * callback returned null, and isEmpty() only asks whether an object has keys.
+ * Without this, a dependency that is satisfied still contributes
+ * `{ theField: null }`, isEmpty reports false, and the validator returns an
+ * error object for a form that is correct.
+ */
+function withoutNullValues(object: any): any {
+  if (!object) { return { }; }
+  return Object.keys(object)
+    .filter(key => isDefined(object[key]))
+    .reduce((kept, key) => { kept[key] = object[key]; return kept; }, { });
+}
 
 /**
  * 'JsonValidators' class
@@ -564,29 +579,52 @@ export class JsonValidators {
 
           // Validate schema dependencies
           requiringFieldErrors = _mergeObjects(requiringFieldErrors,
-            forEachCopy(properties, (requirements, requiredField) => {
-              const requiredFieldErrors = _mergeObjects(
-                forEachCopy(requirements, (requirement, parameter) => {
+            withoutNullValues(forEachCopy(properties, (requirements, requiredField) => {
+              // forEachCopy calls back with (value, key), so the keyword name is
+              // the second argument and its argument is the first.
+              // The values are merged rather than the object itself, because a
+              // validator already returns an object keyed by its own error name
+              // and forEachCopy would file that under the same key again.
+              const requiredFieldErrors = withoutNullValues(_mergeObjects(
+                ...Object.values(forEachCopy(requirements, (parameter, requirement) => {
                   let validator: IValidatorFn = null;
+                  // A boolean exclusiveMaximum or exclusiveMinimum is the draft 4
+                  // modifier of maximum/minimum, not a bound of its own, and the
+                  // branch below consumes it. Treating it as a keyword would
+                  // validate against the bound `true`.
+                  if ((requirement === 'exclusiveMaximum' || requirement === 'exclusiveMinimum') &&
+                    isBoolean(parameter, 'strict')
+                  ) {
+                    return null;
+                  }
                   if (requirement === 'maximum' || requirement === 'minimum') {
-                    const exclusive = !!requirements['exclusiveM' + requirement.slice(1)];
-                    validator = JsonValidators[requirement](parameter, exclusive);
+                    // Draft 4 wrote an exclusive bound as a boolean beside the
+                    // bound itself, so that form picks the exclusive validator.
+                    // The previous code passed the flag as a second argument,
+                    // which neither validator accepts, so it did nothing.
+                    // Draft 6 writes exclusiveMaximum as a number, and that is
+                    // already handled as its own keyword by the branch below.
+                    const exclusiveName = 'exclusiveM' + requirement.slice(1);
+                    const exclusive = requirements[exclusiveName] === true;
+                    validator = JsonValidators[exclusive ? exclusiveName : requirement](parameter);
                   } else if (typeof JsonValidators[requirement] === 'function') {
                     validator = JsonValidators[requirement](parameter);
                   }
-                  return !isDefined(validator) ?
-                    null : validator(control.value[requiredField]);
-                })
-              );
-              return isEmpty(requiredFieldErrors) ?
-                null : { [requiredField]: requiredFieldErrors };
-            })
+                  // Validators read .value, so the raw value has to be wrapped.
+                  return !isDefined(validator) ? null :
+                    validator({ value: control.value[requiredField] } as AbstractControl);
+                }) || { })
+              ));
+              // forEachCopy already files this under requiredField, so returning
+              // { [requiredField]: ... } here would nest the key inside itself.
+              return isEmpty(requiredFieldErrors) ? null : requiredFieldErrors;
+            }))
           );
-          return isEmpty(requiringFieldErrors) ?
-            null : { [requiringField]: requiringFieldErrors };
+          return isEmpty(requiringFieldErrors) ? null : requiringFieldErrors;
         })
       );
-      return isEmpty(allErrors) ? null : allErrors;
+      const realErrors = withoutNullValues(allErrors);
+      return isEmpty(realErrors) ? null : realErrors;
     };
   }
 


### PR DESCRIPTION
## Summary

Repairs the `dependencies` validator, which made any form using that JSON Schema keyword impossible to validate.

## Changes

A satisfied dependency returned an error object rather than null, because `forEachCopy` keeps a key for every entry it visits and the emptiness check only asks whether an object has keys. A form that never touched the dependent field was invalid for the same reason, and a violated dependency reported its error nested twice.

Schema style dependencies never ran. The callback named its parameters in the opposite order to the one `forEachCopy` supplies, so the validator name was read from the value. Correcting that revealed an exclusive flag passed as a second argument neither bound validator accepts, so exclusive bounds were silently inclusive.

## Compatibility

Schema style dependencies now enforce their constraints, so a schema using them begins rejecting values it previously accepted.

## Release impact

No version change. This ships in the next major, where the version signals the behaviour change.

## Validation

All four suites passed, 2,340 specs in total. All 320 corpus cases matched the baseline, though that baseline records rendered control counts rather than validity.