### PR TITLE
fix(core): enforce exclusive bounds and validate nullable types

### DIFF
--- a/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
@@ -127,14 +127,14 @@ describe('form-group.functions', () => {
       });
     });
 
-    it('collects numeric validators including the exclusive flag', () => {
+    it('collects numeric validators, naming the exclusive bound', () => {
       const result: any = buildFormGroupTemplate(makeJsf({
         type: 'integer', minimum: 1, exclusiveMinimum: true, maximum: 9, multipleOf: 2,
       }));
 
       expect(result.validators).toEqual({
-        minimum: [1, true],
-        maximum: [9, false],
+        exclusiveMinimum: [1],
+        maximum: [9],
         multipleOf: [2],
         type: ['integer'],
       });

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
@@ -1019,20 +1019,20 @@ describe('JSON Schema functions', () => {
       )).toEqual({ pattern: ['^a'], format: ['email'], minLength: [1], maxLength: [5] });
     });
 
-    it('collects the number validators with an exclusive flag and the type itself', () => {
+    it('collects the number validators and the type itself', () => {
       expect(getControlValidators({ type: 'number', minimum: 0, maximum: 10, multipleOf: 2 }))
-        .toEqual({ minimum: [0, false], maximum: [10, false], multipleOf: [2], type: ['number'] });
+        .toEqual({ minimum: [0], maximum: [10], multipleOf: [2], type: ['number'] });
     });
 
     it('marks the limits exclusive when the exclusive keywords are true', () => {
       expect(getControlValidators({
         type: 'number', minimum: 0, exclusiveMinimum: true, maximum: 9, exclusiveMaximum: true,
-      })).toEqual({ minimum: [0, true], maximum: [9, true], type: ['number'] });
+      })).toEqual({ exclusiveMinimum: [0], exclusiveMaximum: [9], type: ['number'] });
     });
 
     it('handles the integer type the same way as number', () => {
       expect(getControlValidators({ type: 'integer', minimum: 1 }))
-        .toEqual({ minimum: [1, false], type: ['integer'] });
+        .toEqual({ minimum: [1], type: ['integer'] });
     });
 
     it('collects the object validators', () => {
@@ -1489,5 +1489,38 @@ describe('JSON Schema functions', () => {
       // BUG: schema.type is read with no guard.
       expect(() => fixRequiredArrayProperties(null)).toThrow();
     });
+  });
+});
+
+describe('getControlValidators, exclusive bounds and nullable types', () => {
+  it('emits an exclusiveMinimum validator for the draft 6 numeric form', () => {
+    expect(getControlValidators({ type: 'number', exclusiveMinimum: 5 }))
+      .toEqual({ exclusiveMinimum: [5], type: ['number'] } as any);
+    expect(getControlValidators({ type: 'number', exclusiveMaximum: 9 }))
+      .toEqual({ exclusiveMaximum: [9], type: ['number'] } as any);
+  });
+
+  it('emits an exclusive validator for the draft 4 boolean form', () => {
+    // The flag used to be passed as a second argument JsonValidators.minimum does
+    // not take, so the bound was enforced inclusively.
+    expect(getControlValidators({ type: 'number', minimum: 5, exclusiveMinimum: true }))
+      .toEqual({ exclusiveMinimum: [5], type: ['number'] } as any);
+  });
+
+  it('still emits an inclusive bound when nothing says otherwise', () => {
+    expect(getControlValidators({ type: 'number', minimum: 5 }))
+      .toEqual({ minimum: [5], type: ['number'] } as any);
+  });
+
+  it('keeps the validators of a nullable type', () => {
+    expect(getControlValidators({ type: ['string', 'null'], minLength: 2 }))
+      .toEqual({ minLength: [2] } as any);
+    expect(getControlValidators({ type: ['number', 'null'], minimum: 1 }))
+      .toEqual({ minimum: [1], type: [['number', 'null']] } as any);
+  });
+
+  it('is unchanged for a plain single type', () => {
+    expect(getControlValidators({ type: 'string', minLength: 2 }))
+      .toEqual({ minLength: [2] } as any);
   });
 });

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
@@ -519,8 +519,12 @@ export function getTitleMapFromOneOf(
 export function getControlValidators(schema) {
   if (!isObject(schema)) { return null; }
   const validators: any = { };
-  if (hasOwn(schema, 'type')) {
-    switch (schema.type) {
+  // A nullable type is an array, for example ['string', 'null'], which matched no
+  // case at all and so produced no validators. Each named type contributes its own.
+  const schemaTypes: any[] = hasOwn(schema, 'type') ?
+    (isArray(schema.type) ? schema.type : [schema.type]) : [];
+  for (const schemaType of schemaTypes) {
+    switch (schemaType) {
       case 'string':
         forEach(['pattern', 'format', 'minLength', 'maxLength'], (prop) => {
           if (hasOwn(schema, prop)) { validators[prop] = [schema[prop]]; }
@@ -530,9 +534,20 @@ export function getControlValidators(schema) {
         forEach(['Minimum', 'Maximum'], (ucLimit) => {
           const eLimit = 'exclusive' + ucLimit;
           const limit = ucLimit.toLowerCase();
+          // The exclusive flag used to be passed as a second argument, which
+          // JsonValidators.minimum does not take, so it was dropped and the bound
+          // was enforced inclusively. Emit the exclusive validator by name instead.
           if (hasOwn(schema, limit)) {
-            const exclusive = hasOwn(schema, eLimit) && schema[eLimit] === true;
-            validators[limit] = [schema[limit], exclusive];
+            if (hasOwn(schema, eLimit) && schema[eLimit] === true) {
+              validators[eLimit] = [schema[limit]];
+            } else {
+              validators[limit] = [schema[limit]];
+            }
+          }
+          // Draft 6 onward writes the bound itself into exclusiveMinimum, and with
+          // no 'minimum' alongside it there was no validator at all.
+          if (isNumber(schema[eLimit], 'strict')) {
+            validators[eLimit] = [schema[eLimit]];
           }
         });
         forEach(['multipleOf', 'type'], (prop) => {
@@ -549,7 +564,7 @@ export function getControlValidators(schema) {
           if (hasOwn(schema, prop)) { validators[prop] = [schema[prop]]; }
         });
       break;
-    }
+      }
   }
   if (hasOwn(schema, 'enum')) { validators.enum = [schema.enum]; }
   return validators;


### PR DESCRIPTION
## Summary

Two defects in `getControlValidators`, phase 3 of the execution plan, findings 9 and 10.

## Changes

An exclusive bound was never enforced: the flag was passed as a second argument to `JsonValidators.minimum`, which takes one, so it was dropped and the bound was checked inclusively. The draft 6 numeric form, where the bound lives in `exclusiveMinimum` with no `minimum` beside it, produced no validator at all, because the emit was keyed on `hasOwn(schema, 'minimum')`. Both exclusive validators already existed and are now emitted by name. Separately, a nullable type lost every validator, because the branch switched on `schema.type` as a string and `['string', 'null']` matched no case; each named type now contributes its own.

## Release impact

Behaviour fixes in `@ajsf/core`, due at 18.2.0.

## Validation

2,149 core specs pass and the 400 case corpus does not move. That is by construction rather than luck: `isValid` comes from ajv over the whole document and `formGroup.valid` is read nowhere in the library, so the corpus is blind to control level validators and unit tests carry this instead.

## Compatibility

A schema using `exclusiveMinimum` or `exclusiveMaximum`, or a nullable type with constraints, now rejects values it previously accepted. Four existing tests recorded the two argument shape and were updated.