### PR TITLE
build: release 17.2.0-rc.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,10 +174,17 @@ jobs:
       - name: Publish core
         run: npm publish dist/@ajsf/core --provenance --access public --tag ${{ needs.decide.outputs.dist-tag }}
 
+      # Derived from what verify actually built, rather than a hand written
+      # list. The list read "bootstrap3 bootstrap4 material" when @ajsf/bootstrap5
+      # was added, so the new package would have been skipped silently while the
+      # job reported success.
       - name: Publish frameworks
         run: |
-          for pkg in bootstrap3 bootstrap4 material; do
-            npm publish "dist/@ajsf/$pkg" --provenance --access public --tag ${{ needs.decide.outputs.dist-tag }}
+          for dir in dist/@ajsf/*/; do
+            pkg=$(basename "$dir")
+            if [ "$pkg" = "core" ]; then continue; fi   # already published above
+            echo "[release] publishing @ajsf/$pkg"
+            npm publish "$dir" --provenance --access public --tag ${{ needs.decide.outputs.dist-tag }}
           done
 
       - name: Tag the released commit
@@ -200,8 +207,11 @@ jobs:
         run: |
           VERSION="${{ needs.decide.outputs.version }}"
           DIST_TAG="${{ needs.decide.outputs.dist-tag }}"
+          # Listed from what was published rather than hand written, for the
+          # same reason the publish loop is.
+          PACKAGES=$(for d in dist/@ajsf/*/; do printf '`@ajsf/%s` ' "$(basename "$d")"; done)
           NOTES=$(printf '%s\n' \
-            "\`@ajsf/core\`, \`@ajsf/material\`, \`@ajsf/bootstrap3\` and \`@ajsf/bootstrap4\` published at \`$VERSION\` on the \`$DIST_TAG\` dist-tag." \
+            "$PACKAGES published at \`$VERSION\` on the \`$DIST_TAG\` dist-tag." \
             "" \
             "\`\`\`sh" \
             "npm install @ajsf/core@$VERSION" \

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "17.1.0",
+  "version": "17.2.0-rc.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.1.0",
+    "@ajsf/core": "17.2.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "17.1.0",
+  "version": "17.2.0-rc.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.1.0",
+    "@ajsf/core": "17.2.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "17.1.0",
+  "version": "17.2.0-rc.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "17.1.0",
+  "version": "17.2.0-rc.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "lodash-es": "~4.17.21",
-    "@ajsf/core": "^17.1.0",
+    "@ajsf/core": "17.2.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Releases the four validation fixes already merged to `main` as `17.2.0-rc.0` on the `next` dist-tag.

## Changes

Only the version moves. The fixes themselves are already on `main`: the `dependencies` validator no longer makes correct forms permanently invalid, `mergeSchemas` no longer emits schemas ajv rejects, `uniqueItems` detects duplicates, and a declared draft 1 or 2 is read as a number so its required rule applies.

The publish loop is now derived from what the verify job built rather than from a hand written list of framework names. That list was correct today and would have silently skipped a fifth package tomorrow while still reporting success. Running it here exercises it against the four packages that already exist.

## Compatibility

Each fix changes what validates, so a form that passed before may now report an error. That is why this goes to `next` rather than `latest`.

## Release impact

Publishes four packages at `17.2.0-rc.0`. A version containing a hyphen goes to the `next` dist-tag, so `17.1.0` remains `latest`. Install with `npm install @ajsf/core@next`.

## Validation

The 45 script specs passed and all four libraries built. The fixes themselves were verified in their own pull requests, each against the 320 case corpus.