### PR TITLE
fix(core): combine a titleMap group whose name recurs

### DIFF
--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1475,3 +1475,45 @@ describe('buildLayout', () => {
     });
   });
 });
+
+describe('buildTitleMap, recurring group names', () => {
+  // buildTitleMap mutates the objects it is given: the flattening branch does
+  // `delete title.group`. A fresh fixture per test, or a shared one leaks.
+  const grouped = () => [
+    { group: 'A', name: 'a1', value: 1 },
+    { group: 'B', name: 'b1', value: 2 },
+    { group: 'A', name: 'a2', value: 3 },
+  ];
+
+  it('combines a group name that recurs non-adjacently', () => {
+    const result: any = buildTitleMap(grouped(), null, true, false);
+    expect(result.map((g: any) => g.group)).toEqual(['A', 'B']);
+    expect(result[0].items.map((i: any) => i.value)).toEqual([1, 3]);
+    expect(result[1].items.map((i: any) => i.value)).toEqual([2]);
+  });
+
+  it('still combines adjacent repeats', () => {
+    const result: any = buildTitleMap([
+      { group: 'A', name: 'a1', value: 1 },
+      { group: 'A', name: 'a2', value: 2 },
+    ], null, true, false);
+    expect(result.length).toBe(1);
+    expect(result[0].items.map((i: any) => i.value)).toEqual([1, 2]);
+  });
+
+  it('leaves ungrouped entries alongside groups', () => {
+    const result: any = buildTitleMap([
+      { group: 'A', name: 'a1', value: 1 },
+      { name: 'plain', value: 2 },
+      { group: 'A', name: 'a2', value: 3 },
+    ], null, true, false);
+    expect(result.length).toBe(2);
+    expect(result[0].items.map((i: any) => i.value)).toEqual([1, 3]);
+    expect(result[1]).toEqual({ name: 'plain', value: 2 });
+  });
+
+  it('is unchanged when flattening', () => {
+    const result: any = buildTitleMap(grouped(), null, true, true);
+    expect(result.map((i: any) => i.name)).toEqual(['A: a1', 'B: b1', 'A: a2']);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -1044,12 +1044,16 @@ export function buildTitleMap(
     } else {
       newTitleMap = newTitleMap.reduce((groupTitleMap, title) => {
         if (hasOwn(title, 'group')) {
-          if (title.group !== (groupTitleMap[groupTitleMap.length - 1] || {}).group) {
-            groupTitleMap.push({ group: title.group, items: title.items || [] });
+          // Matching groups combine, so an already open group is found by name.
+          // Comparing only against the last entry opened a second group whenever
+          // a name recurred with anything in between.
+          let openGroup = groupTitleMap.find(item => item.group === title.group);
+          if (!openGroup) {
+            openGroup = { group: title.group, items: title.items || [] };
+            groupTitleMap.push(openGroup);
           }
           if (hasOwn(title, 'name') && hasOwn(title, 'value')) {
-            groupTitleMap[groupTitleMap.length - 1].items
-              .push({ name: title.name, value: title.value });
+            openGroup.items.push({ name: title.name, value: title.value });
             if (title.value === undefined || title.value === null) {
               hasEmptyValue = true;
             }


### PR DESCRIPTION
## Summary

A titleMap group name that recurred non-adjacently opened a second group instead of combining. Phase 1 of the execution plan, finding 19, the last in that phase.

## Changes

The unflattened branch is commented "combine items from matching groups" but compared each entry's group only against the last one pushed, so a titleMap of A, B, A rendered three groups with A appearing twice. The group is now looked up by name. Adjacent repeats behave exactly as before, since the last entry is also found by name.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.1.0 with the rest of phase 1.

## Validation

2,141 core specs pass with four added, covering the non-adjacent case, adjacent repeats, ungrouped entries mixed with groups, and the flattened path being untouched. The corpus does not move, as predicted: both of its grouped titleMaps repeat adjacently.

## Compatibility

Only a titleMap with a non-adjacent repeat changes, and it changes from a duplicated group to a combined one, which is what the code says it intends. Writing the tests surfaced that `buildTitleMap` mutates the objects it is given, because the flattening branch does `delete title.group`; that is left alone here and noted for later.