### PR TITLE
fix(core): import the lodash package that every manifest declares

### DIFF
--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectorRef, Component, Input, OnChanges, OnInit} from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
+import cloneDeep from 'lodash-es/cloneDeep';
+import map from 'lodash-es/map';
 import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
 
 /**

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -5,8 +5,8 @@ import {
   OnChanges,
   OnInit
 } from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
+import cloneDeep from 'lodash-es/cloneDeep';
+import map from 'lodash-es/map';
 import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
 
 /**

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -5,8 +5,8 @@ import {
   OnChanges,
   OnInit
 } from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
+import cloneDeep from 'lodash-es/cloneDeep';
+import map from 'lodash-es/map';
 import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
 
 /**

--- a/projects/ajsf-core/src/lib/json-schema-form.component.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.component.ts
@@ -1,5 +1,5 @@
-import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
+import cloneDeep from 'lodash-es/cloneDeep';
+import isEqual from 'lodash-es/isEqual';
 
 import {
   ChangeDetectionStrategy,

--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash-es/cloneDeep';
 import Ajv from 'ajv';
 import jsonDraft6 from 'ajv/lib/refs/json-schema-draft-06.json';
 import {

--- a/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
+++ b/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash-es/cloneDeep';
 
 /**
  * 'convertSchemaToDraft6' function

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.ts
@@ -1,6 +1,6 @@
-import cloneDeep from 'lodash/cloneDeep';
-import filter from 'lodash/filter';
-import map from 'lodash/map';
+import cloneDeep from 'lodash-es/cloneDeep';
+import filter from 'lodash-es/filter';
+import map from 'lodash-es/map';
 import {
   AbstractControl,
   UntypedFormArray,

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash-es/cloneDeep';
 import { forEach, hasOwn, mergeFilteredObject } from './utility.functions';
 import {
   getType,

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual';
+import isEqual from 'lodash-es/isEqual';
 import {
   _executeAsyncValidators,
   _executeValidators,

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -1,5 +1,5 @@
-import uniqueId from 'lodash/uniqueId';
-import cloneDeep from 'lodash/cloneDeep';
+import uniqueId from 'lodash-es/uniqueId';
+import cloneDeep from 'lodash-es/cloneDeep';
 import {
   checkInlineType,
   getFromSchema,

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual';
+import isEqual from 'lodash-es/isEqual';
 
 import {
   isArray, isEmpty, isNumber, isObject, isString

--- a/projects/ajsf-material/src/lib/material-design-framework.component.ts
+++ b/projects/ajsf-material/src/lib/material-design-framework.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectorRef, Component, Input, OnChanges, OnInit} from '@angular/core';
 import {isDefined, JsonSchemaFormService} from '@ajsf/core';
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash-es/cloneDeep';
 
 @Component({
   // tslint:disable-next-line:component-selector

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
       "@angular/*": [
         "./node_modules/@angular/*"
       ],
-      "lodash/*": [
+      "lodash-es/*": [
         "node_modules/@types/lodash-es/*"
       ],
       "@ajsf/core": [


### PR DESCRIPTION
## Summary

Corrects a dependency mismatch in all four published packages, which declared `lodash-es` and imported plain `lodash`.

## Changes

Source carried nineteen `from 'lodash/...'` imports and no `lodash-es` import, while every manifest declared `lodash-es`. Plain `lodash` was declared in no manifest and resolved in this repository only because karma and webpack-bundle-analyzer bring it in, so a consumer installed an unused package and resolved the imported one by luck.

`tsconfig.json` had a path mapping sending `lodash/*` at `@types/lodash-es`, which made the mismatch type check. It now maps `lodash-es/*`, describing what is imported rather than hiding what is not.

Aligning to `lodash-es` rather than to `lodash` also drops five CommonJS bailout warnings from the demo build, since `lodash-es` is ESM. Three remain, for ajv and for the demo's `brace`, both unrelated.

## Compatibility

Consumers now resolve the package the manifests already required them to install. Nothing in the public API changes.

## Release impact

No version change here. The corrected dependency reaches consumers with the next release.

## Validation

All five suites passed, 2,433 specs, and the 400 corpus cases matched. All five packages build and their output imports `lodash-es`.