### PR TITLE
fix(core)!: type a fixed tuple slot as a tuple, not a list

### DIFF
--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1590,3 +1590,39 @@ describe('buildLayout, array named by key with no items in the layout', () => {
     expect(result[0].items.length).toBeGreaterThan(0);
   });
 });
+
+describe('buildLayout, tuple slots versus list items', () => {
+  // The framework components read arrayItemType === 'list' to decide whether to
+  // render the remove control, so a fixed tuple position used to get one.
+  const tupleSchema = {
+    type: 'object',
+    properties: {
+      pair: {
+        type: 'array',
+        items: [{ type: 'string', title: 'First' }, { type: 'string', title: 'Second' }],
+        additionalItems: { type: 'string', title: 'Extra' },
+      },
+    },
+  };
+
+  const build = () => buildLayout(
+    makeJsf({
+      schema: tupleSchema,
+      layout: [{ key: 'pair', type: 'array', items: ['/pair/0', '/pair/1'] }],
+    }),
+    widgetLibrary
+  );
+
+  it('types a fixed slot as a tuple item, not a list item', () => {
+    const items: any[] = (build() as any)[0].items;
+    const slots = items.filter(item => item.arrayItem && item.type !== '$ref');
+    expect(slots.length).toBeGreaterThan(0);
+    slots.forEach(slot => expect(slot.arrayItemType).toBe('tuple'));
+  });
+
+  it('does not mark a fixed slot removable', () => {
+    const items: any[] = (build() as any)[0].items;
+    const slots = items.filter(item => item.arrayItem && item.type !== '$ref');
+    slots.forEach(slot => expect(slot.removable).toBe(false));
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1625,4 +1625,36 @@ describe('buildLayout, tuple slots versus list items', () => {
     const slots = items.filter(item => item.arrayItem && item.type !== '$ref');
     slots.forEach(slot => expect(slot.removable).toBe(false));
   });
+
+  it('types a slot past the tuple as a removable list item', () => {
+    const result: any = buildLayout(
+      makeJsf({
+        schema: tupleSchema,
+        // A third slot on a two item tuple sits in the additionalItems range.
+        layout: [{ key: 'pair', type: 'array', items: ['/pair/0', '/pair/1', '/pair/2'] }],
+      }),
+      widgetLibrary
+    );
+    const slots: any[] = result[0].items
+      .filter((item: any) => item.arrayItem && item.type !== '$ref');
+    const past = slots.filter((slot: any) => slot.arrayItemType === 'list');
+    expect(past.length).toBe(1);
+    expect(past[0].removable).toBe(true);
+  });
+
+  it('leaves a slot alone when the array is not removable', () => {
+    const result: any = buildLayout(
+      makeJsf({
+        schema: tupleSchema,
+        layout: [{
+          key: 'pair', type: 'array', removable: false,
+          items: ['/pair/0', '/pair/1', '/pair/2'],
+        }],
+      }),
+      widgetLibrary
+    );
+    const slots: any[] = result[0].items
+      .filter((item: any) => item.arrayItem && item.type !== '$ref');
+    slots.forEach((slot: any) => expect(slot.removable).toBe(false));
+  });
 });

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -331,10 +331,10 @@ export function buildLayout(jsf, widgetLibrary) {
               // list item once it sits past the tuple, and a tuple position cannot
               // be removed: the framework components read arrayItemType === 'list'
               // to decide whether to render the remove control.
-              const slot = hasOwn(subItem, 'dataPointer') ?
-                Number(subItem.dataPointer.slice(
-                  subItem.dataPointer.lastIndexOf('/') + 1
-                )) : NaN;
+              // String() rather than a guard: a sub item with no dataPointer
+              // reaches this branch too, and 'undefined' gives NaN, which is the
+              // answer a missing pointer should produce.
+              const slot = Number(String(subItem.dataPointer).split('/').pop());
               const tupleSlot = Number.isInteger(slot) &&
                 slot < newNode.options.tupleItems;
               subItem.arrayItemType = tupleSlot ? 'tuple' : 'list';

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -327,9 +327,18 @@ export function buildLayout(jsf, widgetLibrary) {
               arrayItemGroup.unshift(arrayItem);
             } else {
               subItem.arrayItem = true;
-              // TODO: Check schema to get arrayItemType and removable
-              subItem.arrayItemType = 'list';
-              subItem.removable = newNode.options.removable !== false;
+              // A slot addressed by index is a fixed tuple position. It is only a
+              // list item once it sits past the tuple, and a tuple position cannot
+              // be removed: the framework components read arrayItemType === 'list'
+              // to decide whether to render the remove control.
+              const slot = hasOwn(subItem, 'dataPointer') ?
+                Number(subItem.dataPointer.slice(
+                  subItem.dataPointer.lastIndexOf('/') + 1
+                )) : NaN;
+              const tupleSlot = Number.isInteger(slot) &&
+                slot < newNode.options.tupleItems;
+              subItem.arrayItemType = tupleSlot ? 'tuple' : 'list';
+              subItem.removable = !tupleSlot && newNode.options.removable !== false;
             }
           }
           if (arrayItemGroup.length) {


### PR DESCRIPTION
## Summary

A fixed tuple position rendered a remove button that deleted a slot the schema says is fixed. First half of rc.2, finding 3.

## Changes

Every child of an array layout node not addressed through the list placeholder was typed `arrayItemType: 'list'` and marked removable, and those children are exactly the fixed slots. The framework components read `arrayItemType === 'list'` to decide whether to render the remove control, so the button appeared and worked. The comment above those two lines already named what was missing: "TODO: Check schema to get arrayItemType and removable". The slot index now comes from the item's own data pointer and is compared against `options.tupleItems`.

## Release impact

Breaking, due in 19.0.0-rc.2. It withdraws a control that renders today.

## Validation

2,110 core specs pass with two added, and the corpus does not move, as predicted: `countControls` selects inputs and the remove control is a button. The added tests were confirmed to fail against the old typing.

## Compatibility

A form with a tuple typed array loses the remove button on its fixed positions. Positions past the tuple keep it.