### PR TITLE
fix(core): make checkboxes work with non-string enum values

### DIFF
--- a/projects/ajsf-core/src/lib/widget-library/checkboxes.component.spec.ts
+++ b/projects/ajsf-core/src/lib/widget-library/checkboxes.component.spec.ts
@@ -1,0 +1,46 @@
+import { CheckboxesComponent } from './checkboxes.component';
+
+describe('CheckboxesComponent updateValue', () => {
+  const makeComponent = (values: any[]) => {
+    const component = new CheckboxesComponent(null as any);
+    component.checkboxList = values.map(value => ({ name: `${value}`, value, checked: false }));
+    (component as any).boundControl = false;
+    return component;
+  };
+
+  const clickOn = (component: any, item: any, checked = true) =>
+    component.updateValue({ target: { value: `${item.value}`, checked } }, item);
+
+  // The DOM coerces [value] to a string, so a numeric or boolean enum never
+  // matched the stored value and every click was silently ignored.
+  it('checks a numeric enum item', () => {
+    const component = makeComponent([1, 2, 3]);
+    clickOn(component, component.checkboxList[1]);
+    expect(component.checkboxList.map(i => i.checked)).toEqual([false, true, false]);
+  });
+
+  it('checks a boolean enum item', () => {
+    const component = makeComponent([true, false]);
+    clickOn(component, component.checkboxList[0]);
+    expect(component.checkboxList[0].checked).toBe(true);
+  });
+
+  it('still checks a string enum item', () => {
+    const component = makeComponent(['a', 'b']);
+    clickOn(component, component.checkboxList[0]);
+    expect(component.checkboxList.map(i => i.checked)).toEqual([true, false]);
+  });
+
+  it('unchecks on a second click', () => {
+    const component = makeComponent([1, 2]);
+    clickOn(component, component.checkboxList[0], true);
+    clickOn(component, component.checkboxList[0], false);
+    expect(component.checkboxList[0].checked).toBe(false);
+  });
+
+  it('matches by stringified value when no item is supplied', () => {
+    const component: any = makeComponent([1, 2, 3]);
+    component.updateValue({ target: { value: '3', checked: true } });
+    expect(component.checkboxList.map(i => i.checked)).toEqual([false, false, true]);
+  });
+});

--- a/projects/ajsf-core/src/lib/widget-library/checkboxes.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/checkboxes.component.ts
@@ -29,7 +29,7 @@ import { JsonSchemaFormService, TitleMapItem } from '../json-schema-form.service
           [name]="checkboxItem?.name"
           [readonly]="options?.readonly ? 'readonly' : null"
           [value]="checkboxItem.value"
-          (change)="updateValue($event)">
+          (change)="updateValue($event, checkboxItem)">
         <span [innerHTML]="checkboxItem.name"></span>
       </label>
     </div>
@@ -51,7 +51,7 @@ import { JsonSchemaFormService, TitleMapItem } from '../json-schema-form.service
             [name]="checkboxItem?.name"
             [readonly]="options?.readonly ? 'readonly' : null"
             [value]="checkboxItem.value"
-            (change)="updateValue($event)">
+            (change)="updateValue($event, checkboxItem)">
           <span [innerHTML]="checkboxItem?.name"></span>
         </label>
       </div>
@@ -91,10 +91,17 @@ export class CheckboxesComponent implements OnInit {
     }
   }
 
-  updateValue(event) {
-    for (const checkboxItem of this.checkboxList) {
-      if (event.target.value === checkboxItem.value) {
-        checkboxItem.checked = event.target.checked;
+  updateValue(event, checkboxItem?: any) {
+    if (checkboxItem) {
+      checkboxItem.checked = event.target.checked;
+    } else {
+      // The DOM coerces [value] to a string, so comparing it against a number or
+      // boolean from the enum never matched and every click was ignored. The
+      // template passes the item now; this path remains for external callers.
+      for (const item of this.checkboxList) {
+        if (event.target.value === `${item.value}`) {
+          item.checked = event.target.checked;
+        }
       }
     }
     if (this.boundControl) {


### PR DESCRIPTION
## Summary

A checkbox list built from a numeric or boolean enum ignored every click. Phase 1 of the execution plan, finding 4.

## Changes

The change handler compared `event.target.value` against the stored value with `===`. Angular binds `[value]` on a native input, which the DOM coerces to a string, so for enum `[1, 2, 3]` the comparison was `'1' === 1` and no item was ever marked checked; every click wrote back an unchanged list. The template already had the item in scope, so it now passes it to the handler and the comparison goes away. The string path remains for anyone calling `updateValue` directly, comparing stringified, and the added parameter is optional so the existing one-argument signature still works.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.1.0 with the rest of phase 1. `@ajsf/material` is unaffected: it binds `ngModel` and never compares.

## Validation

2,137 core specs pass with five added covering numeric, boolean and string enums, unchecking, and the direct-call path. The corpus does not move, as predicted: the harness simulates no clicks, so it cannot see this either way.

## Compatibility

`updateValue` keeps its public signature; the item is an optional second parameter. Nothing that worked before changes, because for these enums nothing worked.