### PR TITLE
fix(core): stop an empty array item list throwing

### DIFF
--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1517,3 +1517,32 @@ describe('buildTitleMap, recurring group names', () => {
     expect(result.map((i: any) => i.name)).toEqual(['A: a1', 'B: b1', 'A: a2']);
   });
 });
+
+describe('buildLayout, array layout node with no items', () => {
+  // The branch below reads items[0] on every line, so an empty list threw and
+  // took the entire form with it rather than losing one field.
+  it('does not throw when an array layout node ends up with no items', () => {
+    const jsf = makeJsf({
+      schema: {
+        type: 'object',
+        properties: { things: { type: 'array', items: { type: 'string' } } },
+      },
+      layout: [{ key: 'things', type: 'array', items: [] }],
+    });
+
+    expect(() => buildLayout(jsf, widgetLibrary)).not.toThrow();
+  });
+
+  it('still builds an array layout node that has items', () => {
+    const jsf = makeJsf({
+      schema: {
+        type: 'object',
+        properties: { things: { type: 'array', items: { type: 'string' } } },
+      },
+      layout: [{ key: 'things', type: 'array', items: ['things/-'] }],
+    });
+
+    const result: any = buildLayout(jsf, widgetLibrary);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -328,7 +328,9 @@ export function buildLayout(jsf, widgetLibrary) {
               widget: widgetLibrary.getWidget('section'),
             });
           }
-        } else {
+        // Every statement below reads items[0], so an empty list has nothing to
+        // do here. Falling through threw and took the whole form with it.
+        } else if (newNode.items.length) {
           // TODO: Fix to hndle multiple items
           newNode.items[0].arrayItem = true;
           if (!newNode.items[0].dataPointer) {


### PR DESCRIPTION
## Summary

An array layout node whose item list came out empty threw and took the whole form with it. Phase 2 of the execution plan, finding 16.

## Changes

Every statement in the single-item branch reads `items[0]`, but the branch was reached on length 0 as well as length 1, so it threw. It is now guarded on the list being non-empty. The multi-item branch above and the add-button block below already handle an empty list.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.2.0 with the rest of phase 2.

## Validation

2,139 core specs pass with two added. The corpus does not move, as predicted: no example schema produces an empty item list, so the baseline cannot see this and unit tests carry it instead. The new test was confirmed to fail against the unguarded branch rather than only passing with it.

## Compatibility

Only a layout that throws today changes, and it changes to rendering.