### PR TITLE
docs: add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,10 @@ Finally, if you want to see what scripts a particular framework will automatical
 
 In production, load these assets in the application and remove `loadExternalAssets` to avoid loading them twice.
 
+## Sponsors
+
+[Support AJSF through GitHub Sponsors](https://github.com/sponsors/hamzahamidi). Sponsors are recognized here according to their selected tier.
+
 ## Contributing
 
 See the [contributing guide](./CONTRIBUTING.md) for local setup, tests, and pull request guidance.


### PR DESCRIPTION
## Summary

Adds a neutral Sponsors section to the root README so the GitHub Sponsors tiers have one place for promised recognition.

## Changes

Links to the GitHub Sponsors page and states that sponsors are recognized according to their selected tier. It does not repeat the funding pitch, discuss maintainer workload or show an empty logo placeholder.

The framework README files remain unchanged, so sponsor names and logos have one source of truth.

## Release impact

Only the root README changes, so there is no package release. The section ships with the next published package version.

## Validation

`git diff --check` passed. The GitHub Sponsors link returned HTTP 200. GitHub CI is running again for the amended commit.
