### PR TITLE
fix(core)!: override on a false additionalProperties, merge tuples by slot

### DIFF
--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -13,7 +13,14 @@ Findings 1, 2, 4, 7, 8, 9, 16, 17, 18, 19, 20 shipped in 18.1.0 through 18.3.0.
 Finding 3 shipped at `19.0.0-rc.2`, finding 13 and the draft work at
 `19.0.0-rc.1`, finding 15 at `19.0.0-rc.3`.
 
-Still open: 5, 6, 11, 12, 14, 21, and the layout residual of 10.
+Still open: 5, 6, 21, the `properties` level confusion below, the dead `items`
+branches below, and the layout residual of 10.
+
+The three allOf defects did not ship together. The two that are contained, the
+`additionalProperties` assignment and the positional tuple merge, went first. The
+`properties` level confusion is held back because fixing it activates a branch
+that has never run, so a consumer bisecting a regression can land on one change
+rather than three.
 
 ## The allOf merging findings, 11, 12 and 14
 
@@ -33,6 +40,7 @@ The branch handling `additionalProperties === false` in either schema assigns
 merged schema carries a junk `combinedSchema: false` entry into form building.
 
 **The `properties` case looks for `additionalProperties` inside `properties`.**
+Still open.
 In that branch `schemaValue` is `schema.properties`, so
 `hasOwn(schemaValue, 'additionalProperties')` asks whether the schema declares a
 property literally *named* `additionalProperties`, and
@@ -45,7 +53,7 @@ merging silently altered, including `!hasOwn(combinedObject,
 'additionalProperties')` blocking every new key.
 
 **Tuple `items` are intersected rather than merged by position.** This is finding
-14. When both schemas give `items` as an array it keeps only entries that appear
+14, fixed. When both schemas give `items` as an array it keeps only entries that appear
 in both, comparing with `deepEqual`, which is set semantics. A tuple's `items` is
 positional: `items[i]` constrains element `i`. Merging
 `[{type: 'string'}, {type: 'number'}]` with
@@ -56,3 +64,17 @@ because the two happened to be identical.
 Finding 14 is what makes `prefixItems` a mapping at 21 rather than a second
 layout rewrite, so the positional shape it produces has to be the shape phase 9
 maps onto.
+
+## Found while fixing the above, not in the original audit
+
+**Two `items` branches are unreachable.** The `items` case tests
+`isArray(a) && isArray(b)`, then `isObject(a) && isObject(b)`, then the two mixed
+array-and-object combinations. `isArray` implies `isObject` here, so the second
+test catches array plus object and the last two branches never run. The effect is
+that `items: [ {...} ]` merged with `items: { ... }` is merged key by key and
+comes back as an object with numeric keys, `{ 0: {...}, minLength: 1 }`, rather
+than the object being applied to each tuple slot. Pinned as a BUG in
+`merge-schemas.function.spec.ts`.
+
+Worth fixing with the `properties` level confusion, since both change how a
+merged schema is shaped rather than correcting a single assignment.

--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -1,0 +1,58 @@
+# Audit findings
+
+The execution plan schedules work by finding number, but the numbers themselves
+were only ever recorded in a chat transcript. Recovering the scope of rc.3 meant
+grepping a 37 MB session log, which is not a repeatable way to run a release.
+This file is the durable record. Add to it rather than to a transcript.
+
+Related: [execution plan](./execution-plan.md) schedules these.
+
+## Status
+
+Findings 1, 2, 4, 7, 8, 9, 16, 17, 18, 19, 20 shipped in 18.1.0 through 18.3.0.
+Finding 3 shipped at `19.0.0-rc.2`, finding 13 and the draft work at
+`19.0.0-rc.1`, finding 15 at `19.0.0-rc.3`.
+
+Still open: 5, 6, 11, 12, 14, 21, and the layout residual of 10.
+
+## The allOf merging findings, 11, 12 and 14
+
+All three live in `merge-schemas.function.ts`. They share one file, so they ship
+as one step. Corpus signal is capped at 15 entries: `json-schema-draft04`,
+`json-schema-draft06` and `ng-jsf-deep-ref` are the only three example schemas
+using `allOf`, across five framework legs.
+
+The numbering of 11 against 12 could not be recovered, only that both are allOf
+merging defects with corpus signal. They are recorded here by description, which
+is what a fix needs anyway.
+
+**`additionalProperties: false` writes a key named after a local variable.**
+The branch handling `additionalProperties === false` in either schema assigns
+`combinedSchema.combinedSchema = false` where it means
+`combinedSchema[key] = false`. So `false` never overrides the other value, and a
+merged schema carries a junk `combinedSchema: false` entry into form building.
+
+**The `properties` case looks for `additionalProperties` inside `properties`.**
+In that branch `schemaValue` is `schema.properties`, so
+`hasOwn(schemaValue, 'additionalProperties')` asks whether the schema declares a
+property literally *named* `additionalProperties`, and
+`schemaValue.additionalProperties === false` reads that property's subschema.
+`additionalProperties` is a sibling of `properties`, not a member of it. The
+`combinedObject` side repeats the confusion. Two consequences: the whole
+additionalProperties-aware branch of property merging is unreachable for a normal
+schema, and a schema that does happen to have a property of that name has its
+merging silently altered, including `!hasOwn(combinedObject,
+'additionalProperties')` blocking every new key.
+
+**Tuple `items` are intersected rather than merged by position.** This is finding
+14. When both schemas give `items` as an array it keeps only entries that appear
+in both, comparing with `deepEqual`, which is set semantics. A tuple's `items` is
+positional: `items[i]` constrains element `i`. Merging
+`[{type: 'string'}, {type: 'number'}]` with
+`[{type: 'string'}, {type: 'boolean'}]` yields `[{type: 'string'}]`, so slot 1 is
+dropped and a two slot tuple becomes a one slot tuple. Position 0 survives only
+because the two happened to be identical.
+
+Finding 14 is what makes `prefixItems` a mapping at 21 rather than a second
+layout rewrite, so the positional shape it produces has to be the shape phase 9
+maps onto.

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -116,8 +116,8 @@ on Angular 18, so the upgrade comes first:
     19.0.0-rc.0   Angular 19 itself, no behaviour change
     19.0.0-rc.1   the converter split, ajv 8, draft 7 default, draft 4 floor
     19.0.0-rc.2   tuple slot semantics: finding 3
-    19.0.0-rc.3   the array item template and allOf merging: findings 15, 11, 12, 14
-    19.0.0-rc.4   the widget and submit changes: findings 5, 6, 21
+    19.0.0-rc.3   the array item template, and the two contained allOf defects
+    19.0.0-rc.4   the allOf shaping defects, then the widget and submit changes
     19.0.0        promoted to latest once the series has been exercised
 
 Numbering is per step rather than per finding, so a step can carry more than one

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
@@ -122,21 +122,18 @@ describe('mergeSchemas', () => {
       });
     });
 
-    it('writes a stray combinedSchema key when the new additionalProperties is false', () => {
-      // BUG: the code assigns `combinedSchema.combinedSchema = false` instead of
-      // `combinedSchema[key] = false`, so a literal "combinedSchema" key is added
-      // and the original additionalProperties value is left untouched.
+    it('lets a false additionalProperties in the new schema override', () => {
       expect(mergeSchemas(
         { additionalProperties: { type: 'string' } },
         { additionalProperties: false }
-      )).toEqual({ additionalProperties: { type: 'string' }, combinedSchema: false });
+      )).toEqual({ additionalProperties: false });
     });
 
-    it('writes a stray combinedSchema key when the combined additionalProperties is false', () => {
+    it('lets a false additionalProperties in the combined schema override', () => {
       expect(mergeSchemas(
         { additionalProperties: false },
         { additionalProperties: { type: 'string' } }
-      )).toEqual({ additionalProperties: false, combinedSchema: false });
+      )).toEqual({ additionalProperties: false });
     });
 
     it('returns allOf when additionalItems values conflict and are not objects', () => {
@@ -253,16 +250,38 @@ describe('mergeSchemas', () => {
   });
 
   describe('items', () => {
-    it('keeps only the items entries present in both arrays', () => {
+    // Both arrays means both are tuples, so slot i constrains slot i. These
+    // previously intersected the two arrays by value, which dropped every slot
+    // the tuples did not already agree on and shortened the result.
+    it('merges tuple slots by position and keeps the longer length', () => {
       expect(mergeSchemas(
         { items: [{ type: 'string' }] },
         { items: [{ type: 'string' }, { type: 'number' }] }
-      )).toEqual({ items: [{ type: 'string' }] });
+      )).toEqual({ items: [{ type: 'string' }, { type: 'number' }] });
     });
 
-    it('returns allOf when the two items arrays have nothing in common', () => {
+    it('merges the schemas of a slot both tuples declare', () => {
+      expect(mergeSchemas(
+        { items: [{ type: 'string' }, { minLength: 2 }] },
+        { items: [{ minLength: 1 }, { type: 'string' }] }
+      )).toEqual({ items: [
+        { type: 'string', minLength: 1 }, { minLength: 2, type: 'string' },
+      ] });
+    });
+
+    it('defers a single slot to allOf rather than discarding the whole tuple', () => {
       expect(mergeSchemas({ items: [{ type: 'string' }] }, { items: [{ type: 'number' }] }))
-        .toEqual({ allOf: [{ items: [{ type: 'string' }] }, { items: [{ type: 'number' }] }] });
+        .toEqual({ items: [{ allOf: [{ type: 'string' }, { type: 'number' }] }] });
+    });
+
+    it('constrains a slot past the shorter tuple by its additionalItems', () => {
+      expect(mergeSchemas(
+        { items: [{ type: 'string' }], additionalItems: { maxLength: 4 } },
+        { items: [{ type: 'string' }, { type: 'string' }] }
+      )).toEqual({
+        items: [{ type: 'string' }, { type: 'string', maxLength: 4 }],
+        additionalItems: { maxLength: 4 },
+      });
     });
 
     it('merges two items schema objects', () => {

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -53,7 +53,7 @@ export function mergeSchemas(...schemas) {
               key === 'additionalProperties' &&
               (combinedValue === false || schemaValue === false)
             ) {
-              combinedSchema.combinedSchema = false;
+              combinedSchema[key] = false;
             } else {
               return { allOf: [ ...schemas ] };
             }
@@ -131,12 +131,29 @@ export function mergeSchemas(...schemas) {
             }
           break;
           case 'items':
-            // If arrays, keep only items that appear in both arrays
+            // If both are arrays, both are tuples, so slot i of one constrains
+            // slot i of the other. Intersecting them by value instead dropped
+            // every slot the two did not already agree on, shortening the tuple.
             if (isArray(combinedValue) && isArray(schemaValue)) {
-              combinedSchema.items = combinedValue.filter(item1 =>
-                schemaValue.findIndex(item2 => deepEqual(item1, item2)) > -1
-              );
-              if (!combinedSchema.items.length) { return { allOf: [ ...schemas ] }; }
+              const tupleLength = Math.max(combinedValue.length, schemaValue.length);
+              const merged = [];
+              for (let slot = 0; slot < tupleLength; slot++) {
+                const inCombined = slot < combinedValue.length;
+                const inSchema = slot < schemaValue.length;
+                if (inCombined && inSchema) {
+                  merged.push(mergeSchemas(combinedValue[slot], schemaValue[slot]));
+                } else {
+                  // A slot only one tuple declares still has to satisfy the
+                  // other's additionalItems, which is what constrains the
+                  // positions past its own items.
+                  const own = inCombined ? combinedValue[slot] : schemaValue[slot];
+                  const otherAdditional = inCombined ?
+                    schema.additionalItems : combinedSchema.additionalItems;
+                  merged.push(isObject(otherAdditional) ?
+                    mergeSchemas(own, otherAdditional) : own);
+                }
+              }
+              combinedSchema.items = merged;
             // If both keys are objects, merge them
             } else if (isObject(combinedValue) && isObject(schemaValue)) {
               combinedSchema.items = mergeSchemas(combinedValue, schemaValue);


### PR DESCRIPTION
## Summary

Two contained defects in `allOf` merging. A false `additionalProperties` never overrode the other value, and tuple `items` were intersected by value rather than merged by position, which silently shortened the tuple.

## Changes

The `additionalProperties === false` branch assigned `combinedSchema.combinedSchema`, naming the local variable rather than the key, so the override was lost and a junk entry reached form building. The `items` case applied set semantics to a positional keyword, keeping only slots that were already identical. It now merges slot by slot, keeps the longer length, constrains a slot past the shorter tuple by the other schema's `additionalItems`, and defers an unmergeable slot to `allOf` at that position. Both defects were pinned as characterization tests, so those expectations move rather than being deleted.

## Release impact

No release. Second step of `19.0.0-rc.3`. The remaining two `allOf` defects are recorded in `docs/audit-findings.md` and held for their own change.

## Compatibility

Breaking for a consumer relying on either defect: a merged tuple keeps every slot, and `additionalProperties: false` now wins.

## Validation

All five suites pass: 2,124 core specs plus 76, 76, 87 and 86. Six specs fail without the fix. Corpus delta predicted zero on all 370 and measured zero, and holds by construction: after reference resolution no member of the three `allOf` schemas carries `additionalProperties` or an array `items`.