### PR TITLE
ci: batch dependabot security updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ version: 2
 # not be edited independently of the version.
 #
 # `ignore` applies to version updates only, so security updates still arrive
-# whatever is listed below.
+# whatever is listed below. They are grouped separately for the same reason:
+# a group without `applies-to` covers version updates only, which left security
+# updates arriving one pull request at a time.
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -19,6 +21,9 @@ updates:
       patches:
         patterns: ["*"]
         update-types: ["patch"]
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
     ignore:
       # Angular majors move one at a time, in their own pull request.
       - dependency-name: "@angular*"
@@ -39,6 +44,9 @@ updates:
       patches:
         patterns: ["*"]
         update-types: ["patch"]
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
     ignore:
       - dependency-name: "@angular*"
       - dependency-name: "*"


### PR DESCRIPTION
## Summary

Patch version updates were already grouped, but security updates still arrived one pull request at a time, because a group without `applies-to` covers version updates only. Five landed at once.

## Changes

Adds a `security` group with `applies-to: security-updates` to both watched manifests, so security updates batch the same way patches already do.

## Release impact

No release. Repository configuration only.

## Validation

The file parses and both entries resolve to the two expected groups with `applies-to: security-updates`.

## Compatibility

Grouping does not make the current five mergeable, and that is worth stating plainly. Patching the transitive vulnerability pulls `@angular-devkit/build-angular` from 18.2.21 to 21.2.21, whose peer is `@angular/compiler-cli ^21.0.0` against a tree holding 18.2.14, so `npm ci` exits with ERESOLVE on every one of them. The `ignore` entry for `@angular*` cannot prevent that, because ignore conditions do not apply to security updates. This change means one failing pull request rather than five; finishing the Angular walk is what actually closes those alerts.