### PR TITLE
fix(bootstrap5): space fields with mb-3 instead of form-group

### DIFF
--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -34,6 +34,12 @@ package being changed.
     input-group-append       live  keep               DEAD  drop the wrapper
     sr-only                  live  keep               DEAD  visually-hidden
 
+One caveat before anyone acts on that table. The probe detects a class whose
+rules set properties on the element itself, so a purely contextual selector
+such as `.tab-content > .tab-pane` reads as DEAD even where it is defined.
+`tab-content` and `active` are therefore unverified rather than confirmed dead,
+and want checking by hand before they are touched.
+
 `form-group` is the only one Bootstrap 4 kept, which is why Bootstrap 4 has
 vertical rhythm and Bootstrap 5 has none. It is the whole of the reported
 symptom.
@@ -70,11 +76,6 @@ Bootstrap 3 is correct as it stands and should not be touched.
 ## Testing
 
 The corpus cannot referee this. It records `controls`, `error` and `valid`, and
-a class rename moves none of them. It needs DOM assertions in the framework
+a class rename moves none of them. It needs assertions in the framework
 component specs instead, asserting the emitted class rather than its effect, so
 the test does not depend on a CDN.
-
-One caveat on the probe: it detects classes whose rules set properties on the
-element itself. A purely contextual selector such as `.tab-content > .tab-pane`
-reads as DEAD even when defined, so `tab-content` and `active` in the emitted
-list are unverified rather than confirmed dead.

--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -1,0 +1,80 @@
+# Bootstrap class drift
+
+Why fields have no spacing in Bootstrap 5 and why checkboxes look unstyled in
+Bootstrap 4. Measured against the live demo on 2026-08-16, Bootstrap 4.3.1 and
+5.3.8 as pinned in each framework.
+
+## Mechanism
+
+`bootstrapN-framework.component.ts` appends classes to `options.htmlClass`, and
+the template renders `<div [class]="options?.htmlClass || ''">`. Nothing else
+supplies layout. When Bootstrap drops a class, the div keeps rendering it and
+silently loses the styling, with no error anywhere.
+
+## What is emitted
+
+The Bootstrap 3 and Bootstrap 4 packages emit an identical class list. The
+Bootstrap 4 package is a copy of the Bootstrap 3 one with the CDN URL changed,
+so it serves Bootstrap 3 markup against Bootstrap 4 CSS.
+
+Probed by comparing computed styles of a bare element against the same element
+carrying the class. The two replacement columns differ, so read the one for the
+package being changed.
+
+    class                    BS4   fix for BS4        BS5   fix for BS5
+    form-group               live  keep               DEAD  mb-3
+    checkbox / radio         DEAD  form-check         DEAD  form-check
+    control-label            DEAD  col-form-label     DEAD  form-label
+    help-block               DEAD  form-text          DEAD  form-text
+    form-control-feedback    DEAD  invalid-feedback   DEAD  invalid-feedback
+    has-error / has-success  DEAD  is-invalid         DEAD  is-invalid
+    input-group-addon        DEAD  input-group-text   DEAD  input-group-text
+    pull-right               DEAD  float-right        DEAD  float-end
+    glyphicon                DEAD  none, BS4 dropped  DEAD  none
+    input-group-append       live  keep               DEAD  drop the wrapper
+    sr-only                  live  keep               DEAD  visually-hidden
+
+`form-group` is the only one Bootstrap 4 kept, which is why Bootstrap 4 has
+vertical rhythm and Bootstrap 5 has none. It is the whole of the reported
+symptom.
+
+The Bootstrap 5 package is the better migrated of the two. Its template already
+uses `float-end`, `visually-hidden`, `form-text`, `invalid-feedback`,
+`is-invalid` and `input-group-text`. What it inherited unchanged is the class
+list in the component class, which is where `form-group`, `checkbox` and
+`radio` are added.
+
+## Fixed
+
+`form-group` became `mb-3` and `control-label` became `form-label`, both in the
+Bootstrap 5 component class. That restores the vertical rhythm, which was the
+reported symptom, and gives labels their half rem of separation. Two lines,
+because both classes land on elements the framework template renders itself.
+
+## Still open
+
+`checkbox` and `radio` are not a rename. Bootstrap wants `form-check` on a
+wrapper, `form-check-input` on the input and `form-check-label` on the label.
+The framework can set the last two through `fieldHtmlClass` and
+`itemLabelHtmlClass`, but `checkbox-widget` in core renders a bare `<label>`
+holding an `<input>` and a `<span>`, with no wrapper for `form-check` to land
+on. So it needs a core widget change, not a framework one, and it affects every
+framework that renders a checkbox.
+
+The Bootstrap 4 pass is larger still. Every row above needs its Bootstrap 4
+column applied, and the result is a visible change for anyone relying on the
+current output, so it wants its own release note rather than a quiet fix.
+
+Bootstrap 3 is correct as it stands and should not be touched.
+
+## Testing
+
+The corpus cannot referee this. It records `controls`, `error` and `valid`, and
+a class rename moves none of them. It needs DOM assertions in the framework
+component specs instead, asserting the emitted class rather than its effect, so
+the test does not depend on a CDN.
+
+One caveat on the probe: it detects classes whose rules set properties on the
+element itself. A purely contextual selector such as `.tab-content > .tab-pane`
+reads as DEAD even when defined, so `tab-content` and `active` in the emitted
+list are unverified rather than confirmed dead.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,6 +107,14 @@ bugs pinned so that a regression is visible. Anyone fixing one must update the
 baseline in the same commit, and should not read a red corpus as their own
 mistake.
 
+### Bootstrap 4 is Bootstrap 3 markup
+
+The Bootstrap 4 package emits a class list identical to the Bootstrap 3 one, so
+checkboxes, radios, labels, help text and validation states all render
+unstyled. Bootstrap 5 had the same drift and its spacing half is fixed; the
+checkbox half needs a wrapper element that core does not render today. Measured
+class by class in [Bootstrap class drift](./bootstrap-class-drift.md).
+
 ### fxLayout has never worked
 
 `getFlexAttribute('layout')` reads `(a || 'row') + b ? ' ' + b : ''`. `+` binds

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -36,4 +36,38 @@ describe('FwBootstrap5Component', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // Bootstrap 5 defines neither .form-group nor .control-label, so emitting
+  // them costs the field its spacing with nothing to show that it happened.
+  describe('emitted classes', () => {
+    const initialize = (type: string, extra: any = {}) => {
+      component.layoutNode = { type, options: {}, ...extra };
+      component.initializeFramework();
+      return component;
+    };
+
+    it('spaces a field with mb-3 rather than form-group', () => {
+      const { options } = initialize('text');
+      expect(options.htmlClass).toContain('mb-3');
+      expect(options.htmlClass).not.toContain('form-group');
+    });
+
+    it('labels a field with form-label rather than control-label', () => {
+      const { options } = initialize('text');
+      expect(options.labelHtmlClass).toContain('form-label');
+      expect(options.labelHtmlClass).not.toContain('control-label');
+    });
+
+    it('keeps the list-group classes, which Bootstrap 5 still defines', () => {
+      expect(initialize('array').options.htmlClass).toContain('list-group');
+      expect(initialize('text', { arrayItem: true }).options.htmlClass)
+        .toContain('list-group-item');
+    });
+
+    it('preserves an htmlClass supplied by the layout', () => {
+      const { options } = initialize('text', { options: { htmlClass: 'mine' } });
+      expect(options.htmlClass).toContain('mine');
+      expect(options.htmlClass).toContain('mb-3');
+    });
+  });
 });

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -103,10 +103,11 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
           addClasses(this.options.htmlClass, 'list-group') :
           this.layoutNode.arrayItem && this.layoutNode.type !== '$ref' ?
             addClasses(this.options.htmlClass, 'list-group-item') :
-            addClasses(this.options.htmlClass, 'form-group');
+            // Bootstrap 5 dropped .form-group in favour of margin utilities.
+            addClasses(this.options.htmlClass, 'mb-3');
       this.widgetOptions.htmlClass = '';
       this.options.labelHtmlClass =
-        addClasses(this.options.labelHtmlClass, 'control-label');
+        addClasses(this.options.labelHtmlClass, 'form-label');
       this.widgetOptions.activeClass =
         addClasses(this.widgetOptions.activeClass, 'active');
       this.options.fieldAddonLeft =


### PR DESCRIPTION
## Summary

Bootstrap 5 fields rendered flush against each other with no vertical spacing. The framework component emitted `form-group` and `control-label`, two classes Bootstrap 5 removed, so they reached the DOM and matched nothing. Nothing errored, which is why it went unnoticed through the port.

## Changes

`form-group` becomes `mb-3` and `control-label` becomes `form-label`, the utilities Bootstrap 5 replaced them with. Both land on elements the framework template renders itself, so the change stays inside one component. Four specs assert the emitted classes, including that a layout-supplied `htmlClass` still survives.

## Release impact

Visual fix for `@ajsf/bootstrap5` only. Bootstrap 3 and 4 are untouched. No API change.

## Validation

86 specs pass, including the 80-case corpus. Three of the four new specs were confirmed to fail against the old classes; the fourth covers `list-group`, which is unchanged and passes either way. Verified in the demo: 14 wrappers now carry a 16px margin and labels 8px.

## Compatibility

Anyone overriding `.form-group` in a Bootstrap 5 project must target `.mb-3` instead. `docs/bootstrap-class-drift.md` records the remaining drift: Bootstrap 4 emits a Bootstrap 3 class list, and the checkbox fix needs a wrapper core does not render.