### PR TITLE
docs: ship each breaking step as a release candidate

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -101,6 +101,33 @@ the freeze runs while the walk does.
 **12. After the freeze lifts.** Removing the deprecated validators, and `hasOwn`
 revisited alone with a full corpus run.
 
+## Every breaking step ships as a release candidate
+
+Decided 2026-08-17. The 19.0.0 work is not one release. Each step is published as
+`19.0.0-rc.N`, which carries a hyphen and so goes to the `next` dist-tag, leaving
+`latest` on 18.3.0 until the series is finished. A consumer opts in with
+`npm install @ajsf/core@next` and can report against a single change rather than
+against a pile of them.
+
+That fixes the order, because `version:set` writes the Angular peer ranges from
+the major it is given. An `rc` numbered 19 cannot be cut while the workspace is
+on Angular 18, so the upgrade comes first:
+
+    19.0.0-rc.0   Angular 19 itself, no behaviour change
+    19.0.0-rc.1   the converter split, ajv 8, draft 7 default, draft 4 floor
+    19.0.0-rc.2   the tuple and array semantics: findings 3, 15
+    19.0.0-rc.3   the allOf merging: findings 11, 12, 14
+    19.0.0-rc.4   the widget and submit changes: findings 5, 6, 21
+    19.0.0        promoted to latest once the series has been exercised
+
+Numbering is per step rather than per finding, so a step can carry more than one
+finding when they share a file. What matters is that a consumer bisecting a
+regression lands on a change small enough to read, which the corpus cannot do for
+them: five of the eight breaking findings are invisible to it.
+
+Only the final stable release moves `latest`. A release candidate that turns out
+wrong is abandoned rather than patched, since nothing depends on it by default.
+
 ## Three decisions
 
 **Decided 2026-08-17: sniffing goes, `defaultDraft` defaults to draft 7, and the

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -115,8 +115,8 @@ on Angular 18, so the upgrade comes first:
 
     19.0.0-rc.0   Angular 19 itself, no behaviour change
     19.0.0-rc.1   the converter split, ajv 8, draft 7 default, draft 4 floor
-    19.0.0-rc.2   the tuple and array semantics: findings 3, 15
-    19.0.0-rc.3   the allOf merging: findings 11, 12, 14
+    19.0.0-rc.2   tuple slot semantics: finding 3
+    19.0.0-rc.3   the array item template and allOf merging: findings 15, 11, 12, 14
     19.0.0-rc.4   the widget and submit changes: findings 5, 6, 21
     19.0.0        promoted to latest once the series has been exercised
 
@@ -127,6 +127,25 @@ them: five of the eight breaking findings are invisible to it.
 
 Only the final stable release moves `latest`. A release candidate that turns out
 wrong is abandoned rather than patched, since nothing depends on it by default.
+
+## Finding 15 needs a test the corpus cannot provide
+
+`layout.functions.ts:385` builds the template a new array item is cloned from out
+of `newNode.items[newNode.items.length - 1]`, the last item that already exists.
+On a tuple array that is the last fixed slot, so the Add button hands back a copy
+of it rather than something built from `additionalItems`.
+
+It moved out of rc.2 for reasons worth recording. The corpus harness simulates no
+clicks and calls no `addItem`, so it measures the first render only and is blind to
+this by construction, and the failure mode is a silently wrong shape for every
+added item. The `forEach` immediately after that line also nulls `_id` and rewrites
+`dataPointer` on the assumption the node was cloned from a sibling; one built from
+the schema arrives with correct pointers and fresh ids already, so that post
+processing has to be revisited rather than inherited.
+
+The fix is to build from `schemaPointer + '/additionalItems'`, or `'/items'` when
+that is a single schema, falling back to the clone when neither exists. It needs a
+component test that presses Add, because nothing existing would catch a regression.
 
 ## Three decisions
 


### PR DESCRIPTION
## Summary

Records that the 19.0.0 work publishes as a series of release candidates rather than one release, and fixes the order that follows from it.

## Changes

Each step becomes `19.0.0-rc.N`, which carries a hyphen and so goes to the `next` dist-tag, leaving `latest` on 18.3.0 until the series finishes. Since `version:set` writes the Angular peer ranges from the major it is given, an rc numbered 19 cannot be cut while the workspace is on Angular 18, so the upgrade is rc.0 and the breaking findings follow in numbered steps grouped by the files they touch.

## Release impact

No release. Documentation only.

## Validation

None needed. The mechanics are the ones already used for 17.2.0-rc.0 and rc.1, where the hyphen routed both to `next` and left `latest` untouched.