### PR TITLE
chore: remove 58 lint suppressions that suppressed nothing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,26 @@ Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all
 
 ⚠️ **Never give the upload step `continue-on-error` or `fail_ci_if_error: false`.** It carried both from #361 to #370 and reported success on every run while Codecov rejected every upload with `Token required because branch is protected`. Nine pull requests merged before anyone noticed. A step that cannot fail cannot tell you it is broken.
 
+## Linting
+
+⚠️ **Nothing is linted.** `npm run lint` runs `ng lint`, `angular.json` has no `lint`
+target, and the command exits with `Cannot find "lint" target`. tslint 6.1.3 is
+installed and never invoked, and tslint itself was deprecated in 2019.
+
+58 `tslint:disable-next-line` comments were removed in that light: they suppressed
+rules nothing was running, so they read as "linted, with exceptions" when the truth
+was "not linted at all".
+
+Whoever wires up `angular-eslint` should configure two things rather than suppress
+them per file, because both are deliberate:
+
+- **Component and directive selectors have no prefix.** `checkbox-widget`,
+  `material-input-widget`, `[ace-editor]`. They are public API, named in consumer
+  layout schemas, and the freeze forbids renaming them, so the selector rules have
+  to be configured to accept them.
+- **`format-regex.constants.ts` holds six regexes past any line limit.** They cannot
+  be shortened without becoming less readable.
+
 ## Constraints
 
 - **The public API is frozen** while the Angular upgrade is in progress. Do not remove or rename any export from a `public_api.ts`. In particular `@ajsf/material` must keep exporting `FlexLayoutRootComponent` and `FlexLayoutSectionComponent`, and the `flex-layout-root-widget`, `flex-layout-section-widget` selectors and the `ng-jsf-flex-layout` widget name must keep working. They appear in consumer layout schemas.

--- a/demo/app/ace-editor.directive.ts
+++ b/demo/app/ace-editor.directive.ts
@@ -7,7 +7,6 @@ import 'brace/theme/tomorrow_night';
 
 
 @Directive({
-    // tslint:disable-next-line:directive-selector
     selector: '[ace-editor]',
     standalone: false
 })

--- a/demo/app/demo-root.component.ts
+++ b/demo/app/demo-root.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'demo-root',
     template: `<router-outlet></router-outlet>`,
     standalone: false

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -10,7 +10,6 @@ import { JsonPointer } from '@ajsf/core';
 const DARK_MODE_KEY = 'ajsf-demo-dark-mode';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'demo',
     templateUrl: 'demo.component.html',
     animations: [
@@ -256,9 +255,10 @@ export class DemoComponent implements OnInit {
         // If entered content is not valid JSON,
         // parse as JavaScript instead to include functions
         const newFormObject: any = null;
-        /* tslint:disable */
+        // Four bundled examples embed JavaScript functions, so they are not JSON
+        // and cannot be parsed. This is the demo only; the library never evals.
+        // eslint-disable-next-line no-eval
         eval('newFormObject = ' + newFormString);
-        /* tslint:enable */
         this.jsonFormObject = newFormObject;
         this.jsonFormValid = true;
       } catch (javascriptError) {

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -5,7 +5,6 @@ import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core'
  * Bootstrap 3 framework for Angular JSON Schema Form.
  */
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'bootstrap-3-framework',
     templateUrl: './bootstrap3-framework.component.html',
     styleUrls: ['./bootstrap3-framework.component.scss'],

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -12,7 +12,6 @@ import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core'
  *
  */
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'bootstrap-4-framework',
     templateUrl: './bootstrap4-framework.component.html',
     styleUrls: ['./bootstrap4-framework.component.scss'],

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -12,7 +12,6 @@ import {JsonSchemaFormService, addClasses, cloneDeep, inArray} from '@ajsf/core'
  *
  */
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'bootstrap-5-framework',
     templateUrl: './bootstrap5-framework.component.html',
     styleUrls: ['./bootstrap5-framework.component.scss'],

--- a/projects/ajsf-core/src/lib/json-schema-form.component.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.component.ts
@@ -71,7 +71,6 @@ export const JSON_SCHEMA_FORM_VALUE_ACCESSOR: any = {
  *  - brace, Browserified Ace editor       http://thlorenz.github.io/brace
  */
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'json-schema-form',
     templateUrl: './json-schema-form.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/ajsf-core/src/lib/shared/format-regex.constants.ts
+++ b/projects/ajsf-core/src/lib/shared/format-regex.constants.ts
@@ -22,7 +22,6 @@ export const jsonSchemaFormatTests = {
   'ipv4': /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
 
   // optimized http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
-  // tslint:disable-next-line:max-line-length
   'ipv6': /^\s*(?:(?:(?:[0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:))|(?:(?:[0-9a-f]{1,4}:){6}(?::[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){5}(?:(?:(?::[0-9a-f]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){4}(?:(?:(?::[0-9a-f]{1,4}){1,3})|(?:(?::[0-9a-f]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){3}(?:(?:(?::[0-9a-f]{1,4}){1,4})|(?:(?::[0-9a-f]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){2}(?:(?:(?::[0-9a-f]{1,4}){1,5})|(?:(?::[0-9a-f]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){1}(?:(?:(?::[0-9a-f]{1,4}){1,6})|(?:(?::[0-9a-f]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[0-9a-f]{1,4}){1,7})|(?:(?::[0-9a-f]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?\s*$/i,
 
   // uri: https://github.com/mafintosh/is-my-json-valid/blob/master/formats.js
@@ -32,23 +31,18 @@ export const jsonSchemaFormatTests = {
   'uri-reference': /^(?:(?:[a-z][a-z0-9+-.]*:)?\/\/)?[^\s]*$/i,
 
   // uri-template: https://tools.ietf.org/html/rfc6570
-  // tslint:disable-next-line:max-line-length
   'uri-template': /^(?:(?:[^\x00-\x20"'<>%\\^`{|}]|%[0-9a-f]{2})|\{[+#./;?&=,!@|]?(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?(?:,(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?)*\})*$/i,
 
   // For the source: https://gist.github.com/dperini/729294
   // For test cases: https://mathiasbynens.be/demo/url-regex
-  // tslint:disable-next-line:max-line-length
   // @todo Delete current URL in favour of the commented out URL rule when this ajv issue is fixed https://github.com/eslint/eslint/issues/7983.
-  // tslint:disable-next-line:max-line-length
   // URL: /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u{00a1}-\u{ffff}0-9]+-?)*[a-z\u{00a1}-\u{ffff}0-9]+)(?:\.(?:[a-z\u{00a1}-\u{ffff}0-9]+-?)*[a-z\u{00a1}-\u{ffff}0-9]+)*(?:\.(?:[a-z\u{00a1}-\u{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$/iu,
-  // tslint:disable-next-line:max-line-length
   'url': /^(?:(?:http[s\u017F]?|ftp):\/\/)(?:(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+(?::(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])*)?@)?(?:(?!10(?:\.[0-9]{1,3}){3})(?!127(?:\.[0-9]{1,3}){3})(?!169\.254(?:\.[0-9]{1,3}){2})(?!192\.168(?:\.[0-9]{1,3}){2})(?!172\.(?:1[6-9]|2[0-9]|3[01])(?:\.[0-9]{1,3}){2})(?:[1-9][0-9]?|1[0-9][0-9]|2[01][0-9]|22[0-3])(?:\.(?:1?[0-9]{1,2}|2[0-4][0-9]|25[0-5])){2}(?:\.(?:[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-4]))|(?:(?:(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+-?)*(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+)(?:\.(?:(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+-?)*(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+)*(?:\.(?:(?:[KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]){2,})))(?::[0-9]{2,5})?(?:\/(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])*)?$/i,
 
   // uuid: http://tools.ietf.org/html/rfc4122
   'uuid': /^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i,
 
   // optimized https://gist.github.com/olmokramer/82ccce673f86db7cda5e
-  // tslint:disable-next-line:max-line-length
   'color': /^\s*(#(?:[\da-f]{3}){1,2}|rgb\((?:\d{1,3},\s*){2}\d{1,3}\)|rgba\((?:\d{1,3},\s*){3}\d*\.?\d+\)|hsl\(\d{1,3}(?:,\s*\d{1,3}%){2}\)|hsla\(\d{1,3}(?:,\s*\d{1,3}%){2},\s*\d*\.?\d+\))\s*$/i,
 
   // JSON-pointer: https://tools.ietf.org/html/rfc6901

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -894,7 +894,6 @@ export class JsonValidators {
   static email(control: AbstractControl): ValidationErrors|null {
     if (!control) { return null; }
     const EMAIL_REGEXP =
-      // tslint:disable-next-line:max-line-length
       /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
     return EMAIL_REGEXP.test(control.value) ? null : { 'email': true };
   }

--- a/projects/ajsf-core/src/lib/widget-library/add-reference.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/add-reference.component.ts
@@ -8,7 +8,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'add-reference-widget',
     template: `
     <button *ngIf="showAddButton"

--- a/projects/ajsf-core/src/lib/widget-library/button.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/button.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'button-widget',
     template: `
     <div

--- a/projects/ajsf-core/src/lib/widget-library/checkbox.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/checkbox.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'checkbox-widget',
     template: `
     <label

--- a/projects/ajsf-core/src/lib/widget-library/checkboxes.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/checkboxes.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService, TitleMapItem } from '../json-schema-form.service
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'checkboxes-widget',
     template: `
     <label *ngIf="options?.title"

--- a/projects/ajsf-core/src/lib/widget-library/file.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/file.component.ts
@@ -6,7 +6,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'file-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/hidden.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/hidden.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'hidden-widget',
     template: `
     <input *ngIf="boundControl"

--- a/projects/ajsf-core/src/lib/widget-library/input.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/input.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'input-widget',
     template: `
     <div [class]="options?.htmlClass || ''">

--- a/projects/ajsf-core/src/lib/widget-library/message.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/message.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'message-widget',
     template: `
     <span *ngIf="message"

--- a/projects/ajsf-core/src/lib/widget-library/none.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/none.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'none-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/number.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/number.component.ts
@@ -4,7 +4,6 @@ import { AbstractControl } from '@angular/forms';
 import { JsonSchemaFormService } from '../json-schema-form.service';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'number-widget',
     template: `
     <div [class]="options?.htmlClass || ''">

--- a/projects/ajsf-core/src/lib/widget-library/one-of.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/one-of.component.ts
@@ -6,7 +6,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'one-of-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/orderable.directive.ts
+++ b/projects/ajsf-core/src/lib/widget-library/orderable.directive.ts
@@ -30,7 +30,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
  * - drop: remove 'drag-target-...' classes from element, move dropped array item
  */
 @Directive({
-    // tslint:disable-next-line:directive-selector
     selector: '[orderable]',
     standalone: false
 })

--- a/projects/ajsf-core/src/lib/widget-library/radios.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/radios.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'radios-widget',
     template: `
     <label *ngIf="options?.title"

--- a/projects/ajsf-core/src/lib/widget-library/root.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/root.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'root-widget',
     template: `
     <div *ngFor="let layoutItem of layout; let i = index"

--- a/projects/ajsf-core/src/lib/widget-library/section.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/section.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'section-widget',
     template: `
     <div *ngIf="containerType === 'div'"

--- a/projects/ajsf-core/src/lib/widget-library/select-framework.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/select-framework.component.ts
@@ -6,7 +6,6 @@ import {
 import { JsonSchemaFormService } from '../json-schema-form.service';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'select-framework-widget',
     template: `<div #widgetContainer></div>`,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/select-widget.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/select-widget.component.ts
@@ -6,7 +6,6 @@ import {
 import { JsonSchemaFormService } from '../json-schema-form.service';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'select-widget-widget',
     template: `<div #widgetContainer></div>`,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/select.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/select.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'select-widget',
     template: `
     <div

--- a/projects/ajsf-core/src/lib/widget-library/submit.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/submit.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'submit-widget',
     template: `
     <div

--- a/projects/ajsf-core/src/lib/widget-library/tab.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/tab.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'tab-widget',
     template: `
     <div [class]="options?.htmlClass || ''">

--- a/projects/ajsf-core/src/lib/widget-library/tabs.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/tabs.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'tabs-widget',
     template: `
     <ul

--- a/projects/ajsf-core/src/lib/widget-library/template.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/template.component.ts
@@ -11,7 +11,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'template-widget',
     template: `<div #widgetContainer></div>`,
     standalone: false

--- a/projects/ajsf-core/src/lib/widget-library/textarea.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/textarea.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'textarea-widget',
     template: `
     <div

--- a/projects/ajsf-material/src/lib/material-design-framework.component.ts
+++ b/projects/ajsf-material/src/lib/material-design-framework.component.ts
@@ -2,7 +2,6 @@ import {ChangeDetectorRef, Component, Input, OnChanges, OnInit} from '@angular/c
 import {cloneDeep, isDefined, JsonSchemaFormService} from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-design-framework',
     templateUrl: './material-design-framework.component.html',
     styleUrls: ['./material-design-framework.component.scss'],

--- a/projects/ajsf-material/src/lib/widgets/flex-layout-root.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/flex-layout-root.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'flex-layout-root-widget',
     template: `
     <div *ngFor="let layoutNode of layout; let i = index"

--- a/projects/ajsf-material/src/lib/widgets/flex-layout-section.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/flex-layout-section.component.ts
@@ -3,7 +3,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'flex-layout-section-widget',
     template: `
     <div *ngIf="containerType === 'div'"

--- a/projects/ajsf-material/src/lib/widgets/material-add-reference.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-add-reference.component.ts
@@ -3,7 +3,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-add-reference-widget',
     template: `
     <section [class]="options?.htmlClass || ''" align="end">

--- a/projects/ajsf-material/src/lib/widgets/material-button-group.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-button-group.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService, buildTitleMap } from '@ajsf/core';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-button-group-widget',
     template: `
     <div>

--- a/projects/ajsf-material/src/lib/widgets/material-button.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-button.component.ts
@@ -3,7 +3,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService, hasOwn } from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-button-widget',
     template: `
     <div class="button-row" [class]="options?.htmlClass || ''">

--- a/projects/ajsf-material/src/lib/widgets/material-checkbox.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-checkbox.component.ts
@@ -3,7 +3,6 @@ import { AbstractControl } from '@angular/forms';
 import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-checkbox-widget',
     template: `
     <mat-checkbox *ngIf="boundControl && !showSlideToggle"

--- a/projects/ajsf-material/src/lib/widgets/material-checkboxes.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-checkboxes.component.ts
@@ -7,7 +7,6 @@ import { JsonSchemaFormService, TitleMapItem } from '@ajsf/core';
 // https://material.angular.io/components/list/overview
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-checkboxes-widget',
     template: `
     <div>

--- a/projects/ajsf-material/src/lib/widgets/material-chip-list.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-chip-list.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-chip-list-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-material/src/lib/widgets/material-datepicker.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-datepicker.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-datepicker-widget',
     template: `
     <mat-form-field [appearance]="options?.appearance || matFormFieldDefaultOptions?.appearance || 'fill'"

--- a/projects/ajsf-material/src/lib/widgets/material-file.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-file.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-file-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-material/src/lib/widgets/material-input.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-input.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-input-widget',
     template: `
     <mat-form-field [appearance]="options?.appearance || matFormFieldDefaultOptions?.appearance || 'fill'"

--- a/projects/ajsf-material/src/lib/widgets/material-number.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-number.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-number-widget',
     template: `
     <mat-form-field [appearance]="options?.appearance || matFormFieldDefaultOptions?.appearance || 'fill'"

--- a/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-one-of-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-material/src/lib/widgets/material-radios.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-radios.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService, buildTitleMap } from '@ajsf/core';
 
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-radios-widget',
     template: `
     <div>

--- a/projects/ajsf-material/src/lib/widgets/material-select.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-select.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService, buildTitleMap, isArray } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-select-widget',
     template: `
     <mat-form-field

--- a/projects/ajsf-material/src/lib/widgets/material-slider.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-slider.component.ts
@@ -3,7 +3,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-slider-widget',
     template: `
     <mat-slider discrete *ngIf="boundControl"

--- a/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
@@ -5,7 +5,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 // TODO: Add this control
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-stepper-widget',
     template: ``,
     standalone: false

--- a/projects/ajsf-material/src/lib/widgets/material-tabs.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-tabs.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-tabs-widget',
     template: `
     <nav mat-tab-nav-bar

--- a/projects/ajsf-material/src/lib/widgets/material-textarea.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-textarea.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
-    // tslint:disable-next-line:component-selector
     selector: 'material-textarea-widget',
     template: `
     <mat-form-field [appearance]="options?.appearance || matFormFieldDefaultOptions?.appearance || 'fill'"


### PR DESCRIPTION
## Summary

`npm run lint` exits with `Cannot find "lint" target`, so none of the 58 `tslint:disable-next-line` comments in the repository were suppressing anything.

## Changes

Removes all 58. They were worse than noise: a file carrying a suppression reads as linted with a documented exception, when the truth is that nothing is checked at all. 48 were `component-selector`, 2 `directive-selector` and 7 `max-line-length`. The one block level `/* tslint:disable */` wrapped an `eval` in the demo and is replaced by a comment explaining why the eval is there, which is the part the code could not express. AGENTS.md records that nothing is linted, and the two things a future `angular-eslint` setup must configure rather than suppress.

## Release impact

No release. Comments only, no code changes.

## Validation

2,152 core specs, 82 bootstrap3, 82 bootstrap4, 93 bootstrap5 and 92 material pass, and both the libraries and the demo build. The widget selectors are unchanged, which matters because they are public API.

## Compatibility

None. No selector, export or behaviour changed.