### PR TITLE
fix(core): build array items when the layout only names the key

### DIFF
--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1546,3 +1546,47 @@ describe('buildLayout, array layout node with no items', () => {
     expect(result.length).toBeGreaterThan(0);
   });
 });
+
+describe('buildLayout, array named by key with no items in the layout', () => {
+  const arraySchema = {
+    type: 'object',
+    properties: {
+      things: { type: 'array', items: { type: 'string', title: 'Thing' } },
+    },
+  };
+
+  // The array block was gated on the LAYOUT node carrying 'items', so a layout
+  // entry of { key: 'things' } produced no item nodes and no Add button at all.
+  it('builds item nodes from the schema', () => {
+    const result: any = buildLayout(
+      makeJsf({ schema: arraySchema, layout: [{ key: 'things', type: 'array' }] }),
+      widgetLibrary
+    );
+
+    expect(result.length).toBe(1);
+    expect(Array.isArray(result[0].items)).toBe(true);
+    expect(result[0].items.length).toBeGreaterThan(0);
+  });
+
+  it('adds the Add button', () => {
+    const result: any = buildLayout(
+      makeJsf({ schema: arraySchema, layout: [{ key: 'things', type: 'array' }] }),
+      widgetLibrary
+    );
+
+    const types = result[0].items.map((item: any) => item.type);
+    expect(types).toContain('$ref');
+  });
+
+  it('leaves a layout that supplies its own items alone', () => {
+    const result: any = buildLayout(
+      makeJsf({
+        schema: arraySchema,
+        layout: [{ key: 'things', type: 'array', items: ['things/-'] }],
+      }),
+      widgetLibrary
+    );
+
+    expect(result[0].items.length).toBeGreaterThan(0);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -285,6 +285,23 @@ export function buildLayout(jsf, widgetLibrary) {
       nodeDataMap.set('inputType', newNode.type);
       nodeDataMap.set('widget', newNode.widget);
 
+      // The gate below tests the layout node, not the schema, so a layout entry
+      // that names an array by key carries no 'items' and skipped the whole block:
+      // no item nodes and no Add button. Fill the items from the schema instead.
+      // Only for widgets that render them, since checkboxes ignores items entirely.
+      if (newNode.dataType === 'array' && !hasOwn(newNode, 'items') &&
+        !hasOwn(newNode, 'additionalItems') &&
+        inArray(newNode.type, ['array', 'tabarray'])
+      ) {
+        const fromSchema = buildLayoutFromSchema(
+          jsf, widgetLibrary, nodeValue, schemaPointer, newNode.dataPointer,
+          newNode.arrayItem, newNode.arrayItemType, newNode.options.removable
+        );
+        if (fromSchema && isArray(fromSchema.items) && fromSchema.items.length) {
+          newNode.items = fromSchema.items;
+        }
+      }
+
       if (newNode.dataType === 'array' &&
         (hasOwn(newNode, 'items') || hasOwn(newNode, 'additionalItems'))
       ) {


### PR DESCRIPTION
## Summary

A layout entry of `{ key: 'things' }` for an array typed property rendered no fields and no Add button. Phase 2 of the execution plan, finding 2, the last non-breaking item in the backlog.

## Changes

The array block was gated on the layout node carrying `items` rather than on the schema, so a layout that names an array and leaves its shape to the schema skipped the block entirely. The items are now filled from the schema when the layout supplies none, scoped to the array and tabarray widgets. That scoping is the point: swapping the gate for a schema side test reaches seven nodes in the example schemas whose `items` is undefined, throws on `items.length`, and would move up to thirty corpus entries. Only `section`, `tab` and `tabs` read `layoutNode.items`; `checkboxes` ignores it, and four of those seven resolve to it.

## Release impact

Behaviour fix in `@ajsf/core`, due at 18.3.0.

## Validation

2,152 core specs pass and the 400 case corpus does not move, predicted before the run for the reason above. The three added tests were confirmed to fail with the fallback removed, after a first attempt at that check deleted only a comment and wrongly reported them as passing either way.

## Compatibility

A layout naming an array by key now renders its items, where it previously rendered nothing.