### PR TITLE
build: release 17.2.0-rc.2

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "17.2.0-rc.1",
+  "version": "17.2.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   },
   "private": false,
   "dependencies": {
-    "@ajsf/core": "17.2.0-rc.1",
+    "@ajsf/core": "17.2.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "17.2.0-rc.1",
+  "version": "17.2.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   },
   "private": false,
   "dependencies": {
-    "@ajsf/core": "17.2.0-rc.1",
+    "@ajsf/core": "17.2.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "17.2.0-rc.1",
+  "version": "17.2.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   },
   "private": false,
   "dependencies": {
-    "@ajsf/core": "17.2.0-rc.1",
+    "@ajsf/core": "17.2.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "17.2.0-rc.1",
+  "version": "17.2.0-rc.2",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "17.2.0-rc.1",
+  "version": "17.2.0-rc.2",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   },
   "private": false,
   "dependencies": {
-    "@ajsf/core": "17.2.0-rc.1",
+    "@ajsf/core": "17.2.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Bumps all five packages to `17.2.0-rc.2`. This is the release trigger, so it carries the version change and nothing else.

## Changes

`npm run version:set -- 17.2.0-rc.2 17` moved the version and the internal `@ajsf/core` range together across the five manifests. No source file changes.

## Release impact

Publishes `@ajsf/core`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4`, `@ajsf/bootstrap5` and `@ajsf/material` at `17.2.0-rc.2`. The hyphen routes them to the `next` dist-tag, not `latest`. Three changes ship since rc.1: lodash removed from every package, and two Bootstrap 5 rendering fixes.

## Validation

Verified on main at 62d5826, the exact commit this bumps. All five packages build, and 2,510 specs pass: 2,116 core, 82 bootstrap3, 82 bootstrap4, 93 bootstrap5, 92 material, 45 scripts. That includes the 400-case corpus. The built manifests show `@ajsf/core` depending on `ajv` and `tslib` alone.

## Compatibility

`cloneDeep` is added to the public API of `@ajsf/core`; nothing is removed or renamed. Consumers overriding `.form-group` or `.control-label` in a Bootstrap 5 project must target `.mb-3` and `.form-label`, and `.checkbox`/`.radio` are now `.form-check`.