### PR TITLE
fix(core): stop mergeSchemas producing schemas ajv rejects

### DIFF
--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
@@ -79,16 +79,16 @@ describe('mergeSchemas', () => {
   });
 
   describe('allOf', () => {
-    it('merges the contents of both allOf arrays into a single object', () => {
-      // BUG: the merged result is assigned to allOf directly, so allOf ends up
-      // holding an object instead of an array of schemas.
+    it('concatenates both allOf arrays, keeping allOf an array', () => {
       expect(mergeSchemas({ allOf: [{ minimum: 1 }] }, { allOf: [{ maximum: 9 }] }))
-        .toEqual({ allOf: { minimum: 1, maximum: 9 } });
+        .toEqual({ allOf: [{ minimum: 1 }, { maximum: 9 }] });
     });
 
-    it('nests an allOf object when the allOf contents cannot be merged', () => {
+    it('keeps mutually exclusive members side by side rather than merging them', () => {
+      // Each member of allOf must validate on its own, so contradictory members
+      // stay separate and the data simply fails both.
       expect(mergeSchemas({ allOf: [{ type: 'string' }] }, { allOf: [{ type: 'number' }] }))
-        .toEqual({ allOf: { allOf: [{ type: 'string' }, { type: 'number' }] } });
+        .toEqual({ allOf: [{ type: 'string' }, { type: 'number' }] });
     });
 
     it('returns allOf of the whole schemas when one allOf value is not an array', () => {
@@ -224,13 +224,11 @@ describe('mergeSchemas', () => {
       )).toEqual({ dependencies: { a: { type: 'object', minProperties: 1 } } });
     });
 
-    it('nests the array inside required when converting an array dependency to an object', () => {
-      // BUG: uniqueItems() is called with the dependency array as a single
-      // argument instead of spread, so required holds an array of arrays.
+    it('flattens the array into required when converting an array dependency to an object', () => {
       expect(mergeSchemas(
         { dependencies: { a: ['x'] } },
         { dependencies: { a: { type: 'object' } } }
-      )).toEqual({ dependencies: { a: { required: [['x']], type: 'object' } } });
+      )).toEqual({ dependencies: { a: { required: ['x'], type: 'object' } } });
     });
 
     it('seeds the converted dependency with the already combined required array', () => {
@@ -239,7 +237,7 @@ describe('mergeSchemas', () => {
         { dependencies: { a: { type: 'object' } } }
       )).toEqual({
         required: ['r'],
-        dependencies: { a: { required: ['r', ['x']], type: 'object' } },
+        dependencies: { a: { required: ['r', 'x'], type: 'object' } },
       });
     });
 

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -37,9 +37,14 @@ export function mergeSchemas(...schemas) {
       } else {
         switch (key) {
           case 'allOf':
-            // Combine all items from both arrays
+            // Combine all items from both arrays.
+            // The result has to stay an array: allOf holds a list of schemas
+            // that must all validate. Merging them into one object made
+            // ajv.compile throw "schema is invalid: data/allOf should be array"
+            // from compileAjvSchema, which does not catch, so the form never
+            // rendered.
             if (isArray(combinedValue) && isArray(schemaValue)) {
-              combinedSchema.allOf = mergeSchemas(...combinedValue, ...schemaValue);
+              combinedSchema.allOf = [ ...combinedValue, ...schemaValue ];
             } else {
               return { allOf: [ ...schemas ] };
             }
@@ -112,14 +117,18 @@ export function mergeSchemas(...schemas) {
                   (isArray(schemaValue[subKey]) || isObject(schemaValue[subKey])) &&
                   (isArray(combinedObject[subKey]) || isObject(combinedObject[subKey]))
                 ) {
-                  // If either key is an array, convert it to an object first
+                  // If either key is an array, convert it to an object first.
+                  // The dependency array is spread, not passed whole: passing it
+                  // as a single argument nested it inside required, producing
+                  // required: [['x']], which ajv rejects with
+                  // "data/dependencies/a/required/0 should be string".
                   const required = isArray(combinedSchema.required) ?
                     combinedSchema.required : [];
                   const combinedDependency = isArray(combinedObject[subKey]) ?
-                    { required: uniqueItems(...required, combinedObject[subKey]) } :
+                    { required: uniqueItems(...required, ...combinedObject[subKey]) } :
                     combinedObject[subKey];
                   const schemaDependency = isArray(schemaValue[subKey]) ?
-                    { required: uniqueItems(...required, schemaValue[subKey]) } :
+                    { required: uniqueItems(...required, ...schemaValue[subKey]) } :
                     schemaValue[subKey];
                   combinedObject[subKey] =
                     mergeSchemas(combinedDependency, schemaDependency);


### PR DESCRIPTION
## Summary

Stops `mergeSchemas` producing schemas that ajv rejects, which prevented the form from rendering at all.

## Changes

The `allOf` case assigned the merged object straight to `allOf`, so combining two schemas that each carried an `allOf` array produced an object where a list was required. Because `allOf` holds schemas that must all validate, the two arrays are now concatenated and the value stays a list. Mutually exclusive members sit side by side rather than collapsing into a contradiction that discards one constraint.

The dependencies case passed a dependency array to `uniqueItems` whole instead of spreading it, so converting an array dependency to an object nested that array inside `required`.

Both outputs were checked against ajv directly. The previous ones throw during compilation, which `compileAjvSchema` does not catch, so the exception reached the component.

## Release impact

No version change. This ships in the next major alongside the other behaviour fixes.

## Validation

All four suites passed, 2,340 specs in total. All 320 corpus cases matched the baseline. No example schema exercises either path, which is why this went unnoticed.