### PR TITLE
fix(core): make uniqueItems detect duplicates

### DIFF
--- a/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
@@ -826,12 +826,33 @@ describe('JsonValidators', () => {
       expect(JsonValidators.uniqueItems(true)(ctrl(['a', 'b']))).toBeNull();
     });
 
-    it('also accepts an array containing duplicates', () => {
-      // The duplicate check requires the item to already be in duplicateItems,
-      // which starts empty, so duplicates are never collected.
-      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 2]))).toBeNull();
-      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 1, 1]))).toBeNull();
-      expect(JsonValidators.uniqueItems()(ctrl(['a', 'a', 'a']))).toBeNull();
+    it('rejects an array containing duplicates', () => {
+      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 2])))
+        .toEqual({ uniqueItems: { duplicateItems: [1] } });
+      expect(JsonValidators.uniqueItems()(ctrl(['a', 'a', 'a'])))
+        .toEqual({ uniqueItems: { duplicateItems: ['a'] } });
+    });
+
+    it('reports each duplicated item once, however many times it repeats', () => {
+      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 1, 1])))
+        .toEqual({ uniqueItems: { duplicateItems: [1] } });
+    });
+
+    it('compares items by value, so equal objects and arrays are duplicates', () => {
+      expect(JsonValidators.uniqueItems()(ctrl([{ x: 1 }, { x: 1 }])))
+        .toEqual({ uniqueItems: { duplicateItems: [{ x: 1 }] } });
+      expect(JsonValidators.uniqueItems()(ctrl([[1], [1]])))
+        .toEqual({ uniqueItems: { duplicateItems: [[1]] } });
+    });
+
+    it('finds duplicates that are not next to each other', () => {
+      expect(JsonValidators.uniqueItems()(ctrl([{ x: 1 }, { y: 2 }, { x: 1 }])))
+        .toEqual({ uniqueItems: { duplicateItems: [{ x: 1 }] } });
+    });
+
+    it('treats a number and its string form as different items', () => {
+      // JSON Schema compares by value and type, so 1 and '1' are not duplicates.
+      expect(JsonValidators.uniqueItems()(ctrl([1, '1']))).toBeNull();
     });
 
     it('passes non-array values through untested', () => {
@@ -841,9 +862,8 @@ describe('JsonValidators', () => {
       expect(validator(ctrl({ a: 1 }))).toBeNull();
     });
 
-    it('reports an empty duplicate list when inverted', () => {
-      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 2]), true))
-        .toEqual({ uniqueItems: { duplicateItems: [] } });
+    it('passes a duplicated array when inverted', () => {
+      expect(JsonValidators.uniqueItems()(ctrl([1, 1, 2]), true)).toBeNull();
     });
   });
 

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -639,11 +639,20 @@ export class JsonValidators {
     if (!unique) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value) || !isArray(control.value)) { return null; }
-      const sorted: any[] = control.value.slice().sort();
+      // JSON Schema compares items by value, so two objects that look the same
+      // are duplicates. The previous version sorted the array and compared
+      // adjacent items with ===, which never matches an object, and only pushed
+      // when duplicateItems already contained the item. Since it started empty,
+      // that condition was never true and the validator always passed.
+      const items: any[] = control.value;
       const duplicateItems = [];
-      for (let i = 1; i < sorted.length; i++) {
-        if (sorted[i - 1] === sorted[i] && duplicateItems.includes(sorted[i])) {
-          duplicateItems.push(sorted[i]);
+      for (let i = 0; i < items.length; i++) {
+        for (let j = i + 1; j < items.length; j++) {
+          if (isEqual(items[i], items[j]) &&
+            !duplicateItems.some(duplicate => isEqual(duplicate, items[i]))
+          ) {
+            duplicateItems.push(items[i]);
+          }
         }
       }
       const isValid = !duplicateItems.length;


### PR DESCRIPTION
## Summary

Repairs the `uniqueItems` validator, which never reported a duplicate and so never rejected anything.

## Changes

The duplicate check required the item to be present in the duplicate list already, and that list starts empty, so the condition was false on the first match and nothing was ever recorded. Arrays such as `[1, 1, 2]` and `['a', 'a', 'a']` passed validation.

Negating that condition alone would still have been wrong for objects. The array was sorted with the default comparator, which turns every object into the same string, and adjacent items were compared with strict equality, which is false for two objects that look alike. The scan now compares every pair by value, using the deep equality helper the file already imports. Form arrays are small, so comparing pairs costs little. A number and its string form remain distinct, since JSON Schema compares type as well as value.

## Compatibility

An array containing duplicates validated before and now does not, which is what the keyword is for.

## Release impact

No version change. This ships in the next major alongside the other behaviour fixes.

## Validation

All four suites passed, 2,344 specs in total. All 320 corpus cases matched the baseline.