### PR TITLE
chore: add a sponsor button configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: hamzahamidi


### PR DESCRIPTION
## Summary

Adds a sponsor button to the repository. GitHub reads .github/FUNDING.yml from
the default branch and renders the button from it.

Opened as a draft because it is not mergeable yet. The account named has no
published Sponsors listing, and until it does GitHub reports "Some users
provided are not enrolled in GitHub Sponsors" instead of a button.

## Changes

One new file naming the maintainer account as the sponsorship target.

## Release impact

No release. The file ships in no published package, so nothing a consumer of
the @ajsf packages can observe changes. The version stays at 18.0.0.

## Validation

The key was checked against GitHub's documented list of supported platforms and
the file parses as valid YAML. The API reports hasSponsorsListing as false.
Merging also needs the repository Sponsorships setting, which can only be
enabled in the web interface.
