### PR TITLE
docs: state which JSON Schema drafts are supported

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,39 @@ Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all
 - Plain and direct. Concrete numbers rather than adjectives.
 - Avoid: ensure, leverage, comprehensive, robust, seamless, optimize, overall, ultimately, additionally, furthermore, moreover.
 - State a build or test result only if you ran it. Otherwise say it is unverified.
-- **Keep pull request descriptions under 150 words.** PRs #361 to #369 averaged 314 and were called out as much longer than needed. Three things earn their place: what changed, what was deliberately not done and why, and the verification result. Cut version tables the lockfile already records, prose that restates the diff, and reasoning that belongs in the commit body. A reviewer reads the description to decide where to look, not instead of looking.
+- Pull request descriptions follow a fixed shape. See below.
+
+## Pull request descriptions
+
+Use these four headings, in this order, as plain prose:
+
+```markdown
+## Summary
+
+One or two sentences: what this does, and why it exists.
+
+## Changes
+
+What changed, in paragraphs. Group related edits into one sentence rather
+than listing every file.
+
+## Release impact
+
+Whether this publishes, at what version, and why. Say plainly when there
+is no release.
+
+## Validation
+
+What was run and what it reported. Past tense, concrete numbers.
+```
+
+Add `## Compatibility` when the public API or a consumer visible option is involved.
+
+**Target 100 to 150 words.** PRs #361 to #372 run 96 to 156 after being rewritten by hand; the originals averaged 314 and were called out as much longer than needed.
+
+⚠️ **No tables, no code fences, no warning symbols, no bold mid-sentence.** All twelve rewritten descriptions contain zero of each. Before and after output, version tables and command transcripts belong in the commit body or a review comment, not here.
+
+Third person and declarative: "Removes the deprecated dependency", not "I removed" or "This PR removes". A reviewer reads the description to decide where to look, not instead of looking.
 
 ## Not committed
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,36 @@ No code change is needed. `FlexLayoutRootComponent`, `FlexLayoutSectionComponent
 `fxLayoutGap` all behave as before. The version jump is the Angular-aligned scheme
 starting, not a rewrite: `14.0.0` targets the same Angular 14 that `0.8.0` did.
 
+## JSON Schema versions
+
+Your existing schemas keep working. AJSF stays backward compatible with the older drafts,
+and nothing you have today needs changing.
+
+| Draft | Status |
+| --- | --- |
+| Draft 1, 2, 3, 4 | Supported, converted to draft 6 internally |
+| Draft 6 | Supported directly |
+| Draft 7 | Supported, including `if`, `then` and `else` |
+| 2019-09, 2020-12 | Not supported yet |
+
+Older drafts pass through `convertSchemaToDraft6` before the form is built. Keywords it
+does not recognise are carried through untouched rather than dropped, which is why draft 7
+schemas validate correctly.
+
+Two limits are worth knowing about before you rely on them.
+
+**Draft 7 conditionals validate, but the layout does not follow them.** `if`, `then` and
+`else` are enforced, so a field that becomes required because of another field's value
+really is required and the form will not submit without it. The layout is built once,
+though, so that field is not marked as required until you try to submit. `readOnly` and
+`writeOnly` are accepted and currently have no effect: they are annotations, and neither
+the validator nor the widgets act on them.
+
+**2020-12 is not supported yet.** A schema declaring
+`"$schema": "https://json-schema.org/draft/2020-12/schema"` fails to compile and the form
+does not render, so it fails loudly rather than quietly. It needs a newer validator, and
+`prefixItems` replaces the array form of `items`, which is how AJSF recognises tuples.
+
 ## Check out the live demo and play with the examples
 
 [Check out some examples here.](https://hamidihamza.com/ajsf)
@@ -296,7 +326,7 @@ Combining inputs is useful when each form stores its data and schema together. S
 
 #### Compatibility modes
 
-If you have used Angular Schema Form for AngularJS, React JSON Schema Form, or JSON Form for jQuery, Angular JSON Schema Form recognizes their input names and custom input objects. It supports JSON Schema [draft 6](http://json-schema.org/draft-06/schema), [draft 4](http://json-schema.org/draft-04/schema), [draft 3](http://json-schema.org/draft-03/schema), and the [truncated draft 3 format supported by JSON Form](https://github.com/joshfire/jsonform/wiki#schema-shortcut).
+If you have used Angular Schema Form for AngularJS, React JSON Schema Form, or JSON Form for jQuery, Angular JSON Schema Form recognizes their input names and custom input objects. It also accepts the [truncated draft 3 format supported by JSON Form](https://github.com/joshfire/jsonform/wiki#schema-shortcut). See [JSON Schema versions](#json-schema-versions) for the drafts AJSF supports.
 
 Angular Schema Form (AngularJS) compatibility:
 


### PR DESCRIPTION
## Summary

Documents the JSON Schema drafts AJSF supports, and confirms that schemas written for older drafts keep working.

## Changes

A new "JSON Schema versions" section lists drafts 1 through 4, draft 6 and draft 7 as supported, and 2019-09 and 2020-12 as not yet supported. The older claim further down the README, which mentioned only drafts 3, 4 and 6, now points at it.

The section leads with backward compatibility, because that is the question a reader with existing schemas actually has. It also states two limits plainly: draft 7 conditionals are validated but the layout is built once, so a field that becomes required through `if` and `then` is enforced without being shown as required until submit, and `readOnly` and `writeOnly` are accepted but have no effect.

## Release impact

Only documentation changed, so there is no package release.

## Validation

Every claim was checked against the installed ajv 6.12.6. Draft 7 schemas compile and enforce all three conditional branches. A 2020-12 schema fails to compile, so it fails loudly rather than quietly.