### PR TITLE
docs: say what a release pull request should contain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ What was run and what it reported. Past tense, concrete numbers.
 
 Add `## Compatibility` when the public API or a consumer visible option is involved.
 
+**A release pull request describes the release, not the work being released.** The
+bump carries only a version change, and every fix in it already had its own reviewed
+pull request. Re-narrating them puts the reviewer's attention in the wrong place and is
+how a 95 word description becomes 254. Say what publishes, at what version, and that
+main was verified. Leave `## Compatibility` out unless the bump itself moves a peer
+range: the notes belong on the pull request that made the change.
+
 **Target 100 to 150 words.** PRs #361 to #372 run 96 to 156 after being rewritten by hand; the originals averaged 314 and were called out as much longer than needed.
 
 ⚠️ **No tables, no code fences, no warning symbols, no bold mid-sentence.** All twelve rewritten descriptions contain zero of each. Before and after output, version tables and command transcripts belong in the commit body or a review comment, not here.


### PR DESCRIPTION
## Summary

Records what a release pull request should contain, after the 18.1.0 description ran to 254 words against a 100 to 150 target.

## Changes

Adds a rule that a release pull request describes the release rather than the work being released, since every fix in a bump already had its own reviewed pull request. Says to leave Compatibility out unless the bump itself moves a peer range.

## Release impact

No release. Documentation only.

## Validation

The 18.1.0 description was rewritten under the new rule and came to 95 words from 254, with the same facts.