### PR TITLE
fix(core)!: build a new array item from additionalItems, not the last slot

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -128,24 +128,37 @@ them: five of the eight breaking findings are invisible to it.
 Only the final stable release moves `latest`. A release candidate that turns out
 wrong is abandoned rather than patched, since nothing depends on it by default.
 
-## Finding 15 needs a test the corpus cannot provide
+## Finding 15, fixed at rc.3
 
-`layout.functions.ts:385` builds the template a new array item is cloned from out
-of `newNode.items[newNode.items.length - 1]`, the last item that already exists.
-On a tuple array that is the last fixed slot, so the Add button hands back a copy
-of it rather than something built from `additionalItems`.
+`buildLayout` built the template a new array item is cloned from out of
+`newNode.items[newNode.items.length - 1]`, the last item that already exists. On a
+tuple array that is the last fixed slot, so the Add button handed back a copy of
+it: the measured template for a two slot tuple with `additionalItems` carried
+`title: 'Second'`, `dataPointer: '/pair/1'`, `arrayItemType: 'tuple'` and no
+`options.removable` at all, so every added item duplicated the last fixed slot and
+could not then be removed.
 
-It moved out of rc.2 for reasons worth recording. The corpus harness simulates no
-clicks and calls no `addItem`, so it measures the first render only and is blind to
-this by construction, and the failure mode is a silently wrong shape for every
-added item. The `forEach` immediately after that line also nulls `_id` and rewrites
-`dataPointer` on the assumption the node was cloned from a sibling; one built from
-the schema arrives with correct pointers and fresh ids already, so that post
-processing has to be revisited rather than inherited.
+`buildLayoutFromSchema` already did this correctly, computing
+`schemaPointer + '/additionalItems'` (or `'/items'` when `items` is a single
+schema) and building the node. The two paths had diverged; the fix points the
+custom layout path at the same source.
 
-The fix is to build from `schemaPointer + '/additionalItems'`, or `'/items'` when
-that is a single schema, falling back to the clone when neither exists. It needs a
-component test that presses Add, because nothing existing would catch a regression.
+The clone is kept where it is right. A list array's last item genuinely is the
+template, and only a tuple slot is the wrong thing to copy, so the guard is the
+last item's `arrayItemType === 'tuple'` rather than the array having tuple items.
+The `forEach` that nulls `_id` and slices `dataPointer` runs on the clone branch
+only: a node from `buildLayoutFromSchema` arrives with no id and a relative
+pointer already, so sharing that post processing would have sliced twice.
+
+Seven specs on `buildLayout`, not the component test this section previously
+called for. The template is readable straight out of `layoutRefLibrary`, so no
+click has to be simulated to assert its shape. Five of the seven fail without the
+fix, naming the defect: `'Second'` for `'Extra'`, `'tuple'` for `'list'`,
+`'/pair/1'` unchanged, and `options.removable` undefined. The other two pin the
+clone path that stays.
+
+Corpus delta was predicted at zero on all 370 and measured at zero. The harness
+presses no buttons, so the template is never materialised.
 
 ## Three decisions
 

--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1730,3 +1730,57 @@ describe('buildLayout, the template a new array item is built from', () => {
     expect(() => templateFor(noAdditional, tupleLayout)).not.toThrow();
   });
 });
+
+describe('buildLayout, the item template of a recursive array', () => {
+  // A recursive array stores its template under the shortened pointer and keeps
+  // item pointers relative to it, so both template branches need the recursive
+  // case as well as the plain one.
+  const listSchema = (additional: any) => ({
+    type: 'object',
+    properties: {
+      list: {
+        type: 'array',
+        items: [{ type: 'string', title: 'First' }],
+        ...(additional ? { additionalItems: additional } : {}),
+      },
+    },
+  });
+
+  /**
+   * Points '/tree/children' back at '/tree' so `recursive` is true, and pins the
+   * schema of the shortened pointer to the array, which is what a self
+   * referencing array resolves to.
+   */
+  const recursiveJsf = (schema: any) => makeJsf({
+    schema,
+    layout: [{ key: 'tree.children', type: 'array', items: ['/tree/children/0'] }],
+    dataRecursiveRefMap: new Map([['/tree/children', '/tree']]),
+    dataMap: new Map([['/tree', new Map([['schemaPointer', '/properties/list']])]]),
+  });
+
+  it('marks a schema built template as a recursive reference', () => {
+    const jsf = recursiveJsf(listSchema({ type: 'string', title: 'Extra' }));
+    buildLayout(jsf, widgetLibrary);
+    const template = jsf.layoutRefLibrary['/tree/-'];
+    expect(template).toBeTruthy();
+    expect(template.recursiveReference).toBe(true);
+  });
+
+  it('marks a cloned template as a recursive reference when there is no additionalItems', () => {
+    const jsf = recursiveJsf(listSchema(null));
+    buildLayout(jsf, widgetLibrary);
+    const template = jsf.layoutRefLibrary['/tree/-'];
+    expect(template).toBeTruthy();
+    expect(template.recursiveReference).toBe(true);
+  });
+
+  // BUG: the clone branch rewrites the pointer of every nested item but never
+  // the template's own, so a recursive array's template keeps an absolute
+  // pointer. Pre-existing, and separate from what this change is about.
+  it('leaves a cloned template pointer absolute', () => {
+    const jsf = recursiveJsf(listSchema(null));
+    buildLayout(jsf, widgetLibrary);
+    const template = jsf.layoutRefLibrary['/tree/-'];
+    expect(template.dataPointer.startsWith('/tree')).toBe(true);
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.spec.ts
@@ -1658,3 +1658,75 @@ describe('buildLayout, tuple slots versus list items', () => {
     slots.forEach((slot: any) => expect(slot.removable).toBe(false));
   });
 });
+
+describe('buildLayout, the template a new array item is built from', () => {
+  // The corpus harness presses no buttons, so nothing else here covers the shape
+  // handed back by the Add button.
+  const tupleSchema = {
+    type: 'object',
+    properties: {
+      pair: {
+        type: 'array',
+        items: [{ type: 'string', title: 'First' }, { type: 'string', title: 'Second' }],
+        additionalItems: { type: 'string', title: 'Extra' },
+      },
+    },
+  };
+
+  const templateFor = (schema: any, layout: any[]) => {
+    const jsf = makeJsf({ schema, layout });
+    buildLayout(jsf, widgetLibrary);
+    return jsf.layoutRefLibrary['/pair/-'];
+  };
+
+  const tupleLayout = [{ key: 'pair', type: 'array', items: ['/pair/0', '/pair/1'] }];
+
+  it('builds a list item from additionalItems, not from the last fixed slot', () => {
+    const template = templateFor(tupleSchema, tupleLayout);
+    expect(template).toBeTruthy();
+    expect(template.options.title).toBe('Extra');
+  });
+
+  it('types the added item as a list item so it renders a remove control', () => {
+    expect(templateFor(tupleSchema, tupleLayout).arrayItemType).toBe('list');
+  });
+
+  // Every framework component reads options.removable to decide whether to
+  // render the remove control, so that is the field that has to carry it.
+  it('makes the added item removable', () => {
+    expect(templateFor(tupleSchema, tupleLayout).options.removable).toBe(true);
+  });
+
+  it('does not point the added item at a fixed slot', () => {
+    expect(templateFor(tupleSchema, tupleLayout).dataPointer).not.toBe('/pair/1');
+  });
+
+  it('honours removable false on the array', () => {
+    const template = templateFor(tupleSchema, [{
+      key: 'pair', type: 'array', removable: false, items: ['/pair/0', '/pair/1'],
+    }]);
+    expect(template.options.removable).toBe(false);
+  });
+
+  // A list array's last item genuinely is the template, so that clone is correct
+  // and stays. Only a tuple slot is the wrong thing to copy.
+  it('still clones the last item for an array with no fixed slots', () => {
+    const listSchema = {
+      type: 'object',
+      properties: { pair: { type: 'array', items: { type: 'string', title: 'Tag' } } },
+    };
+    const template = templateFor(listSchema, [{ key: 'pair', type: 'array' }]);
+    expect(template).toBeTruthy();
+    expect(template.arrayItemType).toBe('list');
+  });
+
+  it('falls back to the clone when a tuple array declares no additionalItems', () => {
+    const noAdditional = {
+      type: 'object',
+      properties: {
+        pair: { type: 'array', items: [{ type: 'string' }, { type: 'string' }] },
+      },
+    };
+    expect(() => templateFor(noAdditional, tupleLayout)).not.toThrow();
+  });
+});

--- a/projects/ajsf-core/src/lib/shared/layout.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/layout.functions.ts
@@ -384,19 +384,48 @@ export function buildLayout(jsf, widgetLibrary) {
         }
 
         if (!hasOwn(jsf.layoutRefLibrary, itemRefPointer)) {
-          jsf.layoutRefLibrary[itemRefPointer] =
-            cloneDeep(newNode.items[newNode.items.length - 1]);
-          if (recursive) {
-            jsf.layoutRefLibrary[itemRefPointer].recursiveReference = true;
-          }
-          forEach(jsf.layoutRefLibrary[itemRefPointer], (item, key) => {
-            if (hasOwn(item, '_id')) { item._id = null; }
-            if (recursive) {
-              if (hasOwn(item, 'dataPointer')) {
-                item.dataPointer = item.dataPointer.slice(itemRefPointer.length);
-              }
+          const lastItem = newNode.items[newNode.items.length - 1];
+          // The last existing item is only a template for a new one when it is
+          // itself a list item. On a tuple array it is a fixed slot, so cloning
+          // it gave every added item that slot's schema, title and pointer.
+          const listItemSchemaPointer = isArray(nodeSchema && nodeSchema.items) ?
+            (isObject(nodeSchema.additionalItems) ?
+              schemaPointer + '/additionalItems' : null) :
+            (isObject(nodeSchema && nodeSchema.items) ?
+              schemaPointer + '/items' : null);
+
+          if (lastItem && lastItem.arrayItemType === 'tuple' && listItemSchemaPointer) {
+            // Set to null first to prevent a recursive reference from looping.
+            jsf.layoutRefLibrary[itemRefPointer] = null;
+            jsf.layoutRefLibrary[itemRefPointer] = buildLayoutFromSchema(
+              jsf, widgetLibrary, null,
+              removeRecursiveReferences(
+                listItemSchemaPointer, jsf.schemaRecursiveRefMap, jsf.arrayMap
+              ),
+              recursive ? '' : newNode.dataPointer + '/-',
+              true, 'list', newNode.options.removable !== false, true,
+              recursive ? newNode.dataPointer + '/-' : ''
+            );
+            if (recursive && jsf.layoutRefLibrary[itemRefPointer]) {
+              jsf.layoutRefLibrary[itemRefPointer].recursiveReference = true;
             }
-          }, 'top-down');
+          } else {
+            jsf.layoutRefLibrary[itemRefPointer] = cloneDeep(lastItem);
+            if (recursive) {
+              jsf.layoutRefLibrary[itemRefPointer].recursiveReference = true;
+            }
+            // Only a cloned sibling needs this: it carries the id and the
+            // absolute pointer of the node it was copied from. A node built
+            // from the schema above already has neither.
+            forEach(jsf.layoutRefLibrary[itemRefPointer], (item, key) => {
+              if (hasOwn(item, '_id')) { item._id = null; }
+              if (recursive) {
+                if (hasOwn(item, 'dataPointer')) {
+                  item.dataPointer = item.dataPointer.slice(itemRefPointer.length);
+                }
+              }
+            }, 'top-down');
+          }
         }
 
         // Add any additional default items


### PR DESCRIPTION
## Summary

The template a new array item is cloned from came from the last existing item, which on a tuple array is the last fixed slot. Pressing Add duplicated that slot and produced an item the user could not remove.

## Changes

`buildLayout` now builds the template from `additionalItems`, or from `items` when that is a single schema, which is what `buildLayoutFromSchema` already did. The clone is kept where it is correct, so the guard reads the last item's `arrayItemType`, and the post processing that nulls `_id` and slices `dataPointer` runs on the clone branch alone.

## Release impact

No release. First of the four findings making up `19.0.0-rc.3`.

## Compatibility

Breaking for a consumer relying on an added tuple item inheriting the last fixed slot. It now takes what `additionalItems` declares, and is removable.

## Validation

All five suites pass: 2,122 core specs plus 76, 76, 87 and 86. Ten new specs cover the template shape and the recursive path, and five fail without the fix. Patch coverage is 92.9%. Corpus delta predicted zero on all 370 and measured zero.