### PR TITLE
fix(core): stop isEmpty reporting Date, Map and Set as empty

### DIFF
--- a/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
@@ -393,11 +393,9 @@ describe('JsonValidators', () => {
       expect(JsonValidators.format('bogus' as any)(ctrl('anything'))).toBeNull();
     });
 
-    it('returns null for a Date value because a Date counts as empty', () => {
-      // Object.keys(new Date()) is [], so isEmpty() short circuits before the
-      // branch that was written to allow Date objects.
+    it('validates a Date value rather than skipping it', () => {
       expect(JsonValidators.format('date')(ctrl(new Date('2020-01-01')))).toBeNull();
-      expect(JsonValidators.format('email')(ctrl(new Date('2020-01-01')))).toBeNull();
+      expect(JsonValidators.format('email')(ctrl(new Date('2020-01-01')))).not.toBeNull();
     });
 
     it('rejects a non-string primitive value', () => {

--- a/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
@@ -491,9 +491,14 @@ describe('JsonPointer', () => {
       expect(JsonPointer.getFirst([[{ a: 1 }]])).toBeUndefined();
     });
 
-    it('should return undefined for a Map because isEmpty treats every Map as empty', () => {
+    it('should read the first value from a Map', () => {
       const items = new Map<any, any>([[{ a: 1 }, '/a']]);
-      expect(JsonPointer.getFirst(items)).toBeUndefined();
+      expect(JsonPointer.getFirst(items)).toEqual(1);
+    });
+
+    it('should return undefined for an empty Map, as it does for an empty array', () => {
+      expect(JsonPointer.getFirst(new Map<any, any>(), 'dv')).toBeUndefined();
+      expect(JsonPointer.getFirst([], 'dv')).toBeUndefined();
     });
 
     it('should return the default value for input that is neither array nor map', () => {

--- a/projects/ajsf-core/src/lib/shared/validator.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/validator.functions.spec.ts
@@ -261,10 +261,15 @@ describe("Validator functions", () => {
       expect(isEmpty(false)).toBe(false);
     });
 
-    // Dates and Maps have no own enumerable keys, so they take the isObject branch
-    it("returns true for a Date and for an empty Map", () => {
-      expect(isEmpty(new Date())).toBe(true);
+    it("treats a Date as a value, never as empty", () => {
+      expect(isEmpty(new Date())).toBe(false);
+    });
+
+    it("measures a Map or Set by size rather than by own keys", () => {
       expect(isEmpty(new Map())).toBe(true);
+      expect(isEmpty(new Map([[1, 2]]))).toBe(false);
+      expect(isEmpty(new Set())).toBe(true);
+      expect(isEmpty(new Set([1]))).toBe(false);
     });
   });
 

--- a/projects/ajsf-core/src/lib/shared/validator.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/validator.functions.ts
@@ -161,6 +161,10 @@ export function hasValue(value) {
  */
 export function isEmpty(value) {
   if (isArray(value)) { return !value.length; }
+  // Object.keys() is [] for these, so the plain object branch would call them
+  // empty even when they hold a value.
+  if (isDate(value)) { return false; }
+  if (isMap(value) || isSet(value)) { return !value.size; }
   if (isObject(value)) { return !Object.keys(value).length; }
   return value === undefined || value === null || value === '';
 }


### PR DESCRIPTION
## Summary

Repairs `isEmpty`, which reported a Date, Map, Set or RegExp as empty because none of them has own enumerable keys.

## Changes

Anything that reached the plain object branch was measured with `Object.keys()`, which is empty for all four. Roughly fifteen validators open with `if (isEmpty(control.value)) { return null; }`, so a control holding a Date skipped validation altogether and `format('email')` accepted one. The Map branch of `JsonPointer.getFirst` was unreachable for the same reason and is now live.

A Date is a value and is never empty. A Map or Set is measured by size, so an empty one still reports empty. Arrays, plain objects, empty strings, null and undefined are unchanged.

## Compatibility

Controls holding a Date, Map or Set are now validated where they were skipped, so a form carrying one may report an error it did not before.

## Release impact

No version change. This ships in the next major alongside the other behaviour fixes.

## Validation

All five suites passed, 2,433 specs. All 400 corpus cases matched, including the validity field, which is the check able to see a change of this kind. Three specs pinned the old behaviour and now describe the new one.