### PR TITLE
fix(core): stop isNumber accepting coerced values, and extend the roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,27 @@ returns an empty package until a stable release moves it.
 
     npm deprecate "@ajsf/bootstrap5@0.0.0" "Placeholder only, not a usable release."
 
+### Fix the lodash dependency, which is currently wrong
+
+All four published packages declare `lodash-es` and import plain `lodash`.
+Source carries 19 `from 'lodash/...'` imports and zero `lodash-es` imports, and
+plain `lodash` is declared nowhere. It resolves in this repository only because
+karma and webpack-bundle-analyzer pull it in as development dependencies.
+
+A consumer therefore installs an unused package and resolves the one actually
+imported by luck. This has been shipping since before the Angular walk.
+
+The fix is to remove it rather than to correct the name. Five functions are
+used, and their transitive graph is 152 files:
+
+    uniqueId        a counter, three lines
+    map, filter     native, where they are used on arrays
+    cloneDeep       structuredClone
+    isEqual         the only one needing care
+
+`isEqual` handles NaN, Dates, Maps and Sets, so a naive replacement would
+differ quietly. Verify it against the corpus, which now records validity.
+
 ### Raise the Codecov project target
 
 `codecov.yml` has `project: auto` because coverage was 56 percent when it was
@@ -47,38 +68,35 @@ The 19 Angular alerts are fixed by the walk above, since they are all against
 versions the upgrade replaces. That is the strongest practical argument for
 finishing it.
 
-The 3 `lodash-es` alerts are not reachable. They are `_.template` code
-injection and prototype pollution in `_.unset` and array paths. The library
-imports only `cloneDeep`, `filter`, `isEqual`, `map` and `uniqueId`. Worth
-confirming again after any lodash upgrade rather than assuming.
+The 3 `lodash-es` alerts are not reachable twice over. They are `_.template`
+code injection and prototype pollution in `_.unset` and array paths, none of
+which the library calls, and `lodash-es` is not imported at all: the code
+imports plain `lodash`, as the item above describes. Removing the dependency
+closes them.
 
 The 72 development alerts are worth one pass to confirm none of them affect the
 published artifacts, then triaging in bulk.
 
 ## Correctness
 
-### Group C: the deferred bugs
+### Group C: what is left
 
-Four helpers were left alone deliberately during the fix work, because each is
-load bearing. Call sites counted across the four packages:
+Four helpers were deferred during the fix work because each is load bearing.
+Two are now done and took two others with them.
 
-    isEmpty    47   treats Date, Map, Set and RegExp as empty
-    isNumber   21   global isNaN, so null, '', true and [] are all numbers
-    hasOwn    134   returns the element rather than a boolean for a numeric key
-    getType    21   getType('') is 'integer', falls out of isNumber
+`isEmpty` reported a Date, Map, Set and RegExp as empty, so roughly fifteen
+validator guards skipped those values entirely. Fixed.
 
-`isEmpty` is the one to schedule first. Roughly fifteen of its call sites are
-the `if (isEmpty(control.value)) { return null; }` guard at the top of a
-validator, so a Date valued or Map valued control bypasses validation
-completely today. Fixing it turns those guards back on, which is the point and
-also why it cannot land during an upgrade.
+`isNumber` used the global isNaN, so null, the empty string, booleans, arrays
+and Dates all counted as numbers. Fixed, and it repaired `getType('')`,
+`isPrimitive([])`, and the NaN that `toJavaScriptType` and `toSchemaType`
+returned for dates, booleans and the empty string.
 
-`isNumber` cascades into `getType`, `isPrimitive`, `toJavaScriptType` and
-`merge-schemas`. Fixing it makes `type('number')` stop accepting `true`. Wide,
-and no user has asked for it.
-
-`hasOwn` at 134 call sites is the largest blast radius in the library for the
-smallest visible payoff. Revisit alone, after the walk, with a full corpus run.
+`hasOwn` is the remainder, at 134 call sites. It returns the element rather
+than a boolean for a numeric key on an array, so `hasOwn([0, 1], 0)` is `0` and
+reads as false. It is the largest reach in the library for the smallest visible
+payoff, and nothing user facing depends on it. Revisit alone, after the walk,
+with a full corpus run.
 
 ### Bugs frozen into the corpus baseline
 
@@ -120,6 +138,49 @@ prerequisite for 2019-09 and 2020-12, whose support lives behind separate entry
 points. Worth doing as its own change, separate from the draft work, so a
 failure has one cause.
 
+### JSON Schema is validated twice, by two implementations
+
+`json-schema-form.service.ts:249` runs `validateFormData(this.data)`, an ajv
+function compiled from the whole schema, and uses its output for `isValid` and
+`validationErrors`. Separately, `getControlValidators` builds a validator per
+control out of `JsonValidators`, which is a hand written implementation of the
+same specification. Both run against the same data.
+
+That duplication is where most of the bugs found during the Angular walk lived.
+`exclusiveMinimum` was an exclusive maximum, `uniqueItems` never reported a
+duplicate, and `dependencies` made any form using it permanently invalid. ajv
+gets all three right, and has for years.
+
+The duplication is not gratuitous. Angular reactive forms want a `ValidatorFn`
+per control so a field can carry its own error state, while ajv reports
+document level errors keyed by JSON pointer. Mapping ajv errors back onto
+controls by pointer is a known pattern and would delete most of
+`json.validators.ts`, which is 895 lines.
+
+Two things to establish before committing to it. Whether running ajv on the
+whole document per keystroke is acceptable, or whether errors should be mapped
+from the existing single run. And whether consumers depend on `JsonValidators`
+directly, since it is exported from `public_api.ts` and removing it is a
+breaking change on its own.
+
+This is worth more than any single fix left on this page, because it removes
+the class of bug rather than instances of it.
+
+### Not zod, and not lodash, for the type helpers
+
+Both come up. Neither fits.
+
+zod validates shapes authored in TypeScript at build time. AJSF receives an
+arbitrary JSON Schema at run time and has no compile time type to describe, and
+zod would not touch `isNumber` or `isEmpty`, which are internal predicates
+rather than schema validation.
+
+lodash cannot replace the predicates either, because the semantics differ on
+purpose. `isNumber('3')` has to be true, since a form input is a string and a
+schema may carry `"3"`, while lodash says false. `isNumber(NaN)` has to be
+false, while lodash says true. `_.isEmpty(new Date())` is true in lodash, which
+is the same bug fixed in `isEmpty` here.
+
 ### Conditional layout
 
 `if`, `then` and `else` validate correctly today and the layout ignores them, so
@@ -133,7 +194,7 @@ Five files carry most of the library:
 
     1068  shared/layout.functions.ts
     1012  shared/jsonpointer.functions.ts
-     909  shared/json.validators.ts
+     895  shared/json.validators.ts
      883  json-schema-form.service.ts
      788  shared/json-schema.functions.ts
 

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
@@ -314,10 +314,9 @@ describe('mergeSchemas', () => {
       )).toEqual({ maximum: 5, maxLength: 8, maxItems: 2, maxProperties: 3 });
     });
 
-    it('coerces boolean exclusiveMaximum values to numbers', () => {
-      // isNumber() returns true for booleans, so Math.min(true, false) === 0.
+    it('keeps boolean exclusiveMaximum values apart rather than coercing them', () => {
       expect(mergeSchemas({ exclusiveMaximum: true }, { exclusiveMaximum: false }))
-        .toEqual({ exclusiveMaximum: 0 });
+        .toEqual({ allOf: [{ exclusiveMaximum: true }, { exclusiveMaximum: false }] });
     });
 
     it('returns allOf when a maximum keyword value is not numeric', () => {

--- a/projects/ajsf-core/src/lib/shared/validator.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/validator.functions.spec.ts
@@ -306,13 +306,14 @@ describe("Validator functions", () => {
       expect(isNumber(-Infinity)).toBe(false);
     });
 
-    // Global isNaN coerces these to 0 or 1, so they read as numbers
-    it("accepts null, empty string, booleans and arrays", () => {
-      expect(isNumber(null)).toBe(true);
-      expect(isNumber("")).toBe(true);
-      expect(isNumber(true)).toBe(true);
-      expect(isNumber([])).toBe(true);
-      expect(isNumber(new Date())).toBe(true);
+    it("rejects null, empty string, booleans, arrays and dates", () => {
+      expect(isNumber(null)).toBe(false);
+      expect(isNumber("")).toBe(false);
+      expect(isNumber("   ")).toBe(false);
+      expect(isNumber(true)).toBe(false);
+      expect(isNumber([])).toBe(false);
+      expect(isNumber([5])).toBe(false);
+      expect(isNumber(new Date())).toBe(false);
     });
 
     it("requires a JavaScript number when strict", () => {
@@ -344,12 +345,11 @@ describe("Validator functions", () => {
       expect(isInteger({})).toBe(false);
     });
 
-    // Same coercion quirk as isNumber: these all yield a remainder of 0
-    it("accepts null, empty string, booleans and arrays", () => {
-      expect(isInteger(null)).toBe(true);
-      expect(isInteger("")).toBe(true);
-      expect(isInteger(true)).toBe(true);
-      expect(isInteger([])).toBe(true);
+    it("rejects null, empty string, booleans and arrays", () => {
+      expect(isInteger(null)).toBe(false);
+      expect(isInteger("")).toBe(false);
+      expect(isInteger(true)).toBe(false);
+      expect(isInteger([])).toBe(false);
     });
 
     it("requires a JavaScript number when strict", () => {
@@ -533,9 +533,8 @@ describe("Validator functions", () => {
       expect(getType("abc")).toEqual("string");
     });
 
-    // The empty string coerces to 0, so isInteger claims it before isString
-    it("returns 'integer' for the empty string", () => {
-      expect(getType("")).toEqual("integer");
+    it("returns 'string' for the empty string", () => {
+      expect(getType("")).toEqual("string");
     });
 
     it("only detects JavaScript numbers when strict", () => {
@@ -608,9 +607,8 @@ describe("Validator functions", () => {
       expect(isPrimitive(() => null)).toBe(false);
     });
 
-    // An array coerces to 0, so isNumber accepts it
-    it("returns true for an array", () => {
-      expect(isPrimitive([])).toBe(true);
+    it("returns false for an array", () => {
+      expect(isPrimitive([])).toBe(false);
     });
   });
 
@@ -654,8 +652,8 @@ describe("Validator functions", () => {
     });
 
     it("stringifies numbers and booleans when 'string' is allowed", () => {
-      expect(toJavaScriptType(true, "string")).toEqual("true");
       expect(toJavaScriptType(10.5, "string")).toEqual("10.5");
+      expect(toJavaScriptType(true, "string")).toEqual("true");
     });
 
     it("converts a date to an ISO day string when 'string' is allowed", () => {
@@ -664,19 +662,18 @@ describe("Validator functions", () => {
       );
     });
 
-    // parseInt / parseFloat run on the date's display string, which is not numeric
-    it("returns NaN for a date when only a numeric type is allowed", () => {
-      expect(toJavaScriptType(new Date(2011, 9, 5), "number")).toBeNaN();
-      expect(toJavaScriptType(new Date(2011, 9, 5), "integer")).toBeNaN();
+    it("returns the timestamp of a date when only a numeric type is allowed", () => {
+      expect(toJavaScriptType(new Date(2011, 9, 5), "number"))
+        .toEqual(new Date(2011, 9, 5).getTime());
     });
 
     it("returns the timestamp of an invalid date when only a numeric type is allowed", () => {
       expect(toJavaScriptType(new Date("not a date"), "number")).toBeNaN();
     });
 
-    it("returns NaN for the empty string with a numeric type", () => {
-      expect(toJavaScriptType("", "integer")).toBeNaN();
-      expect(toJavaScriptType("", "number")).toBeNaN();
+    it("returns null for the empty string with a numeric type", () => {
+      expect(toJavaScriptType("", "integer")).toBeNull();
+      expect(toJavaScriptType("", "number")).toBeNull();
     });
   });
 
@@ -709,11 +706,9 @@ describe("Validator functions", () => {
       expect(toSchemaType(true, ["string"])).toEqual("true");
     });
 
-    // parseFloat("true") is NaN, and the unary plus keeps it NaN
-    it("returns NaN for a boolean when a numeric type is allowed", () => {
-      expect(toSchemaType(true, ["number"])).toBeNaN();
-      expect(toSchemaType(false, ["number"])).toBeNaN();
-      expect(toSchemaType(true, ["number", "string"])).toBeNaN();
+    it("converts a boolean to 1 or 0 when a numeric type is allowed", () => {
+      expect(toSchemaType(true, ["number"])).toEqual(1);
+      expect(toSchemaType(false, ["number"])).toEqual(0);
     });
 
     it("converts null to an empty string or to zero", () => {
@@ -726,8 +721,8 @@ describe("Validator functions", () => {
       expect(toSchemaType(undefined, ["string"])).toBeUndefined();
     });
 
-    it("returns NaN for the empty string with an integer type", () => {
-      expect(toSchemaType("", ["integer"])).toBeNaN();
+    it("converts the empty string to zero when an integer type is allowed", () => {
+      expect(toSchemaType("", ["integer"])).toEqual(0);
     });
 
     it("keeps the empty string when 'string' is allowed", () => {

--- a/projects/ajsf-core/src/lib/shared/validator.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/validator.functions.ts
@@ -192,7 +192,12 @@ export function isString(value) {
  */
 export function isNumber(value, strict: any = false) {
   if (strict && typeof value !== 'number') { return false; }
-  return !isNaN(value) && value !== value / 0;
+  // Numeric strings count, so a schema may carry "3". Everything else does not,
+  // including null, '', booleans, arrays and Dates, all of which the global
+  // isNaN would coerce to a number.
+  if (typeof value !== 'number' && typeof value !== 'string') { return false; }
+  if (typeof value === 'string' && !value.trim().length) { return false; }
+  return Number.isFinite(Number(value));
 }
 
 /**
@@ -205,8 +210,8 @@ export function isNumber(value, strict: any = false) {
  * // {boolean } - true if number, false if not
  */
 export function isInteger(value, strict: any = false) {
-  if (strict && typeof value !== 'number') { return false; }
-  return !isNaN(value) &&  value !== value / 0 && value % 1 === 0;
+  if (!isNumber(value, strict)) { return false; }
+  return Number(value) % 1 === 0;
 }
 
 /**
@@ -409,6 +414,7 @@ export function toJavaScriptType(value, types, strictIntegers = true)  {
     // convert the date to a string
     if (isDate(value)) { return toIsoString(value); }
     if (isNumber(value)) { return value.toString(); }
+    if (isBoolean(value, 'strict')) { return value.toString(); }
   }
   // If value is a date, and types includes 'integer' or 'number',
   // but not 'string', convert the date to a number


### PR DESCRIPTION
## Summary

Repairs `isNumber` and `isInteger`, which used the global `isNaN` and so accepted null, the empty string, booleans, arrays and Dates as numbers.

## Changes

Numeric strings still count, because a form input is a string and a schema may legitimately carry `"3"`. Everything the global `isNaN` merely coerced no longer does.

Four items tracked separately were repaired by the same change: `getType("")` was `"integer"` and is now `"string"`, `isPrimitive([])` was true, `toJavaScriptType(date, "number")` returned NaN and now returns the timestamp, and `toSchemaType(true, ["number"])` returned NaN where its own doc comment promises 1.

It also exposed a path that depended on the bug. `toSchemaType` has a branch commented "Convert null and boolean to string" that worked only because a boolean counted as a number and picked up `.toString()` in the number branch. `toJavaScriptType` now converts a strict boolean explicitly, so the intent survives without the accident.

## Compatibility

`type('number')` stops accepting `true`, and callers of `getType` or `isPrimitive` see corrected answers.

## Release impact

No version change. This ships in the next major alongside the other behaviour fixes.

## Validation

All five suites passed, 2,433 specs, and all 400 corpus cases matched including the validity field. Eleven specs pinned the old behaviour and now describe the new one.