### PR TITLE
build: advertise the sponsors page in the published packages and readme

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -26,6 +26,7 @@
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
+  "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
     "@ajsf/core": "^18.0.0",

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -26,6 +26,7 @@
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
+  "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
     "@ajsf/core": "^18.0.0",

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -26,6 +26,7 @@
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
+  "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
     "@ajsf/core": "^18.0.0",

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -24,6 +24,7 @@
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
+  "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
     "ajv": "^6.10.0",

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -26,6 +26,7 @@
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
+  "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
     "@ajsf/core": "^18.0.0",


### PR DESCRIPTION
## Summary

Adds a funding field to the five published packages and a Sponsors section to
the README. npm prints "N packages are looking for funding" on install and
resolves it through npm fund, reaching about 31,000 downloads a month.

Four of the six sponsor tiers promise a name or company logo in the README,
and no README had anywhere to put one.

## Changes

One line in each library manifest, and a short section before Contributing in
the root README. The root manifest is private and never published.

## Release impact

No release now. Both are published content, but they land without a version
bump, leaving the release workflow idle. They ship with the next version.

## Validation

Building @ajsf/core on Node 20.19.0 confirmed ng-packagr copies the field into
the generated manifest. Installing that build into an empty project printed
"1 package is looking for funding", and npm fund resolved the sponsors url.
