### PR TITLE
build: release 19.0.0-rc.2

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "19.0.0-rc.1",
+  "version": "19.0.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.1",
+    "@ajsf/core": "19.0.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "19.0.0-rc.1",
+  "version": "19.0.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.1",
+    "@ajsf/core": "19.0.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "19.0.0-rc.1",
+  "version": "19.0.0-rc.2",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.1",
+    "@ajsf/core": "19.0.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "19.0.0-rc.1",
+  "version": "19.0.0-rc.2",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "19.0.0-rc.1",
+  "version": "19.0.0-rc.2",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.1",
+    "@ajsf/core": "19.0.0-rc.2",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Bumps all five packages to 19.0.0-rc.2 for a release of work already merged and reviewed in earlier pull requests. This pull request contains no implementation changes.

## Changes

Updates the version and the internal @ajsf/core range in five package.json files using the repository version script. No source files change.

## Release impact

Publishes the five packages at 19.0.0-rc.2 to the `next` dist-tag. `latest` stays on 18.3.0. This candidate carries one change: a fixed tuple position no longer renders a remove button.

## Validation

Verified on main at b85594f, the exact commit this bumps. Five packages build, 2,457 specs pass, and the corpus is unchanged at 370 cases.