### PR TITLE
fix(core): repair setCopy, remove and forEachDeepCopy

### DIFF
--- a/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/jsonpointer.functions.spec.ts
@@ -11,6 +11,46 @@ import { JsonPointer } from './jsonpointer.functions';
  * given a pointer array), so every fixture is built inside the test that uses it.
  */
 describe('JsonPointer', () => {
+  describe('setCopy, remove and forEachDeepCopy edge cases', () => {
+    it('rejects an empty pointer rather than writing a key named undefined', () => {
+      const result = JsonPointer.setCopy({ a: 1 }, '', 'x');
+      expect(result).toEqual({ a: 1 });
+      expect(Object.keys(result)).not.toContain('undefined');
+    });
+
+    it('still sets through a real pointer', () => {
+      expect(JsonPointer.setCopy({ a: 1 }, '/b', 2)).toEqual({ a: 1, b: 2 });
+    });
+
+    it('removes a key from a Map, so has() stops reporting it', () => {
+      const object: any = { m: new Map<string, any>([['k', 1]]) };
+      expect(JsonPointer.has(object, '/m/k')).toBe(true);
+      JsonPointer.remove(object, '/m/k');
+      expect(object.m.has('k')).toBe(false);
+      expect(JsonPointer.has(object, '/m/k')).toBe(false);
+    });
+
+    it('keeps a Date, Map or Set whole instead of flattening it', () => {
+      const date = new Date(5);
+      const map = new Map<string, any>([['k', 1]]);
+      const set = new Set<any>([1]);
+      const copied: any = JsonPointer.forEachDeepCopy({ date, map, set, n: 1 });
+      expect(copied.date instanceof Date).toBe(true);
+      expect(copied.date.getTime()).toBe(5);
+      expect(copied.map instanceof Map).toBe(true);
+      expect(copied.map.get('k')).toBe(1);
+      expect(copied.set instanceof Set).toBe(true);
+      expect(copied.n).toBe(1);
+    });
+
+    it('still walks plain objects and arrays', () => {
+      const copied: any = JsonPointer.forEachDeepCopy({ a: { b: [1, 2] } });
+      expect(copied).toEqual({ a: { b: [1, 2] } });
+      expect(copied.a).not.toBe(undefined);
+    });
+  });
+
+
   describe('toDataPointer, key escaping', () => {
     // parse() hands back an unescaped key, so it has to be re-escaped on the way
     // out or the result is a pointer the library's own validator rejects.
@@ -655,8 +695,8 @@ describe('JsonPointer', () => {
       expect(map.get('a').get('b')).toEqual(1);
     });
 
-    it('should set a key literally named undefined for the empty pointer', () => {
-      expect(JsonPointer.setCopy({}, '', 1)).toEqual({ 'undefined': 1 });
+    it('should reject the empty pointer, matching set()', () => {
+      expect(JsonPointer.setCopy({}, '', 1)).toEqual({});
     });
 
     it('should return the object unchanged for an invalid pointer', () => {
@@ -901,12 +941,16 @@ describe('JsonPointer', () => {
       expect(JsonPointer.forEachDeepCopy(undefined)).toBeUndefined();
     });
 
-    it('should return an empty object for a Date because spreading loses it', () => {
-      expect(JsonPointer.forEachDeepCopy(new Date(0))).toEqual({});
+    it('should return a Date whole rather than flattening it', () => {
+      const copied: any = JsonPointer.forEachDeepCopy(new Date(0));
+      expect(copied instanceof Date).toBe(true);
+      expect(copied.getTime()).toBe(0);
     });
 
-    it('should return an empty object for a Map because spreading loses the entries', () => {
-      expect(JsonPointer.forEachDeepCopy(new Map([['a', 1]]))).toEqual({});
+    it('should return a Map whole rather than losing the entries', () => {
+      const copied: any = JsonPointer.forEachDeepCopy(new Map([['a', 1]]));
+      expect(copied instanceof Map).toBe(true);
+      expect(copied.get('a')).toBe(1);
     });
 
     it('should return null when the iteratee is not a function', () => {

--- a/projects/ajsf-core/src/lib/shared/jsonpointer.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/jsonpointer.functions.ts
@@ -10,7 +10,7 @@ import {
   isNotExpression
 } from './utility.functions';
 import {Injectable} from '@angular/core';
-import {isArray, isDefined, isEmpty, isMap, isNumber, isObject, isString} from './validator.functions';
+import {isArray, isDate, isDefined, isEmpty, isMap, isNumber, isObject, isSet, isString} from './validator.functions';
 
 /**
  * 'JsonPointer' class
@@ -358,7 +358,9 @@ export class JsonPointer {
    */
   static setCopy(object, pointer, value, insert = false) {
     const keyArray = this.parse(pointer);
-    if (keyArray !== null) {
+    // set() carries the same length guard: without it an empty pointer leaves
+    // lastKey undefined and writes a property literally named 'undefined'.
+    if (keyArray !== null && keyArray.length) {
       const newObject = copy(object);
       let subObject = newObject;
       for (let i = 0; i < keyArray.length - 1; ++i) {
@@ -440,6 +442,8 @@ export class JsonPointer {
       if (isArray(parentObject)) {
         if (lastKey === '-') { lastKey = parentObject.length - 1; }
         parentObject.splice(lastKey, 1);
+      } else if (isMap(parentObject)) {
+        parentObject.delete(lastKey);
       } else if (isObject(parentObject)) {
         delete parentObject[lastKey];
       }
@@ -547,7 +551,11 @@ export class JsonPointer {
       console.error(`forEachDeepCopy error: Iterator is not a function:`, fn);
       return null;
     }
-    if (isObject(object) || isArray(object)) {
+    // A Date, Map or Set is an object to `isObject`, and spreading one yields {},
+    // so they are passed through whole rather than flattened.
+    if (isArray(object) || (isObject(object) && !isDate(object) &&
+      !isMap(object) && !isSet(object))
+    ) {
       let newObject = isArray(object) ? [ ...object ] : { ...object };
       if (!bottomUp) { newObject = fn(newObject, pointer, rootObject); }
       for (const key of Object.keys(newObject)) {


### PR DESCRIPTION
## Summary

Three JSON Pointer defects in one file, phase 1 of the execution plan, findings 17, 18 and 20.

## Changes

`setCopy` was missing the length guard `set()` carries, so an empty pointer left `lastKey` undefined and wrote a property literally named `undefined` rather than rejecting the pointer. `remove` treated a Map as a plain object and called `delete` on it, which does nothing to Map entries, so the key survived and `has()` went on reporting it. `forEachDeepCopy` spread anything `isObject()` accepted, and a Date, Map or Set spreads to `{}`, so any of the three inside a copied structure came back empty; they are passed through whole now while plain objects and arrays are still walked.

## Release impact

Behaviour fixes in `@ajsf/core`, due at 18.1.0 with the rest of phase 1.

## Validation

2,132 core specs pass with eight added, and the corpus does not move any of the 400, as predicted: none of these three have a call site the harness reaches.

## Compatibility

Three existing tests recorded the old behaviour and named it, including "should return an empty object for a Date because spreading loses it". They pinned the defects rather than the contract, so they are updated rather than worked around. A consumer relying on `setCopy` writing an `undefined` key, or on a Date flattening to `{}`, would see a change; both look like defects rather than contracts.