### PR TITLE
fix(core): escape property names when building JSON Pointers

### DIFF
--- a/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
@@ -1426,3 +1426,28 @@ describe('form-group.functions', () => {
     });
   });
 });
+
+describe('buildFormGroupTemplate, keys needing escaping', () => {
+  // A key holding / or ~ produced a pointer isJsonPointer rejects, so compile()
+  // returned null and the whole form failed to build rather than one field.
+  it('builds a control for a key containing a tilde', () => {
+    const result: any = buildFormGroupTemplate(makeJsf({
+      type: 'object', properties: { 'a~b': { type: 'string' } },
+    }));
+    expect(Object.keys(result.controls)).toContain('a~b');
+  });
+
+  it('builds a control for a key containing a slash', () => {
+    const result: any = buildFormGroupTemplate(makeJsf({
+      type: 'object', properties: { 'a/b': { type: 'string' } },
+    }));
+    expect(Object.keys(result.controls)).toContain('a/b');
+  });
+
+  it('marks such a key required without corrupting the pointer', () => {
+    const result: any = buildFormGroupTemplate(makeJsf({
+      type: 'object', required: ['a/b'], properties: { 'a/b': { type: 'string' } },
+    }));
+    expect(result.controls['a/b'].validators.required).toEqual([]);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.ts
@@ -127,10 +127,10 @@ export function buildFormGroupTemplate(
           .forEach(key => controls[key] = buildFormGroupTemplate(
             jsf, JsonPointer.get(nodeValue, [<string>key]), setValues,
             schemaPointer + (hasOwn(schema.properties, key) ?
-              '/properties/' + key : '/additionalProperties'
+              '/properties/' + JsonPointer.escape(key) : '/additionalProperties'
             ),
-            dataPointer + '/' + key,
-            templatePointer + '/controls/' + key
+            dataPointer + '/' + JsonPointer.escape(key),
+            templatePointer + '/controls/' + JsonPointer.escape(key)
           ));
         jsf.formOptions.fieldsRequired = setRequiredFields(schema, controls);
       }
@@ -377,7 +377,8 @@ export function setRequiredFields(schema: any, formControlTemplate: any): boolea
     fieldsRequired = true;
     let requiredArray = isArray(schema.required) ? schema.required : [schema.required];
     requiredArray = forEach(requiredArray,
-      key => JsonPointer.set(formControlTemplate, '/' + key + '/validators/required', [])
+      key => JsonPointer.set(formControlTemplate,
+        '/' + JsonPointer.escape(key) + '/validators/required', [])
     );
   }
   return fieldsRequired;

--- a/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
@@ -11,6 +11,31 @@ import { JsonPointer } from './jsonpointer.functions';
  * given a pointer array), so every fixture is built inside the test that uses it.
  */
 describe('JsonPointer', () => {
+  describe('toDataPointer, key escaping', () => {
+    // parse() hands back an unescaped key, so it has to be re-escaped on the way
+    // out or the result is a pointer the library's own validator rejects.
+    it('escapes a key containing a tilde', () => {
+      const schema = { properties: { 'a~b': { type: 'string' } } };
+      const pointer = JsonPointer.toDataPointer('/properties/a~0b', schema);
+      expect(pointer).toEqual('/a~0b');
+      expect(JsonPointer.isJsonPointer(pointer)).toBe(true);
+      expect(JsonPointer.parse(pointer)).toEqual(['a~b']);
+    });
+
+    it('escapes a key containing a slash', () => {
+      const schema = { properties: { 'a/b': { type: 'string' } } };
+      const pointer = JsonPointer.toDataPointer('/properties/a~1b', schema);
+      expect(pointer).toEqual('/a~1b');
+      expect(JsonPointer.parse(pointer)).toEqual(['a/b']);
+    });
+
+    it('leaves an ordinary key alone', () => {
+      const schema = { properties: { plain: { type: 'string' } } };
+      expect(JsonPointer.toDataPointer('/properties/plain', schema)).toEqual('/plain');
+    });
+  });
+
+
 
   // Many branches log to console.error on purpose. Silencing keeps the run readable.
   beforeEach(() => {

--- a/projects/ajsf-core/src/lib/shared/jsonpointer.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/jsonpointer.functions.ts
@@ -922,7 +922,9 @@ export class JsonPointer {
       ) {
         const secondKey = pointerArray.shift();
         const pointerSuffix = this.toDataPointer(pointerArray, schema[firstKey][secondKey]);
-        return pointerSuffix === null ? null : '/' + secondKey + pointerSuffix;
+        // parse() returned secondKey unescaped, so it has to go back escaped:
+        // toSchemaPointer does the same at the matching site.
+        return pointerSuffix === null ? null : '/' + this.escape(secondKey) + pointerSuffix;
       } else if (firstKey === 'additionalItems' ||
         (firstKey === 'items' && isObject(schema.items))
       ) {

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -574,15 +574,15 @@ export function buildLayoutFromSchema(
         )
         .forEach(key => {
           const keySchemaPointer = hasOwn(schema.properties, key) ?
-            '/properties/' + key : '/additionalProperties';
+            '/properties/' + JsonPointer.escape(key) : '/additionalProperties';
           const innerItem = buildLayoutFromSchema(
             jsf, widgetLibrary, isObject(nodeValue) ? nodeValue[key] : null,
             schemaPointer + keySchemaPointer,
-            dataPointer + '/' + key,
+            dataPointer + '/' + JsonPointer.escape(key),
             false, null, null, forRefLibrary, dataPointerPrefix
           );
           if (innerItem) {
-            if (isInputRequired(schema, '/' + key)) {
+            if (isInputRequired(schema, '/' + JsonPointer.escape(key))) {
               innerItem.options.required = true;
               jsf.fieldsRequired = true;
             }


### PR DESCRIPTION
## Summary

A property name containing `/` or `~` took down the entire form rather than its own field. This is phase 1 of the execution plan, findings 1 and 8.

## Changes

Pointer segments were concatenated raw, so a `~` made `isJsonPointer` reject the result, `compile()` returned null, and `buildFormGroupTemplate` threw with nothing catching it. A `/` silently produced a nested pointer and the field was dropped instead. The key is now escaped at the six sites that build a pointer from one. `toDataPointer` had the mirror defect, re-emitting a key that `parse()` had already unescaped; `toSchemaPointer` escapes at the matching site and is what it should have looked like.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.1.0 with the rest of phase 1.

## Validation

2,127 core specs pass with six added, and the corpus does not move a single one of the 400. That was asserted before the run rather than observed after: no property name in any of the 84 example schemas contains `/` or `~`, so this change cannot reach a corpus case. A moved baseline entry would have been a defect in this pull request.

## Compatibility

`parse()` already unescaped, so callers see the same key they did before, and `escape()` is the identity for every name without `/` or `~`. No form that renders today changes.