### PR TITLE
build: release 18.3.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^18.2.0",
+    "@ajsf/core": "^18.3.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^18.2.0",
+    "@ajsf/core": "^18.3.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^18.2.0",
+    "@ajsf/core": "^18.3.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^18.2.0",
+    "@ajsf/core": "^18.3.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Bumps all five packages to 18.3.0 for a release of work already merged and reviewed in earlier pull requests. This pull request contains no implementation changes.

## Changes

Updates the version and the internal @ajsf/core range in five package.json files using the repository version script. No source files change.

## Release impact

Publishes @ajsf/core, @ajsf/bootstrap3, @ajsf/bootstrap4, @ajsf/bootstrap5 and @ajsf/material at 18.3.0 under latest. Angular peer ranges remain ^18.0.0. This completes the non breaking findings from the audit; the rest are breaking and wait for 19.0.0.

## Validation

Verified on main at 21a44c3, the exact commit this bumps. Five packages build, 2,497 specs pass, and the 400 case corpus is unchanged.