### PR TITLE
refactor: keep comments focused and document the roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,19 @@ Add `## Compatibility` when the public API or a consumer visible option is invol
 
 Third person and declarative: "Removes the deprecated dependency", not "I removed" or "This PR removes". A reviewer reads the description to decide where to look, not instead of looking.
 
+## Code comments
+
+The default is no comment. Add one only for information the code cannot express: an invariant that is not obvious, an external contract, a compatibility constraint or an intentional limitation.
+
+Before keeping a comment, all four statements must be true:
+
+1. A clearer name, type, helper or test cannot replace it.
+2. It explains why the code has to work this way. It does not narrate the next line.
+3. It describes the current code without relying on the pull request or its history.
+4. It fits in one short sentence. If it needs a paragraph, simplify the code or move the context to the commit body or documentation.
+
+Delete comments about previous implementations, fixed bugs, debugging history, test results, line percentages and facts visible in the code. Keep public API documentation and short warnings whose removal could lead to a correctness bug.
+
 ## Not committed
 
 `docs/superpowers/` holds generated design and planning documents. It is gitignored on purpose. Do not add it.

--- a/docs/json-schema-drafts.md
+++ b/docs/json-schema-drafts.md
@@ -1,0 +1,106 @@
+# Supporting more JSON Schema drafts
+
+Design note. Not implemented. Written after the Angular 17 release, while
+deciding how to reach 2020-12 support.
+
+## Where we are
+
+Every incoming schema goes through `convertSchemaToDraft6` once, in
+`json-schema-form.component.ts:492`, and the result replaces `jsf.schema`. That
+single function currently does three unrelated jobs.
+
+**It detects the draft.** From `$schema` when present, otherwise by sniffing for
+legacy keywords.
+
+**It downconverts for the validator.** Drafts 1 through 4 become draft 6, which
+ajv 6.12.6 then validates.
+
+**It normalises for the form builder.** The builder reads the converted schema,
+not the original, and depends on the shapes conversion produces. For example
+`form-group.functions.ts:377` treats `required` as an array, which is only true
+after a draft 3 boolean `required` has been rewritten.
+
+Two consequences follow.
+
+Draft 7 already validates correctly, because the converter passes keywords it
+does not recognise through untouched and ajv 6 supports draft 7 natively. The
+README claimed drafts 3, 4 and 6 for years while draft 7 worked.
+
+2020-12 fails at compile with `no schema with key or ref
+https://json-schema.org/draft/2020-12/schema`. The form does not render.
+
+## The proposal
+
+Split the three jobs.
+
+**A validation engine per draft, chosen by `$schema`.** This is the part that
+makes new drafts cheap: adding one becomes adding an engine rather than
+extending a converter. It needs ajv 8, whose 2019-09 and 2020-12 support lives
+behind separate entry points (`ajv/dist/2019`, `ajv/dist/2020`), with
+`ajv-draft-04` for draft 4. Schemas validate against the spec they declare, so
+`unevaluatedProperties` and `$dynamicRef` work rather than being ignored.
+
+**A layout normaliser, kept and renamed.** The builder still needs one internal
+shape. This is the smaller honest job the current converter is half doing, and
+it is where `prefixItems` would be mapped onto whatever the builder uses for
+tuples.
+
+**Draft detection as its own function**, so the rule is stated once.
+
+## Why this is not just an ajv upgrade
+
+Validation is the easy half. The builder references `if`, `then`, `else`,
+`prefixItems`, `dependentRequired` and `unevaluatedProperties` exactly zero
+times today. Two consequences that no engine change fixes:
+
+A draft 7 `if` / `then` schema validates correctly now, and the layout still
+does not mark the conditionally required field as required, because layout is
+built once. The form refuses to submit and the user cannot see why.
+
+2020-12 replaces the array form of `items` with `prefixItems`. Tuple detection
+keys off `items` being an array (`layout.functions.ts:300`), so a 2020-12 tuple
+would produce a wrong layout rather than an error. Silent, which is worse.
+
+## The default draft
+
+When `$schema` is absent the converter infers a draft from which legacy keywords
+it finds. Measured:
+
+    no $schema, modern schema        untouched, correct
+    no $schema, one optional: true   infers draft 2, every other property becomes required
+    no $schema, required: true       infers draft 3
+
+The middle case is the problem. One `optional: true` anywhere makes every other
+property required, and nothing in the schema asked for that.
+
+Replace sniffing with a `defaultDraft` option, defaulting to the newest draft
+supported. `$schema` always wins when present. Sniffing then either goes, or
+survives only behind an explicit opt in for consumers who rely on it today.
+
+This matches how JSON Schema itself reads an absent `$schema`: the newest
+version the tool supports, not a guess from the contents.
+
+## Order
+
+1. Angular 18. Mechanical, and the corpus covers it well.
+2. The three way split, with no behaviour change. Tests first.
+3. `defaultDraft`, replacing sniffing. Breaking for anyone relying on the
+   inference, so it ships at a major.
+4. ajv 8 and the engine registry, still only drafts 4 through 7.
+5. 2019-09 and 2020-12 engines, plus the layout work for `prefixItems`.
+6. Conditional layout for `if` / `then` / `else`, which is the largest item and
+   worth its own design note.
+
+Steps 3 onwards change what validates. The package major is pinned to the
+Angular major, so a breaking change can only ship at an Angular boundary.
+
+## What the corpus will and will not catch
+
+The 400 case baseline records rendered control counts and thrown errors per
+example schema. It is a strong net for step 2, which should not move a single
+case, and for anything that stops a form rendering.
+
+It is a weak net for steps 3 onwards, because it records neither validity nor
+which fields are required. A change that makes a schema validate differently is
+largely invisible to it. Those steps need tests written against validation
+results directly, not against rendering.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,169 @@
+# Roadmap
+
+Written after `17.2.0-rc.1`. Everything here was found while walking Angular 14
+to 17 and is recorded so it does not have to be rediscovered. Items are ordered
+by what they cost a user, not by how interesting they are.
+
+Related: [JSON Schema drafts](./json-schema-drafts.md) has the detail for the
+draft work summarised below.
+
+## Now
+
+### Finish the Angular walk: 18, 19, 20, 21, 22
+
+Five majors. The corpus covers this well (control counts move when rendering
+breaks), so it is the safest large change available.
+
+Known ahead of time: Angular 18 raises the Node floor above the current
+`.nvmrc` of 18.17.1, and `version:set` already syncs `engines` from the
+installed CLI. Vitest arrives at 20, where Angular ships its own builder, and
+the decision was to switch there rather than at 18, since before 20 it means
+migrating twice.
+
+`18.0.0` is also where the four merged validation fixes reach `latest`.
+
+### Deprecate the Bootstrap 5 placeholder
+
+`@ajsf/bootstrap5` has `latest` on the empty `0.0.0` stub, because npm claims
+`latest` on a first publish whatever `--tag` says. `npm install @ajsf/bootstrap5`
+returns an empty package until a stable release moves it.
+
+    npm deprecate "@ajsf/bootstrap5@0.0.0" "Placeholder only, not a usable release."
+
+### Raise the Codecov project target
+
+`codecov.yml` has `project: auto` because coverage was 56 percent when it was
+written. It is 87 percent now, so the target can become a real number without
+failing anything.
+
+## Security
+
+94 open Dependabot alerts sounds worse than it is, and the split matters:
+
+    72  development scope   never reach a consumer of @ajsf/*
+    22  runtime scope       19 Angular, 3 lodash-es
+
+The 19 Angular alerts are fixed by the walk above, since they are all against
+versions the upgrade replaces. That is the strongest practical argument for
+finishing it.
+
+The 3 `lodash-es` alerts are not reachable. They are `_.template` code
+injection and prototype pollution in `_.unset` and array paths. The library
+imports only `cloneDeep`, `filter`, `isEqual`, `map` and `uniqueId`. Worth
+confirming again after any lodash upgrade rather than assuming.
+
+The 72 development alerts are worth one pass to confirm none of them affect the
+published artifacts, then triaging in bulk.
+
+## Correctness
+
+### Group C: the deferred bugs
+
+Four helpers were left alone deliberately during the fix work, because each is
+load bearing. Call sites counted across the four packages:
+
+    isEmpty    47   treats Date, Map, Set and RegExp as empty
+    isNumber   21   global isNaN, so null, '', true and [] are all numbers
+    hasOwn    134   returns the element rather than a boolean for a numeric key
+    getType    21   getType('') is 'integer', falls out of isNumber
+
+`isEmpty` is the one to schedule first. Roughly fifteen of its call sites are
+the `if (isEmpty(control.value)) { return null; }` guard at the top of a
+validator, so a Date valued or Map valued control bypasses validation
+completely today. Fixing it turns those guards back on, which is the point and
+also why it cannot land during an upgrade.
+
+`isNumber` cascades into `getType`, `isPrimitive`, `toJavaScriptType` and
+`merge-schemas`. Fixing it makes `type('number')` stop accepting `true`. Wide,
+and no user has asked for it.
+
+`hasOwn` at 134 call sites is the largest blast radius in the library for the
+smallest visible payoff. Revisit alone, after the walk, with a full corpus run.
+
+### Bugs frozen into the corpus baseline
+
+Six of the 400 baseline entries record a thrown error as expected behaviour,
+including `value.forEach is not a function` on `jsf-fields-checkboxbuttons` and
+`Cannot set properties of undefined` on `ng-jsf-layout-only`. They are real
+bugs pinned so that a regression is visible. Anyone fixing one must update the
+baseline in the same commit, and should not read a red corpus as their own
+mistake.
+
+### fxLayout has never worked
+
+`getFlexAttribute('layout')` reads `(a || 'row') + b ? ' ' + b : ''`. `+` binds
+tighter than `?:`, so it always returns `' ' + fxLayoutWrap` and `fxLayout:
+'column'` evaluates to `" undefined"`. Fixing it changes rendering for anyone
+using the option, which is why it was left. It needs its own pull request and a
+corpus run.
+
+## Architecture
+
+### Split convertSchemaToDraft6
+
+It does three jobs: detect the draft, downconvert for the validator, and
+normalise for the form builder. The builder reads the converted schema, so the
+third job is load bearing. Splitting them makes a new draft an added engine
+rather than an extended converter. Detail in
+[JSON Schema drafts](./json-schema-drafts.md).
+
+### A default draft instead of sniffing
+
+With no `$schema` the converter infers a draft from which legacy keywords it
+finds, and a single `optional: true` makes every other property required. A
+`defaultDraft` option replaces the guess.
+
+### ajv 6 to ajv 8
+
+ajv is pinned at 6.12.6 and effectively unmaintained. ajv 8 is also the
+prerequisite for 2019-09 and 2020-12, whose support lives behind separate entry
+points. Worth doing as its own change, separate from the draft work, so a
+failure has one cause.
+
+### Conditional layout
+
+`if`, `then` and `else` validate correctly today and the layout ignores them, so
+a field that becomes required through a condition is enforced without being
+shown as required until submit. The layout is built once. This is the largest
+item on this page and deserves its own design note before any code.
+
+## Size and shape
+
+Five files carry most of the library:
+
+    1068  shared/layout.functions.ts
+    1012  shared/jsonpointer.functions.ts
+     909  shared/json.validators.ts
+     883  json-schema-form.service.ts
+     788  shared/json-schema.functions.ts
+
+They are now covered (87 percent), which makes splitting them safe in a
+way it was not before. Do it opportunistically, when a change already touches
+one, rather than as a project of its own. Splitting a file nobody is editing
+buys nothing and costs review.
+
+## Documentation
+
+The source is bimodal. `shared/` carries prose doc comments on roughly 90
+percent of exported functions, while `widget-library/` has none in 25 of 26
+files, and the two services the README tells users to call, `WidgetLibraryService`
+and `FrameworkLibraryService`, have none at all.
+
+An autogenerated API reference would therefore be rich for internals and empty
+for the public surface, which is backwards. Two cheap fixes first: convert the
+26 trailing comments on the `<json-schema-form>` inputs and outputs to doc
+comments, and generate the widget reference from the `widgetLibrary` map, which
+has 80 entries and 38 explanatory comments already. Compodoc after that, not
+Docusaurus: it reads Angular source directly and adds no second toolchain.
+
+## Testing
+
+The 400 case corpus records two fields per case, `controls` and `error`. It is a
+strong net for anything that changes what renders and a weak one for anything
+that changes what validates. That distinction decides which changes it can
+referee, and it is why the draft work needs tests written against validation
+results directly.
+
+The baseline was recorded in headless Chrome. Moving to Vitest at Angular 20
+means re-recording it, which should be its own commit with the diff read case by
+case, never bundled into another change.

--- a/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
+++ b/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
@@ -28,12 +28,6 @@ export function convertSchemaToDraft6(schema, options: OptionObject = {}) {
   let newSchema = { ...schema };
   const simpleTypes = ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'];
 
-  // The draft number is read through a capture group and converted, rather than
-  // taken as a character. $schema[30] is the right character, but it is a
-  // string, so every later comparison (draft === 1, draft === 2) was false and
-  // the v1 and v2 rules never ran. It also overwrote a correct numeric draft
-  // passed in options, so declaring $schema disabled the conversion it should
-  // have enabled.
   if (typeof newSchema.$schema === 'string') {
     const declaredDraft = /http\:\/\/json\-schema\.org\/draft\-0(\d)\/schema\#/
       .exec(newSchema.$schema);

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -27,15 +27,7 @@ import { JsonSchemaFormatNames, jsonSchemaFormatTests } from './format-regex.con
 import { map } from 'rxjs/operators';
 
 
-/**
- * Drops keys whose value is null or undefined.
- *
- * forEachCopy keeps a key for every entry it visits, including the ones whose
- * callback returned null, and isEmpty() only asks whether an object has keys.
- * Without this, a dependency that is satisfied still contributes
- * `{ theField: null }`, isEmpty reports false, and the validator returns an
- * error object for a form that is correct.
- */
+// forEachCopy retains keys whose callback returns null.
 function withoutNullValues(object: any): any {
   if (!object) { return { }; }
   return Object.keys(object)
@@ -570,53 +562,35 @@ export class JsonValidators {
             properties = dependencies[requiringField]['properties'] || { };
           }
 
-          // Validate property dependencies
           for (const requiredField of requiredFields) {
             if (xor(!hasValue(control.value[requiredField]), invert)) {
               requiringFieldErrors[requiredField] = { 'required': true };
             }
           }
 
-          // Validate schema dependencies
           requiringFieldErrors = _mergeObjects(requiringFieldErrors,
             withoutNullValues(forEachCopy(properties, (requirements, requiredField) => {
-              // forEachCopy calls back with (value, key), so the keyword name is
-              // the second argument and its argument is the first.
-              // The values are merged rather than the object itself, because a
-              // validator already returns an object keyed by its own error name
-              // and forEachCopy would file that under the same key again.
+              // forEachCopy passes (value, key), unlike Array.forEach.
               const requiredFieldErrors = withoutNullValues(_mergeObjects(
                 ...Object.values(forEachCopy(requirements, (parameter, requirement) => {
                   let validator: IValidatorFn = null;
-                  // A boolean exclusiveMaximum or exclusiveMinimum is the draft 4
-                  // modifier of maximum/minimum, not a bound of its own, and the
-                  // branch below consumes it. Treating it as a keyword would
-                  // validate against the bound `true`.
+                  // Draft 4 uses booleans here as modifiers, not bounds.
                   if ((requirement === 'exclusiveMaximum' || requirement === 'exclusiveMinimum') &&
                     isBoolean(parameter, 'strict')
                   ) {
                     return null;
                   }
                   if (requirement === 'maximum' || requirement === 'minimum') {
-                    // Draft 4 wrote an exclusive bound as a boolean beside the
-                    // bound itself, so that form picks the exclusive validator.
-                    // The previous code passed the flag as a second argument,
-                    // which neither validator accepts, so it did nothing.
-                    // Draft 6 writes exclusiveMaximum as a number, and that is
-                    // already handled as its own keyword by the branch below.
                     const exclusiveName = 'exclusiveM' + requirement.slice(1);
                     const exclusive = requirements[exclusiveName] === true;
                     validator = JsonValidators[exclusive ? exclusiveName : requirement](parameter);
                   } else if (typeof JsonValidators[requirement] === 'function') {
                     validator = JsonValidators[requirement](parameter);
                   }
-                  // Validators read .value, so the raw value has to be wrapped.
                   return !isDefined(validator) ? null :
                     validator({ value: control.value[requiredField] } as AbstractControl);
                 }) || { })
               ));
-              // forEachCopy already files this under requiredField, so returning
-              // { [requiredField]: ... } here would nest the key inside itself.
               return isEmpty(requiredFieldErrors) ? null : requiredFieldErrors;
             }))
           );
@@ -677,11 +651,6 @@ export class JsonValidators {
     if (!unique) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value) || !isArray(control.value)) { return null; }
-      // JSON Schema compares items by value, so two objects that look the same
-      // are duplicates. The previous version sorted the array and compared
-      // adjacent items with ===, which never matches an object, and only pushed
-      // when duplicateItems already contained the item. Since it started empty,
-      // that condition was never true and the validator always passed.
       const items: any[] = control.value;
       const duplicateItems = [];
       for (let i = 0; i < items.length; i++) {

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -37,12 +37,6 @@ export function mergeSchemas(...schemas) {
       } else {
         switch (key) {
           case 'allOf':
-            // Combine all items from both arrays.
-            // The result has to stay an array: allOf holds a list of schemas
-            // that must all validate. Merging them into one object made
-            // ajv.compile throw "schema is invalid: data/allOf should be array"
-            // from compileAjvSchema, which does not catch, so the form never
-            // rendered.
             if (isArray(combinedValue) && isArray(schemaValue)) {
               combinedSchema.allOf = [ ...combinedValue, ...schemaValue ];
             } else {
@@ -117,11 +111,6 @@ export function mergeSchemas(...schemas) {
                   (isArray(schemaValue[subKey]) || isObject(schemaValue[subKey])) &&
                   (isArray(combinedObject[subKey]) || isObject(combinedObject[subKey]))
                 ) {
-                  // If either key is an array, convert it to an object first.
-                  // The dependency array is spread, not passed whole: passing it
-                  // as a single argument nested it inside required, producing
-                  // required: [['x']], which ajv rejects with
-                  // "data/dependencies/a/required/0 should be string".
                   const required = isArray(combinedSchema.required) ?
                     combinedSchema.required : [];
                   const combinedDependency = isArray(combinedObject[subKey]) ?


### PR DESCRIPTION
## Summary

Keeps source comments limited to useful context and records follow up work from the Angular 14 to 17 upgrades.

## Changes

Removes comments that repeated visible code or commit history. `AGENTS.md` now defaults to no comment and allows comments only for constraints or contracts that code cannot express.

`docs/json-schema-drafts.md` separates draft detection, validator conversion and form normalization. `docs/roadmap.md` orders the remaining upgrade, security, correctness, architecture, documentation and testing work by user impact.

## Release impact

Code behavior and the public API are unchanged, so there is no package release.

## Validation

