### PR TITLE
docs: settle defaultDraft on draft 7 and drop sniffing

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -103,10 +103,13 @@ revisited alone with a full corpus run.
 
 ## Three decisions
 
-**Does the property level `required: true` collection stay ungated?** It has no
-draft condition today. Ungated, `defaultDraft` flips 10 baseline entries. Behind
-a draft gate it flips 29, and 9 of the 80 corpus schemas stop requiring anything.
-Recommend ungated, which is also the smaller change.
+**Decided 2026-08-17: sniffing goes, `defaultDraft` defaults to draft 7, and the
+`required: true` collection stays ungated.** Draft 7 as a literal rather than "the
+newest supported" is what keeps the 2019-09 and 2020-12 engines additive, and ajv
+6.12.6 already validates draft 7, so this does not wait for ajv 8. The earlier
+figure of 9 corpus schemas carrying property level `required: true` was wrong: a
+raw grep counted the layout node feature and the JSONForm shorthand as well. It
+reaches 3 of the 80.
 
 **Patch findings 9 and 10 now, or wait for phase 10?** Roughly twelve lines that
 phase 10 deletes. Recommend patching, because the specs proving them are the

--- a/docs/json-schema-drafts.md
+++ b/docs/json-schema-drafts.md
@@ -73,9 +73,24 @@ it finds. Measured:
 The middle case is the problem. One `optional: true` anywhere makes every other
 property required, and nothing in the schema asked for that.
 
-Replace sniffing with a `defaultDraft` option, defaulting to the newest draft
-supported. `$schema` always wins when present. Sniffing then either goes, or
-survives only behind an explicit opt in for consumers who rely on it today.
+Replace sniffing with a `defaultDraft` option defaulting to **draft 7**, decided
+2026-08-17. `$schema` always wins when present. Sniffing goes entirely rather
+than surviving behind an opt in.
+
+Draft 7 is a literal rather than "the newest draft supported", and that is the
+load bearing part. If the default tracked the newest engine, adding the 2019-09
+and 2020-12 engines would silently reinterpret every schema that declares no
+`$schema`, which is 75 of the 80 examples, and each new engine would become a
+breaking change. Pinned to a literal, adding an engine is additive and can ship
+at a minor.
+
+It also costs nothing to schedule: ajv 6.12.6 already validates draft 7
+natively, so `defaultDraft` does not have to wait for the ajv 8 move.
+
+The `required: true` collection is not inference and stays, ungated. It converts
+a draft 3 property keyword into the array shape the form builder needs, three of
+the 80 examples use it, and removing it would loosen forms silently rather than
+error.
 
 This matches how JSON Schema itself reads an absent `$schema`: the newest
 version the tool supports, not a guess from the contents.


### PR DESCRIPTION
## Summary

Settles the open decision on draft handling: sniffing goes entirely, `defaultDraft` replaces it, and the default is the literal draft 7.

## Changes

Records that `$schema` always wins when present and that inference is removed rather than kept behind an opt in, since one `optional: true` anywhere currently makes the converter infer draft 2 and mark every other property required. Draft 7 is pinned as a literal rather than tracking the newest supported draft, which keeps later engines additive. The `required: true` collection stays ungated: it is a conversion rather than an inference. Corrects the figure for property level `required: true` from 9 examples to 3.

## Release impact

No release. Documentation only. The change it describes is breaking and ships at 19.0.0.

## Validation

Confirmed that ajv 6.12.6 validates draft 7 natively, so this does not wait for the ajv 8 move.