### PR TITLE
refactor(core): remove the lodash dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,25 +2,28 @@
 
 Notes for AI coding agents working in this repository. Humans may find the traps section useful too.
 
-`@ajsf/*` is a JSON Schema form builder for Angular, published as four packages from one Angular CLI workspace: `@ajsf/core` plus the `@ajsf/material`, `@ajsf/bootstrap3` and `@ajsf/bootstrap4` framework packages. All four version in lockstep.
+`@ajsf/*` is a JSON Schema form builder for Angular, published as five packages from one Angular CLI workspace: `@ajsf/core` plus the `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4` and `@ajsf/bootstrap5` framework packages. All five version in lockstep.
 
 ## Environment
 
-The repository targets **Angular 14.2 on Node 16.13.2** (`.nvmrc`) with TypeScript 4.7.
+The repository targets **Angular 17.3 on Node 18.17.1** (`.nvmrc`) with TypeScript 5.4.
+Read the version out of `.nvmrc` rather than typing it: it moves with each
+Angular major, and an older Node fails the build with a CLI version check
+rather than anything that points at the real cause.
 
 ⚠️ **`nvm use` does not stick unless nvm is sourced with `--no-use`.** Without it the shell keeps the default Node and everything still appears to work, so a build or an install silently runs on the wrong version. Start every shell that touches the toolchain with:
 
 ```bash
 export NVM_DIR="$HOME/.nvm"
 . "$NVM_DIR/nvm.sh" --no-use
-nvm use 16.13.2
+nvm use "$(cat .nvmrc)"
 ```
 
 ## Commands
 
 ```bash
 npm ci                       # install
-npm run build:libs           # build all four packages into dist/@ajsf/
+npm run build:libs           # build all five packages into dist/@ajsf/
 npm run build:demo           # build the libraries and the demo app
 npm start                    # serve the demo
 npm run test:scripts         # tests for scripts/, plain jasmine, fast
@@ -33,7 +36,7 @@ Library tests need the headless launcher flags:
 npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
 ```
 
-Substitute `test:bs3`, `test:bs4`, `test:material` for the other three.
+Substitute `test:bs3`, `test:bs4`, `test:bs5`, `test:material` for the others.
 
 ## Versioning
 
@@ -56,7 +59,7 @@ Publishing is automated through `.github/workflows/release.yml` and npm OIDC Tru
 
 1. Open a PR containing only the `npm run version:set` bump.
 2. Merge it. The trigger is the version **changing** in that push, so any merge that leaves it alone is a no-op. A version sitting in the repository ahead of what is on npm is fine and does not start a release.
-3. The `verify` job builds and runs all four suites, ungated, and uploads `dist` as an artifact.
+3. The `verify` job builds and runs all five suites, ungated, and uploads `dist` as an artifact.
 4. Approve the `npm-publish` deployment. Nothing reaches npm before this, and by now the build is green.
 5. `release` publishes the artifact `verify` built, `core` first, then the three framework packages, and tags the commit.
 
@@ -66,7 +69,7 @@ A version containing a hyphen goes to the `next` dist-tag, everything else to `l
 
 ## Coverage
 
-Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all four libraries. CI uploads them to Codecov from the `20.x` matrix leg only: both legs run the same tests on the same commit, so a second upload is a duplicate.
+Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all five libraries. CI uploads them to Codecov from the `20.x` matrix leg only: both legs run the same tests on the same commit, so a second upload is a duplicate.
 
 **Codecov authenticates with the `CODECOV_TOKEN` secret, not OIDC**, which is deliberate and differs from the npm publishing flow. `codecov/codecov-action` does accept `use_oidc: true`, but the CLI has a reported failure mode where it ignores the OIDC credential, falls back to tokenless and then fails on a rate limit (`codecov-action#1461`, closed with no stated fix), and fork pull requests receive no `id-token` at all. The token is the predictable option. Do not switch this to OIDC without confirming an upload actually lands.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,27 +30,6 @@ returns an empty package until a stable release moves it.
 
     npm deprecate "@ajsf/bootstrap5@0.0.0" "Placeholder only, not a usable release."
 
-### Fix the lodash dependency, which is currently wrong
-
-All four published packages declare `lodash-es` and import plain `lodash`.
-Source carries 19 `from 'lodash/...'` imports and zero `lodash-es` imports, and
-plain `lodash` is declared nowhere. It resolves in this repository only because
-karma and webpack-bundle-analyzer pull it in as development dependencies.
-
-A consumer therefore installs an unused package and resolves the one actually
-imported by luck. This has been shipping since before the Angular walk.
-
-The fix is to remove it rather than to correct the name. Five functions are
-used, and their transitive graph is 152 files:
-
-    uniqueId        a counter, three lines
-    map, filter     native, where they are used on arrays
-    cloneDeep       structuredClone
-    isEqual         the only one needing care
-
-`isEqual` handles NaN, Dates, Maps and Sets, so a naive replacement would
-differ quietly. Verify it against the corpus, which now records validity.
-
 ### Raise the Codecov project target
 
 `codecov.yml` has `project: auto` because coverage was 56 percent when it was
@@ -68,11 +47,9 @@ The 19 Angular alerts are fixed by the walk above, since they are all against
 versions the upgrade replaces. That is the strongest practical argument for
 finishing it.
 
-The 3 `lodash-es` alerts are not reachable twice over. They are `_.template`
-code injection and prototype pollution in `_.unset` and array paths, none of
-which the library calls, and `lodash-es` is not imported at all: the code
-imports plain `lodash`, as the item above describes. Removing the dependency
-closes them.
+The 3 `lodash-es` alerts are closed: lodash is gone from all five packages.
+`@ajsf/core` now depends on `ajv` and `tslib` only, and the four framework
+packages on `@ajsf/core` and `tslib`.
 
 The 72 development alerts are worth one pass to confirm none of them affect the
 published artifacts, then triaging in bulk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@angular/router": "^17.3.12",
         "brace": "^0.11.1",
         "core-js": "^3.6.5",
-        "lodash-es": "~4.17.21",
         "rxjs": "^7.0.0",
         "zone.js": "~0.14.10"
       },
@@ -31,7 +30,6 @@
         "@angular/compiler-cli": "^17.3.12",
         "@angular/language-service": "^17.3.12",
         "@types/jasmine": "~4.0.0",
-        "@types/lodash": "^4.14.182",
         "@types/node": "^12.11.1",
         "codelyzer": "^6.0.0",
         "conventional-changelog-cli": "^4.1.0",
@@ -50,7 +48,7 @@
         "webpack-bundle-analyzer": "^4.6.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.10.0",
+        "node": "^18.13.0 || >=20.9.0",
         "npm": ">=8.5.0"
       }
     },
@@ -5673,12 +5671,6 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -11323,11 +11315,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -20903,12 +20890,6 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
-      "dev": true
-    },
     "@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -25062,11 +25043,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@angular/router": "^17.3.12",
     "brace": "^0.11.1",
     "core-js": "^3.6.5",
-    "lodash-es": "~4.17.21",
     "rxjs": "^7.0.0",
     "zone.js": "~0.14.10"
   },
@@ -93,7 +92,6 @@
     "@angular/compiler-cli": "^17.3.12",
     "@angular/language-service": "^17.3.12",
     "@types/jasmine": "~4.0.0",
-    "@types/lodash": "^4.14.182",
     "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
     "conventional-changelog-cli": "^4.1.0",

--- a/projects/ajsf-bootstrap3/ng-package.json
+++ b/projects/ajsf-bootstrap3/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "lodash-es",
     "@ajsf/core"
   ]
 }

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -28,15 +28,11 @@
   },
   "private": false,
   "dependencies": {
-    "lodash-es": "~4.17.21",
     "@ajsf/core": "17.2.0-rc.1",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0"
-  },
-  "devDependencies": {
-    "@types/lodash-es": "^4.17.3"
   }
 }

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -1,7 +1,5 @@
 import {ChangeDetectorRef, Component, Input, OnChanges, OnInit} from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
-import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
+import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core';
 
 /**
  * Bootstrap 3 framework for Angular JSON Schema Form.
@@ -202,7 +200,7 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
 
         if (this.options.debug) {
           const vars: any[] = [];
-          this.debugOutput = map(vars, thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
+          this.debugOutput = vars.map(thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
         }
       }
       this.frameworkInitialized = true;

--- a/projects/ajsf-bootstrap4/ng-package.json
+++ b/projects/ajsf-bootstrap4/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "lodash-es",
     "@ajsf/core"
   ]
 }

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -28,15 +28,11 @@
   },
   "private": false,
   "dependencies": {
-    "lodash-es": "~4.17.21",
     "@ajsf/core": "17.2.0-rc.1",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0"
-  },
-  "devDependencies": {
-    "@types/lodash-es": "^4.17.6"
   }
 }

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -5,9 +5,7 @@ import {
   OnChanges,
   OnInit
 } from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
-import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
+import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core';
 
 /**
  * Bootstrap 4 framework for Angular JSON Schema Form.
@@ -207,7 +205,7 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
 
         if (this.options.debug) {
           const vars: any[] = [];
-          this.debugOutput = map(vars, thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
+          this.debugOutput = vars.map(thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
         }
       }
       this.frameworkInitialized = true;

--- a/projects/ajsf-bootstrap5/ng-package.json
+++ b/projects/ajsf-bootstrap5/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "lodash-es",
     "@ajsf/core"
   ]
 }

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -28,15 +28,11 @@
   },
   "private": false,
   "dependencies": {
-    "lodash-es": "~4.17.21",
     "@ajsf/core": "17.2.0-rc.1",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0"
-  },
-  "devDependencies": {
-    "@types/lodash-es": "^4.17.6"
   }
 }

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -5,9 +5,7 @@ import {
   OnChanges,
   OnInit
 } from '@angular/core';
-import cloneDeep from 'lodash/cloneDeep';
-import map from 'lodash/map';
-import {JsonSchemaFormService, addClasses, inArray} from '@ajsf/core';
+import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core';
 
 /**
  * Bootstrap 5 framework for Angular JSON Schema Form.
@@ -207,7 +205,7 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
 
         if (this.options.debug) {
           const vars: any[] = [];
-          this.debugOutput = map(vars, thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
+          this.debugOutput = vars.map(thisVar => JSON.stringify(thisVar, null, 2)).join('\n');
         }
       }
       this.frameworkInitialized = true;

--- a/projects/ajsf-core/ng-package.json
+++ b/projects/ajsf-core/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "lodash-es",
     "ajv"
   ]
 }

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -26,7 +26,6 @@
   },
   "private": false,
   "dependencies": {
-    "lodash-es": "~4.17.21",
     "ajv": "^6.10.0",
     "tslib": "^2.0.0"
   },
@@ -36,8 +35,5 @@
     "@angular/forms": "^17.0.0",
     "@angular/platform-browser": "^17.0.0",
     "rxjs": "^7.0.0"
-  },
-  "devDependencies": {
-    "@types/lodash-es": "^4.17.6"
   }
 }

--- a/projects/ajsf-core/src/lib/json-schema-form.component.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.component.ts
@@ -1,5 +1,5 @@
-import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
+import { cloneDeep } from './shared/clone-deep.function';
+import { deepEqual } from './shared/deep-equal.function';
 
 import {
   ChangeDetectionStrategy,
@@ -65,7 +65,6 @@ export const JSON_SCHEMA_FORM_VALUE_ACCESSOR: any = {
  *
  * This library depends on:
  *  - Angular (obviously)                  https://angular.io
- *  - lodash, JavaScript utility library   https://github.com/lodash/lodash
  *  - ajv, Another JSON Schema validator   https://github.com/epoberezkin/ajv
  *
  * In addition, the Example Playground also depends on:
@@ -246,7 +245,7 @@ export class JsonSchemaFormComponent implements ControlValueAccessor, OnChanges,
       ) {
         // If only 'form' input changed, get names of changed keys
         changedInput = Object.keys(this.previousInputs.form || {})
-          .filter(key => !isEqual(this.previousInputs.form[key], this.form[key]))
+          .filter(key => !deepEqual(this.previousInputs.form[key], this.form[key]))
           .map(key => `form.${key}`);
         resetFirst = false;
       }

--- a/projects/ajsf-core/src/lib/json-schema-form.service.spec.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.spec.ts
@@ -24,7 +24,7 @@ describe('JsonSchemaFormService', () => {
   let jsf: JsonSchemaFormService;
   let widgetLibrary: WidgetLibraryService;
 
-  /** Deep clone without pulling lodash into the spec. */
+  /** Deep clone, kept independent of the library's own cloneDeep. */
   const clone = (value: any): any => JSON.parse(JSON.stringify(value));
 
   /**

--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
-import cloneDeep from 'lodash/cloneDeep';
+import { cloneDeep } from './shared/clone-deep.function';
 import Ajv from 'ajv';
 import jsonDraft6 from 'ajv/lib/refs/json-schema-draft-06.json';
 import {

--- a/projects/ajsf-core/src/lib/shared/clone-deep.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/clone-deep.function.spec.ts
@@ -1,0 +1,100 @@
+import { cloneDeep } from './clone-deep.function';
+
+describe('cloneDeep', () => {
+  it('returns primitives, null and undefined unchanged', () => {
+    expect(cloneDeep(3)).toBe(3);
+    expect(cloneDeep('a')).toBe('a');
+    expect(cloneDeep(true)).toBe(true);
+    expect(cloneDeep(null)).toBeNull();
+    expect(cloneDeep(undefined)).toBeUndefined();
+  });
+
+  // The reason structuredClone cannot be used: every form clones the validation
+  // messages, whose 'format' and 'multipleOf' entries are functions.
+  it('carries functions over by reference', () => {
+    const format = (error: any) => `bad ${error}`;
+    const copy = cloneDeep({ messages: { format, plain: 'x' } });
+    expect(copy.messages.format).toBe(format);
+    expect(copy.messages.format('t')).toBe('bad t');
+  });
+
+  it('carries class references over unchanged', () => {
+    class WidgetComponent { }
+    const copy = cloneDeep({ widget: WidgetComponent });
+    expect(copy.widget).toBe(WidgetComponent);
+  });
+
+  it('copies a Date into a new instance with the same time', () => {
+    const date = new Date('2020-03-04T05:06:07Z');
+    const copy = cloneDeep(date);
+    expect(copy).not.toBe(date);
+    expect(copy.getTime()).toBe(date.getTime());
+  });
+
+  it('copies a RegExp, keeping source, flags and lastIndex', () => {
+    const pattern = /ab+/gi;
+    pattern.lastIndex = 2;
+    const copy = cloneDeep(pattern);
+    expect(copy).not.toBe(pattern);
+    expect(copy.source).toBe('ab+');
+    expect(copy.flags).toBe('gi');
+    expect(copy.lastIndex).toBe(2);
+    // A RegExp built by Object.create has no internal slots and throws here,
+    // which is the failure mode this branch exists to prevent.
+    copy.lastIndex = 0;
+    expect(copy.test('xabbb')).toBe(true);
+  });
+
+  it('copies Maps and Sets, cloning their contents', () => {
+    const inner = { a: 1 };
+    const map = cloneDeep(new Map<string, any>([['k', inner]]));
+    expect(map.get('k')).toEqual(inner);
+    expect(map.get('k')).not.toBe(inner);
+    const set = cloneDeep(new Set<any>([inner]));
+    expect(Array.from(set)[0]).not.toBe(inner);
+  });
+
+  it('deep copies nested objects and arrays without sharing references', () => {
+    const source = { a: [{ b: 1 }], c: { d: [2, 3] } };
+    const copy = cloneDeep(source);
+    expect(copy).toEqual(source);
+    expect(copy.a).not.toBe(source.a);
+    expect(copy.a[0]).not.toBe(source.a[0]);
+    expect(copy.c.d).not.toBe(source.c.d);
+    copy.a[0].b = 99;
+    expect(source.a[0].b).toBe(1);
+  });
+
+  // Array.prototype.forEach skips holes and drops trailing ones, which would
+  // change the length.
+  it('preserves array length across sparse holes', () => {
+    const sparse = [1, , 3];
+    sparse.length = 5;
+    const copy = cloneDeep(sparse);
+    expect(copy.length).toBe(5);
+    expect(1 in copy).toBe(false);
+    expect(copy[2]).toBe(3);
+  });
+
+  it('terminates on a cycle and keeps the shared reference', () => {
+    const source: any = { name: 'root' };
+    source.self = source;
+    const copy = cloneDeep(source);
+    expect(copy.self).toBe(copy);
+    expect(copy.name).toBe('root');
+  });
+
+  it('keeps a shared reference shared within one clone', () => {
+    const shared = { n: 1 };
+    const copy = cloneDeep({ first: shared, second: shared });
+    expect(copy.first).toBe(copy.second);
+    expect(copy.first).not.toBe(shared);
+  });
+
+  it('keeps the prototype of a class instance', () => {
+    class Point { constructor(public x = 1) { } }
+    const copy = cloneDeep(new Point(5));
+    expect(copy instanceof Point).toBe(true);
+    expect(copy.x).toBe(5);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/clone-deep.function.ts
+++ b/projects/ajsf-core/src/lib/shared/clone-deep.function.ts
@@ -1,0 +1,52 @@
+import { isDate, isMap, isSet } from './validator.functions';
+
+function isRegExp(item: any): boolean {
+  return !!item && Object.prototype.toString.call(item) === '[object RegExp]';
+}
+
+function clone(value: any, seen: WeakMap<any, any>): any {
+  if (value === null || typeof value !== 'object') { return value; }
+  if (seen.has(value)) { return seen.get(value); }
+  if (isDate(value)) { return new Date(value.getTime()); }
+  if (isRegExp(value)) {
+    const pattern = new RegExp(value.source, value.flags);
+    pattern.lastIndex = value.lastIndex;
+    return pattern;
+  }
+  let copy: any;
+  if (Array.isArray(value)) {
+    copy = new Array(value.length);
+    seen.set(value, copy);
+    for (let i = 0; i < value.length; i++) {
+      if (i in value) { copy[i] = clone(value[i], seen); }
+    }
+  } else if (isMap(value)) {
+    copy = new Map();
+    seen.set(value, copy);
+    value.forEach((item: any, key: any) => copy.set(key, clone(item, seen)));
+  } else if (isSet(value)) {
+    copy = new Set();
+    seen.set(value, copy);
+    value.forEach((item: any) => copy.add(clone(item, seen)));
+  } else {
+    copy = Object.create(Object.getPrototypeOf(value));
+    seen.set(value, copy);
+    Object.keys(value).forEach(key => copy[key] = clone(value[key], seen));
+  }
+  return copy;
+}
+
+/**
+ * 'cloneDeep' function
+ *
+ * Recursively copies plain objects, arrays, Dates, RegExps, Maps and Sets.
+ * Functions and class references are carried over unchanged, which is why
+ * structuredClone cannot be used here: layout nodes hold Angular component
+ * classes and the validation messages hold formatter functions.
+ *
+ * // {any} value - the value to copy
+ * // {any} - the copy
+ */
+export function cloneDeep<T>(value: T): T {
+  return clone(value, new WeakMap());
+}

--- a/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
+++ b/projects/ajsf-core/src/lib/shared/convert-schema-to-draft6.function.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import { cloneDeep } from './clone-deep.function';
 
 /**
  * 'convertSchemaToDraft6' function

--- a/projects/ajsf-core/src/lib/shared/deep-equal.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/deep-equal.function.spec.ts
@@ -1,0 +1,62 @@
+import { deepEqual } from './deep-equal.function';
+
+describe('deepEqual', () => {
+  it('compares primitives', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual(1, '1')).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+
+  it('compares by SameValueZero, so NaN equals NaN and 0 equals -0', () => {
+    expect(deepEqual(NaN, NaN)).toBe(true);
+    expect(deepEqual(0, -0)).toBe(true);
+  });
+
+  // A Date has no own enumerable keys, so a plain key walk would call any two
+  // Dates equal, and would let a Date satisfy an enum containing {}.
+  it('compares Dates by timestamp and never to a plain object', () => {
+    expect(deepEqual(new Date(5), new Date(5))).toBe(true);
+    expect(deepEqual(new Date(5), new Date(6))).toBe(false);
+    expect(deepEqual(new Date(5), {})).toBe(false);
+    expect(deepEqual({}, new Date(5))).toBe(false);
+  });
+
+  it('compares arrays by index and length', () => {
+    expect(deepEqual([1, [2, 3]], [1, [2, 3]])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual([1], [1, undefined])).toBe(false);
+  });
+
+  it('never equates an array with a numeric-key object', () => {
+    expect(deepEqual([1, 2], { 0: 1, 1: 2 } as any)).toBe(false);
+  });
+
+  it('ignores key order', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  // Without the hasOwnProperty check both sides have one key and both lookups
+  // are undefined, so these would compare equal.
+  it('distinguishes a present undefined value from a missing key', () => {
+    expect(deepEqual({ a: undefined }, { b: undefined })).toBe(false);
+    expect(deepEqual({ a: undefined }, {})).toBe(false);
+  });
+
+  it('compares nested plain objects', () => {
+    expect(deepEqual({ a: { b: [1, { c: 2 }] } }, { a: { b: [1, { c: 2 }] } })).toBe(true);
+    expect(deepEqual({ a: { b: [1, { c: 2 }] } }, { a: { b: [1, { c: 3 }] } })).toBe(false);
+  });
+
+  it('compares unsupported exotics by reference rather than calling them equal', () => {
+    expect(deepEqual(/a/, /a/)).toBe(false);
+    expect(deepEqual(new Map([['a', 1]]), new Map([['a', 1]]))).toBe(false);
+    const shared = /a/;
+    expect(deepEqual(shared, shared)).toBe(true);
+  });
+
+  it('does not equate a sparse hole with a value', () => {
+    expect(deepEqual([, 1], [2, 1])).toBe(false);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/deep-equal.function.ts
+++ b/projects/ajsf-core/src/lib/shared/deep-equal.function.ts
@@ -1,0 +1,45 @@
+import { isDate } from './validator.functions';
+
+// typeof is 'object' for Date, RegExp, Map, Set and arrays too, none of which an
+// own-key walk compares correctly: they have no own enumerable keys, so any two
+// of them would read as equal.
+function isPlainObject(value: any): boolean {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+/**
+ * 'deepEqual' function
+ *
+ * Structural equality for JSON Schema values and form data: primitives by
+ * SameValueZero, Dates by timestamp, arrays by index, plain objects by own
+ * enumerable keys in any order. Any other object compares by reference.
+ * Input must be acyclic.
+ *
+ * // {any} value1 - first value
+ * // {any} value2 - second value
+ * // {boolean} - true if structurally equal
+ */
+export function deepEqual(value1: any, value2: any): boolean {
+  if (value1 === value2) { return true; }
+  if (value1 !== value1 && value2 !== value2) { return true; }
+  if (isDate(value1) || isDate(value2)) {
+    return isDate(value1) && isDate(value2) &&
+      value1.getTime() === value2.getTime();
+  }
+  const isArray1 = Array.isArray(value1);
+  if (isArray1 !== Array.isArray(value2)) { return false; }
+  if (isArray1) {
+    if (value1.length !== value2.length) { return false; }
+    for (let i = 0; i < value1.length; i++) {
+      if (!deepEqual(value1[i], value2[i])) { return false; }
+    }
+    return true;
+  }
+  if (!isPlainObject(value1) || !isPlainObject(value2)) { return false; }
+  const keys1 = Object.keys(value1);
+  if (keys1.length !== Object.keys(value2).length) { return false; }
+  return keys1.every(key =>
+    Object.prototype.hasOwnProperty.call(value2, key) &&
+    deepEqual(value1[key], value2[key])
+  );
+}

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.ts
@@ -1,6 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
-import filter from 'lodash/filter';
-import map from 'lodash/map';
+import { cloneDeep } from './clone-deep.function';
 import {
   AbstractControl,
   UntypedFormArray,
@@ -301,9 +299,12 @@ export function buildFormGroup(template: any): AbstractControl {
         });
         return new UntypedFormGroup(groupControls, validatorFn);
       case 'FormArray':
-        return new UntypedFormArray(filter(map(template.controls,
-          controls => buildFormGroup(controls)
-        )), validatorFn);
+        return new UntypedFormArray(
+          (template.controls || [])
+            .map(controls => buildFormGroup(controls))
+            .filter(Boolean),
+          validatorFn
+        );
       case 'FormControl':
         return new UntypedFormControl(template.value, validatorFns);
     }

--- a/projects/ajsf-core/src/lib/shared/index.ts
+++ b/projects/ajsf-core/src/lib/shared/index.ts
@@ -10,6 +10,8 @@ export {
   JavaScriptType, PrimitiveValue, PlainObject, IValidatorFn, AsyncIValidatorFn
 } from './validator.functions';
 
+export { cloneDeep } from './clone-deep.function';
+
 export {
   addClasses, copy, forEach, forEachCopy, hasOwn, mergeFilteredObject,
   uniqueItems, commonItems, fixTitle, toTitleCase

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import { cloneDeep } from './clone-deep.function';
 import { forEach, hasOwn, mergeFilteredObject } from './utility.functions';
 import {
   getType,

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual';
+import { deepEqual } from './deep-equal.function';
 import {
   _executeAsyncValidators,
   _executeValidators,
@@ -213,7 +213,7 @@ export class JsonValidators {
         (isBoolean(enumValue, 'strict') &&
           toJavaScriptType(inputValue, 'boolean') === enumValue) ||
         (enumValue === null && !hasValue(inputValue)) ||
-        isEqual(enumValue, inputValue);
+        deepEqual(enumValue, inputValue);
       const isValid = isArray(currentValue) ?
         currentValue.every(inputValue => allowedValues.some(enumValue =>
           isEqualVal(enumValue, inputValue)
@@ -655,8 +655,8 @@ export class JsonValidators {
       const duplicateItems = [];
       for (let i = 0; i < items.length; i++) {
         for (let j = i + 1; j < items.length; j++) {
-          if (isEqual(items[i], items[j]) &&
-            !duplicateItems.some(duplicate => isEqual(duplicate, items[i]))
+          if (deepEqual(items[i], items[j]) &&
+            !duplicateItems.some(duplicate => deepEqual(duplicate, items[i]))
           ) {
             duplicateItems.push(items[i]);
           }

--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -49,9 +49,9 @@ const widgetLibrary: any = {
 };
 
 /**
- * Removes every '_id' key, at any depth. Layout node ids come from lodash
- * uniqueId(), whose counter is global across the whole test bundle, so their
- * values can never be asserted.
+ * Removes every '_id' key, at any depth. The id counter is module scoped and
+ * therefore global across the whole test bundle, so the values can never be
+ * asserted.
  */
 function stripIds(node: any): any {
   if (Array.isArray(node)) { return node.map(stripIds); }

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -1,5 +1,4 @@
-import uniqueId from 'lodash/uniqueId';
-import cloneDeep from 'lodash/cloneDeep';
+import { cloneDeep } from './clone-deep.function';
 import {
   checkInlineType,
   getFromSchema,
@@ -25,6 +24,10 @@ import {
   } from './validator.functions';
 import { JsonPointer } from './jsonpointer.functions';
 import { TitleMapItem } from '../json-schema-form.service';
+
+let idCounter = 0;
+
+const uniqueId = () => String(++idCounter);
 
 
 

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual';
+import { deepEqual } from './deep-equal.function';
 
 import {
   isArray, isEmpty, isNumber, isObject, isString
@@ -32,7 +32,7 @@ export function mergeSchemas(...schemas) {
     for (const key of Object.keys(schema)) {
       const combinedValue = combinedSchema[key];
       const schemaValue = schema[key];
-      if (!hasOwn(combinedSchema, key) || isEqual(combinedValue, schemaValue)) {
+      if (!hasOwn(combinedSchema, key) || deepEqual(combinedValue, schemaValue)) {
         combinedSchema[key] = schemaValue;
       } else {
         switch (key) {
@@ -62,7 +62,7 @@ export function mergeSchemas(...schemas) {
             // Keep only items that appear in both arrays
             if (isArray(combinedValue) && isArray(schemaValue)) {
               combinedSchema[key] = combinedValue.filter(item1 =>
-                schemaValue.findIndex(item2 => isEqual(item1, item2)) > -1
+                schemaValue.findIndex(item2 => deepEqual(item1, item2)) > -1
               );
               if (!combinedSchema[key].length) { return { allOf: [ ...schemas ] }; }
             } else {
@@ -75,7 +75,7 @@ export function mergeSchemas(...schemas) {
               const combinedObject = { ...combinedValue };
               for (const subKey of Object.keys(schemaValue)) {
                 if (!hasOwn(combinedObject, subKey) ||
-                  isEqual(combinedObject[subKey], schemaValue[subKey])
+                  deepEqual(combinedObject[subKey], schemaValue[subKey])
                 ) {
                   combinedObject[subKey] = schemaValue[subKey];
                 // Don't combine matching keys with different values
@@ -96,7 +96,7 @@ export function mergeSchemas(...schemas) {
               const combinedObject = { ...combinedValue };
               for (const subKey of Object.keys(schemaValue)) {
                 if (!hasOwn(combinedObject, subKey) ||
-                  isEqual(combinedObject[subKey], schemaValue[subKey])
+                  deepEqual(combinedObject[subKey], schemaValue[subKey])
                 ) {
                   combinedObject[subKey] = schemaValue[subKey];
                 // If both keys are arrays, include all items from both arrays,
@@ -134,7 +134,7 @@ export function mergeSchemas(...schemas) {
             // If arrays, keep only items that appear in both arrays
             if (isArray(combinedValue) && isArray(schemaValue)) {
               combinedSchema.items = combinedValue.filter(item1 =>
-                schemaValue.findIndex(item2 => isEqual(item1, item2)) > -1
+                schemaValue.findIndex(item2 => deepEqual(item1, item2)) > -1
               );
               if (!combinedSchema.items.length) { return { allOf: [ ...schemas ] }; }
             // If both keys are objects, merge them
@@ -203,7 +203,7 @@ export function mergeSchemas(...schemas) {
               const combinedObject = { ...combinedValue };
               for (const subKey of Object.keys(schemaValue)) {
                 if (!hasOwn(combinedObject, subKey) ||
-                  isEqual(combinedObject[subKey], schemaValue[subKey])
+                  deepEqual(combinedObject[subKey], schemaValue[subKey])
                 ) {
                   combinedObject[subKey] = schemaValue[subKey];
                 // If both keys are objects, merge them
@@ -244,7 +244,7 @@ export function mergeSchemas(...schemas) {
                   });
               }
               for (const subKey of Object.keys(schemaValue)) {
-                if (isEqual(combinedObject[subKey], schemaValue[subKey]) || (
+                if (deepEqual(combinedObject[subKey], schemaValue[subKey]) || (
                   !hasOwn(combinedObject, subKey) &&
                   !hasOwn(combinedObject, 'additionalProperties')
                 )) {

--- a/projects/ajsf-material/ng-package.json
+++ b/projects/ajsf-material/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "lodash-es",
     "@ajsf/core"
   ]
 }

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -28,7 +28,6 @@
   },
   "private": false,
   "dependencies": {
-    "lodash-es": "~4.17.21",
     "@ajsf/core": "17.2.0-rc.1",
     "tslib": "^2.0.0"
   },

--- a/projects/ajsf-material/src/lib/material-design-framework.component.ts
+++ b/projects/ajsf-material/src/lib/material-design-framework.component.ts
@@ -1,6 +1,5 @@
 import {ChangeDetectorRef, Component, Input, OnChanges, OnInit} from '@angular/core';
-import {isDefined, JsonSchemaFormService} from '@ajsf/core';
-import cloneDeep from 'lodash/cloneDeep';
+import {cloneDeep, isDefined, JsonSchemaFormService} from '@ajsf/core';
 
 @Component({
   // tslint:disable-next-line:component-selector

--- a/scripts/set-version.spec.js
+++ b/scripts/set-version.spec.js
@@ -12,7 +12,7 @@ function fixture() {
   write('ajsf-core', {
     name: '@ajsf/core', version: '0.8.0',
     keywords: ['Angular', 'ng', 'Angular14', 'Angular 14', 'ng14', 'JSON Schema'],
-    dependencies: { 'lodash-es': '~4.17.21' },
+    dependencies: { ajv: '^6.10.0' },
     peerDependencies: { '@angular/core': '>=14.0.0', '@angular/common': '>=14.0.0', rxjs: '^7.0.0' },
   });
   write('ajsf-material', {
@@ -78,7 +78,7 @@ describe('setVersion', () => {
     const dir = fixture();
     setVersion('18.0.0', 18, dir);
     expect(read(dir, 'ajsf-core').peerDependencies.rxjs).toEqual('^7.0.0');
-    expect(read(dir, 'ajsf-core').dependencies['lodash-es']).toEqual('~4.17.21');
+    expect(read(dir, 'ajsf-core').dependencies.ajv).toEqual('^6.10.0');
   });
 
   it('leaves Angular peers alone when angularMajor is null', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,6 @@
       "@angular/*": [
         "./node_modules/@angular/*"
       ],
-      "lodash/*": [
-        "node_modules/@types/lodash-es/*"
-      ],
       "@ajsf/core": [
         "dist/@ajsf/core"
       ],

--- a/tslint.json
+++ b/tslint.json
@@ -18,8 +18,7 @@
     "forin": true,
     "import-blacklist": [
       true,
-      "rxjs/Rx",
-      "lodash"
+      "rxjs/Rx"
     ],
     "import-spacing": true,
     "indent": [


### PR DESCRIPTION
## Summary

All five packages declared `lodash-es` while the source imported plain `lodash`, which was declared nowhere and resolved only because karma and webpack-bundle-analyzer hoist it as development dependencies. Consumers installed a package nothing imported and got the one that was imported by luck.

## Changes

Replaces the five functions used rather than correcting the name. `cloneDeep` and `deepEqual` become small helpers in core, `uniqueId` a module-local counter in `layout.functions`, and `map` and `filter` become native. `structuredClone` cannot stand in for `cloneDeep`: it throws on functions, and the service constructor clones validation messages whose `format` and `multipleOf` are functions. `deepEqual` is named apart from the unrelated one-argument `isEqual` in `utility.functions` and stays internal; `cloneDeep` is exported because the framework packages call it.

## Release impact

`@ajsf/core` now depends on `ajv` and `tslib` alone, the framework packages on `@ajsf/core` and `tslib`. This closes the three runtime `lodash-es` Dependabot alerts. It publishes with the next version bump rather than on its own.

## Validation

2,499 specs pass: 2,116 core, 82 each for bootstrap3, bootstrap4 and bootstrap5, 92 material, 45 scripts. That includes the 400-case corpus, which pins rendering. All five packages build, and the built output contains no lodash reference.

## Compatibility

`cloneDeep` is added to the public API of `@ajsf/core`; nothing is removed or renamed. Two narrowings: a `FormArray` template whose `controls` is a plain object rather than an array is no longer accepted, which nothing in the library produces, and structurally identical but distinct RegExps, Maps and Sets now compare unequal rather than equal.