### PR TITLE
feat(demo): add a dark mode toggle

### DIFF
--- a/demo/app/ace-editor.directive.ts
+++ b/demo/app/ace-editor.directive.ts
@@ -2,6 +2,7 @@ import { Directive, ElementRef, EventEmitter, Input, Output } from '@angular/cor
 import ace from 'brace';
 import 'brace/mode/json';
 import 'brace/theme/sqlserver';
+import 'brace/theme/tomorrow_night';
 
 
 

--- a/demo/app/demo.component.html
+++ b/demo/app/demo.component.html
@@ -1,6 +1,14 @@
 <div class="demo-page-header">
   <mat-toolbar class="mat-elevation-z4 mat-medium" color="primary">
-    Angular JSON Schema Form — Demonstration Playground
+    <span class="toolbar-title">Angular JSON Schema Form — Demonstration Playground</span>
+    <button mat-icon-button
+      class="theme-toggle"
+      type="button"
+      [attr.aria-label]="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
+      [title]="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
+      (click)="toggleDarkMode()">
+      <mat-icon>{{darkMode ? 'light_mode' : 'dark_mode'}}</mat-icon>
+    </button>
   </mat-toolbar>
   <div class="header-content">
     An Angular <a href="http://json-schema.org/">JSON Schema</a> Form builder
@@ -131,6 +139,7 @@
       ace-editor
       [text]="jsonFormSchema"
       [options]="aceEditorOptions"
+      [theme]="aceTheme"
       [readOnly]="false"
       [autoUpdateContent]="true"
       (textChanged)="generateForm($event)"
@@ -143,7 +152,9 @@
     <h4 class="default-cursor" (click)="toggleVisible('form')">
       {{visible.form ? '▼' : '▶'}} Generated Form
     </h4>
-    <div *ngIf="visible.form" class="json-schema-form" [@expandSection]="true">
+    <div *ngIf="visible.form" class="json-schema-form" [@expandSection]="true"
+      [attr.data-bs-theme]="formPaneTheme"
+      [class.light-form-pane]="lightFormPane">
       <div *ngIf="!formActive">{{jsonFormStatusMessage}}</div>
 
       <!-- This is the form! -->

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -7,6 +7,8 @@ import { HttpClient } from '@angular/common/http';
 import { Examples } from './example-schemas.model';
 import { JsonPointer } from '@ajsf/core';
 
+const DARK_MODE_KEY = 'ajsf-demo-dark-mode';
+
 @Component({
   // tslint:disable-next-line:component-selector
   selector: 'demo',
@@ -80,7 +82,35 @@ export class DemoComponent implements OnInit {
     printMargin: false,
     autoScrollEditorIntoView: true,
   };
+  darkMode = false;
   @ViewChild(MatMenuTrigger, { static: true }) menuTrigger: MatMenuTrigger;
+
+  // Bootstrap 5 opts a subtree into its dark palette with this attribute.
+  // Bootstrap 3 and 4 have no dark theme, so their pane stays light.
+  get formPaneTheme(): string | null {
+    return this.darkMode && this.selectedFramework === 'bootstrap-5' ? 'dark' : null;
+  }
+
+  // Bootstrap 3 and 4 ship no dark theme, so their pane keeps a light surface
+  // rather than putting dark page text on light form controls.
+  get lightFormPane(): boolean {
+    return this.darkMode &&
+      (this.selectedFramework === 'bootstrap-3' || this.selectedFramework === 'bootstrap-4');
+  }
+
+  get aceTheme(): string {
+    return this.darkMode ? 'tomorrow_night' : 'sqlserver';
+  }
+
+  toggleDarkMode() {
+    this.setDarkMode(!this.darkMode);
+    localStorage.setItem(DARK_MODE_KEY, String(this.darkMode));
+  }
+
+  private setDarkMode(on: boolean) {
+    this.darkMode = on;
+    document.body.classList.toggle('dark-theme', on);
+  }
 
   constructor(
     private http: HttpClient,
@@ -89,6 +119,10 @@ export class DemoComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    const stored = localStorage.getItem(DARK_MODE_KEY);
+    this.setDarkMode(stored === null ?
+      matchMedia('(prefers-color-scheme: dark)').matches : stored === 'true');
+
     // Subscribe to query string to detect schema to load
     this.route.queryParams.subscribe(
       params => {

--- a/demo/styles.scss
+++ b/demo/styles.scss
@@ -16,6 +16,35 @@ $demo-app-warn:    mat.define-palette(mat.$red-palette);
 $demo-app-theme:   mat.define-light-theme($demo-app-primary, $demo-app-accent, $demo-app-warn);
 @include mat.all-component-themes($demo-app-theme);
 
+// Colors only: all-component-themes would emit the typography a second time.
+$demo-app-dark-theme: mat.define-dark-theme($demo-app-primary, $demo-app-accent, $demo-app-warn);
+.dark-theme {
+  @include mat.all-component-colors($demo-app-dark-theme);
+}
+
+
+:root {
+  --demo-bg: rgb(250, 250, 250);
+  --demo-fg: rgba(0, 0, 0, 0.87);
+  --demo-editor-bg: rgb(253, 253, 253);
+  --demo-border: #ccc;
+  --demo-data-good: #dfd;
+  --demo-data-bad: #fcc;
+  --demo-header-bg: #{mat.get-color-from-palette($demo-app-primary, lighter)};
+  --demo-header-fg: rgba(0, 0, 0, 0.87);
+}
+
+.dark-theme {
+  --demo-bg: #303030;
+  --demo-fg: #fff;
+  --demo-editor-bg: #1d1f21;
+  --demo-border: #555;
+  --demo-data-good: #1b3a1b;
+  --demo-data-bad: #4a1f1f;
+  --demo-header-bg: #1a2733;
+  --demo-header-fg: #fff;
+}
+
 $font-family: 'Roboto', 'Noto', 'Helvetica Neue', sans-serif;
 $row-height: 56px;
 
@@ -29,7 +58,8 @@ mat-toolbar {
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: rgb(250, 250, 250) !important;
+  background-color: var(--demo-bg) !important;
+  color: var(--demo-fg);
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
@@ -40,7 +70,8 @@ body {
 }
 
 .demo-page-header {
-  background-color: mat.get-color-from-palette($demo-app-primary, lighter);
+  background-color: var(--demo-header-bg);
+  color: var(--demo-header-fg);
   margin-bottom: 12px;
   .header-content {
     font-family: $font-family;
@@ -58,16 +89,16 @@ body {
 [ace-editor], .data-good, .data-bad {
   border-radius: 3px;
   padding: 6px;
-  border: 1px solid #ccc !important;
+  border: 1px solid var(--demo-border) !important;
 }
 
-[ace-editor] { background-color: rgb(253, 253, 253) !important; }
+[ace-editor] { background-color: var(--demo-editor-bg) !important; }
 
 .avoidwrap { display:inline-block; }
 
-.data-good { background-color: #dfd; }
+.data-good { background-color: var(--demo-data-good); }
 
-.data-bad { background-color: #fcc; }
+.data-bad { background-color: var(--demo-data-bad); }
 
 .default-cursor:hover { cursor: default; }
 
@@ -116,3 +147,16 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+mat-toolbar .toolbar-title { flex: 1 1 auto; }
+
+.dark-theme .json-schema-form.light-form-pane {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 4px;
+  padding: 8px;
+}
+
+// Plain HTML has no stylesheet to theme, so let the browser render its native
+// controls dark instead of leaving white boxes on a dark page.
+.dark-theme .json-schema-form:not(.light-form-pane) { color-scheme: dark; }


### PR DESCRIPTION
## Summary

The demonstration playground was light only. Adds a toolbar toggle that starts from `prefers-color-scheme` and remembers an explicit choice in `localStorage`.

## Changes

Material gets a dark theme through `all-component-colors` rather than `all-component-themes`, so the typography is not emitted a second time. The hardcoded page, editor, border, header and data colours become custom properties with a light default and a dark override, and the ACE editor follows through the `theme` input the directive already exposed.

The generated form cannot follow uniformly. Bootstrap 5 opts into its own palette with `data-bs-theme`, Material follows the app theme, and plain HTML gets `color-scheme` so the browser renders native controls dark. Bootstrap 3 and 4 ship no dark theme, so their pane keeps a light surface rather than putting dark page text on light form controls.

## Release impact

No release. The demo is not published; this changes nothing a consumer of `@ajsf/*` can observe.

## Validation

The demo builds. Measured in the browser for each framework in dark mode: Bootstrap 5 renders `data-bs-theme="dark"`, Material and plain HTML leave the pane transparent with `color-scheme: dark`, and Bootstrap 4 keeps a white pane with `rgba(0, 0, 0, 0.87)` text. Light mode is unchanged at `rgb(250, 250, 250)` body, `rgb(187, 222, 251)` header and `rgb(253, 253, 253)` editor.