### PR TITLE
fix(bootstrap5): style checks and radios with form-check

### DIFF
--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -57,15 +57,31 @@ Bootstrap 5 component class. That restores the vertical rhythm, which was the
 reported symptom, and gives labels their half rem of separation. Two lines,
 because both classes land on elements the framework template renders itself.
 
+`checkbox` and `radio` then followed. Bootstrap wants `form-check` on a
+wrapper, `form-check-input` on the input and `form-check-label` on the label.
+The first reading of this said it needed a core widget change, because
+`checkbox-widget` renders a bare `<label>` with no wrapper. That was wrong:
+`.form-check` is a descendant selector, and the framework renders its own div
+around the widget, so the class reaches the input from there. Measured against
+canonical Bootstrap markup the geometry is identical, and no core file changed.
+
+The one type that needs the framework div is the single `checkbox`, since
+`checkbox-widget` reads no `htmlClass` at all. The vertical `checkboxes` and
+`radios` widgets already bind `htmlClass` per item, and the inline variants take
+`form-check form-check-inline` on the item label.
+
 ## Still open
 
-`checkbox` and `radio` are not a rename. Bootstrap wants `form-check` on a
-wrapper, `form-check-input` on the input and `form-check-label` on the label.
-The framework can set the last two through `fieldHtmlClass` and
-`itemLabelHtmlClass`, but `checkbox-widget` in core renders a bare `<label>`
-holding an `<input>` and a `<span>`, with no wrapper for `form-check` to land
-on. So it needs a core widget change, not a framework one, and it affects every
-framework that renders a checkbox.
+`form-check-label` emits no declarations in this DOM shape. Bootstrap defines it
+only through sibling selectors such as `.form-check-input:disabled ~
+.form-check-label`, and the widgets nest the input inside the label. So the
+class is emitted as the contract, but disabled and validation label states stay
+inert until the input becomes a sibling. That is a core restructure across
+`checkbox`, `checkboxes` and `radios`, affecting four packages.
+
+The button set path (`checkboxbuttons`, `radiobuttons`) is migrated off the dead
+`btn-default` and `sr-only` but not measured. Bootstrap 5's own idiom there is
+`btn-check`, which also wants the input as a sibling of the label.
 
 The Bootstrap 4 pass is larger still. Every row above needs its Bootstrap 4
 column applied, and the result is a visible change for anyone relying on the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,8 +88,8 @@ mistake.
 
 The Bootstrap 4 package emits a class list identical to the Bootstrap 3 one, so
 checkboxes, radios, labels, help text and validation states all render
-unstyled. Bootstrap 5 had the same drift and its spacing half is fixed; the
-checkbox half needs a wrapper element that core does not render today. Measured
+unstyled. Bootstrap 5 had the same drift and is now migrated, spacing and
+checks alike, without touching core. The same approach applies here. Measured
 class by class in [Bootstrap class drift](./bootstrap-class-drift.md).
 
 ### fxLayout has never worked

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -28,6 +28,7 @@
         <div
         [class.h-100]="true"
         [class.mt-1]="true"
+        [class.form-check]="isSingleCheck"
         [class.is-invalid]="!!options?.errorMessage"
         [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
       >

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.scss
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.scss
@@ -3,27 +3,6 @@
     top: 40px;
   }
 
-  .checkbox,
-  .radio {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  .checkbox-inline,
-  .checkbox-inline + .checkbox-inline,
-  .checkbox-inline + .radio-inline,
-  .radio-inline,
-  .radio-inline + .radio-inline,
-  .radio-inline + .checkbox-inline {
-    margin-left: 0;
-    margin-right: 10px;
-  }
-
-  .checkbox-inline:last-child,
-  .radio-inline:last-child {
-    margin-right: 0;
-  }
-
   .ng-invalid.ng-touched {
     border: 1px solid #f44336;
   }

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -69,5 +69,68 @@ describe('FwBootstrap5Component', () => {
       expect(options.htmlClass).toContain('mine');
       expect(options.htmlClass).toContain('mb-3');
     });
+
+    it('gives checks and radios the Bootstrap 5 form-check trio', () => {
+      const single = initialize('checkbox');
+      expect(single.widgetOptions.fieldHtmlClass).toContain('form-check-input');
+      expect(single.widgetOptions.itemLabelHtmlClass).toContain('form-check-label');
+
+      const many = initialize('checkboxes');
+      expect(many.widgetOptions.htmlClass).toContain('form-check');
+
+      const radios = initialize('radios');
+      expect(radios.widgetOptions.htmlClass).toContain('form-check');
+      expect(radios.widgetOptions.fieldHtmlClass).toContain('form-check-input');
+    });
+
+    it('marks inline checks and radios with form-check-inline', () => {
+      for (const type of ['checkboxes-inline', 'radios-inline']) {
+        const { widgetOptions } = initialize(type);
+        expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-inline');
+        expect(widgetOptions.itemLabelHtmlClass).not.toContain('checkbox-inline');
+        expect(widgetOptions.itemLabelHtmlClass).not.toContain('radio-inline');
+      }
+    });
+
+    it('stops emitting the Bootstrap 3 checkbox and radio classes', () => {
+      for (const type of ['checkbox', 'checkboxes', 'radio', 'radios']) {
+        const { widgetOptions } = initialize(type);
+        const emitted = [
+          widgetOptions.htmlClass, widgetOptions.fieldHtmlClass,
+          widgetOptions.itemLabelHtmlClass,
+        ].join(' ');
+        expect(emitted).not.toMatch(/(^|\s)(checkbox|radio)(\s|$)/);
+      }
+    });
+
+    it('uses a live Bootstrap 5 button class for button sets', () => {
+      const { widgetOptions } = initialize('radiobuttons');
+      expect(widgetOptions.itemLabelHtmlClass).toContain('btn-outline-primary');
+      expect(widgetOptions.fieldHtmlClass).toContain('visually-hidden');
+      expect(widgetOptions.fieldHtmlClass).not.toContain('sr-only');
+    });
+  });
+
+  // The single checkbox has no element of its own carrying htmlClass, so
+  // .form-check has to come from the framework's own wrapper div.
+  describe('single checkbox wrapper', () => {
+    const render = (node: any) => {
+      component.layoutNode = node;
+      component.initializeFramework();
+      fixture.detectChanges();
+      return fixture.nativeElement.querySelector('.form-check');
+    };
+
+    it('marks the wrapper for a plain checkbox', () => {
+      expect(render({ type: 'checkbox', options: {} })).toBeTruthy();
+    });
+
+    it('leaves the wrapper alone for a text field', () => {
+      expect(render({ type: 'text', options: {} })).toBeNull();
+    });
+
+    it('leaves the wrapper alone when an addon makes it an input group', () => {
+      expect(render({ type: 'checkbox', options: { fieldAddonLeft: '@' } })).toBeNull();
+    });
   });
 });

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -37,6 +37,11 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
   ) {
   }
 
+  get isSingleCheck(): boolean {
+    return this.layoutNode.type === 'checkbox' &&
+      !this.options.fieldAddonLeft && !this.options.fieldAddonRight;
+  }
+
   get showRemoveButton(): boolean {
     if (!this.options.removable || this.options.readonly ||
       this.layoutNode.type === '$ref'
@@ -123,28 +128,45 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
       // Set miscelaneous styles and settings for each control type
       switch (this.layoutNode.type) {
         // Checkbox controls
+        // CheckboxComponent renders no element carrying htmlClass, so the
+        // single checkbox takes .form-check from the framework's own div.
         case 'checkbox':
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
+          break;
         case 'checkboxes':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'checkbox');
+            this.widgetOptions.htmlClass, 'form-check');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'checkboxes-inline':
-          this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'checkbox');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, 'checkbox-inline');
+            this.widgetOptions.itemLabelHtmlClass,
+            'form-check form-check-inline form-check-label');
           break;
         // Radio controls
         case 'radio':
         case 'radios':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'radio');
+            this.widgetOptions.htmlClass, 'form-check');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'radios-inline':
-          this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'radio');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, 'radio-inline');
+            this.widgetOptions.itemLabelHtmlClass,
+            'form-check form-check-inline form-check-label');
           break;
         // Button sets - checkboxbuttons and radiobuttons
         case 'checkboxbuttons':
@@ -154,9 +176,10 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
           this.widgetOptions.itemLabelHtmlClass = addClasses(
             this.widgetOptions.itemLabelHtmlClass, 'btn');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, this.options.style || 'btn-default');
+            this.widgetOptions.itemLabelHtmlClass,
+            this.options.style || 'btn-outline-primary');
           this.widgetOptions.fieldHtmlClass = addClasses(
-            this.widgetOptions.fieldHtmlClass, 'sr-only');
+            this.widgetOptions.fieldHtmlClass, 'visually-hidden');
           break;
         // Single button controls
         case 'button':


### PR DESCRIPTION
## Summary

Checks and radios rendered as unstyled native controls with the label flush against the box. The framework emitted the Bootstrap 3 names `checkbox`, `radio`, `checkbox-inline` and `radio-inline`; Bootstrap 4 replaced all four with the form-check family and Bootstrap 5 kept that.

## Changes

Emits `form-check` on the wrapper, `form-check-input` on the input and `form-check-label` on the label. The single checkbox takes the wrapper class from the framework's own div, since `CheckboxComponent` reads no `htmlClass`, and is skipped when an addon turns that div into an input group. The vertical widgets already bind `htmlClass` per item. Drops the scss that zeroed the old classes, and replaces `btn-default` and `sr-only` in the button set path. Corrects the roadmap claim that this needed a core change.

## Release impact

Visual fix for `@ajsf/bootstrap5` only. No core file changes, so no API movement.

## Validation

93 specs pass, including the 80-case corpus. Measured in the demo: input floated left at `-24px` into a 24px wrapper with the label at +24px, matching canonical Bootstrap markup, and zero legacy classes left in the DOM. All five packages build and their suites pass against this branch merged with main.

## Compatibility

An earlier reading held that this needed a core widget change. It does not: `.form-check` is a descendant selector and reaches the input through the framework's own div. `form-check-label` is emitted as the contract but is inert, because Bootstrap defines it only through sibling selectors and the widgets nest the input inside the label. The button set path is migrated but unmeasured.