### PR TITLE
fix(core): stop a recursive array dropping its data

### DIFF
--- a/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
@@ -433,15 +433,26 @@ describe('form-group.functions', () => {
       expect(result.controls.length).toBe(2);
     });
 
-    it('skips filling the array when the list item pointer is recursive', () => {
+    it('fills a recursive array from the supplied data', () => {
+      // The guard here never admitted a recursive array, so every supplied item
+      // was dropped and patchValue could not add them back to an empty FormArray.
       const jsf = makeJsf(
         { type: 'array', items: { type: 'string' } },
         { dataRecursiveRefMap: new Map<string, string>([['/-', '']]) }
       );
       const result: any = buildFormGroupTemplate(jsf, ['a', 'b']);
 
-      expect(result.controls).toEqual([]);
+      expect(result.controls.length).toBe(2);
       expect(Object.keys(jsf.templateRefLibrary)).toEqual(['']);
+    });
+
+    it('still creates no controls for a recursive array with no data', () => {
+      const jsf = makeJsf(
+        { type: 'array', items: { type: 'string' } },
+        { dataRecursiveRefMap: new Map<string, string>([['/-', '']]) }
+      );
+
+      expect(buildFormGroupTemplate(jsf, null).controls).toEqual([]);
     });
 
     it('throws when additionalItems is given without items', () => {

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.ts
@@ -214,7 +214,10 @@ export function buildFormGroupTemplate(
         }
         // const itemOptions = jsf.dataMap.get(itemRefPointer) || new Map();
         const itemOptions = nodeOptions;
-        if (!itemRecursive || hasOwn(validators, 'required')) {
+        // validators never carries 'required' here, the parent writes that later, so
+        // for a recursive array this was always false and every supplied item was
+        // dropped. Supplied data is finite, so filling from it still terminates.
+        if (!itemRecursive || hasOwn(validators, 'required') || isArray(nodeValue)) {
           const arrayLength = Math.min(Math.max(
             itemRecursive ? 0 :
               (itemOptions.get('tupleItems') + itemOptions.get('listItems')) || 0,


### PR DESCRIPTION
## Summary

A self recursive array silently lost every item of the data supplied to it. Phase 2 of the execution plan, finding 7.

## Changes

The guard that fills an array from supplied data read `!itemRecursive || hasOwn(validators, 'required')`, and `validators` never carries `required` at that point, because the parent writes it later through `setRequiredFields`. For a recursive array the condition was therefore always false, no controls were built, and `patchValue` could not add items to the empty FormArray afterwards. Supplied data is now admitted into the condition, which terminates because the data is finite even though the schema it recurses through is not.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.2.0.

## Validation

2,144 core specs pass and the 400 case corpus does not move, as predicted before the run. An existing test named the defect as a feature, "skips filling the array when the list item pointer is recursive", so it pinned the bug rather than a contract and was replaced by one asserting the items arrive.

## Compatibility

A form whose data contains items for a recursive array now renders them. Nothing that rendered before changes.