### PR TITLE
fix(core)!: read additionalProperties beside properties, not inside it

### DIFF
--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -13,8 +13,7 @@ Findings 1, 2, 4, 7, 8, 9, 16, 17, 18, 19, 20 shipped in 18.1.0 through 18.3.0.
 Finding 3 shipped at `19.0.0-rc.2`, finding 13 and the draft work at
 `19.0.0-rc.1`, finding 15 at `19.0.0-rc.3`.
 
-Still open: 5, 6, 21, the `properties` level confusion below, the dead `items`
-branches below, and the layout residual of 10.
+Still open: 5, 6, 21, and the layout residual of 10.
 
 The three allOf defects did not ship together. The two that are contained, the
 `additionalProperties` assignment and the positional tuple merge, went first. The
@@ -40,7 +39,7 @@ The branch handling `additionalProperties === false` in either schema assigns
 merged schema carries a junk `combinedSchema: false` entry into form building.
 
 **The `properties` case looks for `additionalProperties` inside `properties`.**
-Still open.
+Fixed.
 In that branch `schemaValue` is `schema.properties`, so
 `hasOwn(schemaValue, 'additionalProperties')` asks whether the schema declares a
 property literally *named* `additionalProperties`, and
@@ -76,5 +75,15 @@ comes back as an object with numeric keys, `{ 0: {...}, minLength: 1 }`, rather
 than the object being applied to each tuple slot. Pinned as a BUG in
 `merge-schemas.function.spec.ts`.
 
-Worth fixing with the `properties` level confusion, since both change how a
-merged schema is shaped rather than correcting a single assignment.
+Fixed with the `properties` level confusion, since both change how a merged
+schema is shaped rather than correcting a single assignment.
+
+## An escape hatch worth revisiting
+
+`mergeSchemas` returns `{ allOf: [ ...schemas ] }` from roughly twenty branches
+whenever it cannot merge, which is a correct answer for a validator and a poor one
+here. Neither `layout.functions.ts` nor `form-group.functions.ts` handles `allOf`,
+so a schema that comes back unmerged from `getSubSchema` has no field building
+path and its fields do not render. ajv still validates the original schema, so
+this costs fields rather than correctness. Not scheduled, and worth measuring
+before it is.

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.spec.ts
@@ -289,12 +289,14 @@ describe('mergeSchemas', () => {
         .toEqual({ items: { type: 'string', minLength: 2 } });
     });
 
-    it('flattens an items array into an indexed object when mixed with an items object', () => {
-      // BUG: isArray() implies isObject(), so an array plus an object hits the
-      // "both objects" branch and the array is merged key by key (0, 1, ...)
-      // instead of the object being applied to each array entry.
+    it('applies an items object to each slot of an items tuple', () => {
       expect(mergeSchemas({ items: [{ type: 'string' }] }, { items: { minLength: 1 } }))
-        .toEqual({ items: { 0: { type: 'string' }, minLength: 1 } });
+        .toEqual({ items: [{ type: 'string', minLength: 1 }] });
+    });
+
+    it('applies an items object to each slot in either argument order', () => {
+      expect(mergeSchemas({ items: { minLength: 1 } }, { items: [{ type: 'string' }] }))
+        .toEqual({ items: [{ type: 'string', minLength: 1 }] });
     });
 
     it('returns allOf when an items value is neither an array nor an object', () => {
@@ -466,51 +468,68 @@ describe('mergeSchemas', () => {
         .toEqual({ allOf: [{ properties: { a: 'x' } }, { properties: { a: 'y' } }] });
     });
 
-    it('drops non-matching combined keys when the new properties has additionalProperties false', () => {
-      expect(mergeSchemas(
-        { properties: { a: { type: 'string' } } },
-        { properties: { additionalProperties: false } }
-      )).toEqual({ properties: { additionalProperties: false } });
-    });
-
-    it('merges non-matching combined keys with an additionalProperties schema object', () => {
-      expect(mergeSchemas(
-        { properties: { a: { type: 'string' } } },
-        { properties: { additionalProperties: { minLength: 3 } } }
-      )).toEqual({
-        properties: {
-          a: { type: 'string', minLength: 3 },
-          additionalProperties: { minLength: 3 },
-        },
-      });
-    });
-
-    it('exempts matching keys from the additionalProperties false deletion', () => {
+    // additionalProperties sits beside properties. These previously passed a
+    // property named after the keyword, which is what the code was reading, so
+    // they described the misfire rather than the rule.
+    it('drops a combined key the new schema forbids, keeping the ones it declares', () => {
       expect(mergeSchemas(
         { properties: { a: { type: 'string' }, z: { type: 'number' } } },
-        { properties: { a: { minLength: 1 }, additionalProperties: false } }
+        { properties: { a: { minLength: 1 } }, additionalProperties: false }
       )).toEqual({
-        properties: { a: { type: 'string', minLength: 1 }, additionalProperties: false },
+        properties: { a: { type: 'string', minLength: 1 } },
+        additionalProperties: false,
       });
     });
 
-    it('merges a new property key with the combined additionalProperties schema', () => {
+    it('constrains a combined key the new schema does not declare by its additionalProperties', () => {
       expect(mergeSchemas(
-        { properties: { additionalProperties: { minLength: 2 } } },
+        { properties: { a: { type: 'string' } } },
+        { properties: {}, additionalProperties: { minLength: 3 } }
+      )).toEqual({
+        properties: { a: { type: 'string', minLength: 3 } },
+        additionalProperties: { minLength: 3 },
+      });
+    });
+
+    it('constrains a new key by the additionalProperties already folded in', () => {
+      expect(mergeSchemas(
+        { properties: {}, additionalProperties: { minLength: 2 } },
         { properties: { b: { type: 'string' } } }
+      )).toEqual({
+        properties: { b: { minLength: 2, type: 'string' } },
+        additionalProperties: { minLength: 2 },
+      });
+    });
+
+    it('leaves out a new key when a schema already folded in forbids it', () => {
+      expect(mergeSchemas(
+        { properties: {}, additionalProperties: false },
+        { properties: { b: { type: 'string' } } }
+      )).toEqual({ properties: {}, additionalProperties: false });
+    });
+
+    // The accumulated additionalProperties is read from the input rather than
+    // from the half built result, so neither the order of the schemas nor the
+    // order of the keys inside them changes the answer.
+    it('gives the same answer whichever schema declares additionalProperties first', () => {
+      const forbidding = { properties: { a: { type: 'string' } }, additionalProperties: false };
+      const other = { properties: { b: { type: 'number' } } };
+      const expected = { properties: { a: { type: 'string' } }, additionalProperties: false };
+      expect(mergeSchemas(forbidding, other)).toEqual(expected);
+      expect(mergeSchemas(other, forbidding)).toEqual(expected);
+    });
+
+    it('treats a property named additionalProperties as an ordinary property', () => {
+      expect(mergeSchemas(
+        { properties: { a: { type: 'string' } } },
+        { properties: { additionalProperties: false, b: { type: 'number' } } }
       )).toEqual({
         properties: {
-          additionalProperties: { minLength: 2 },
-          b: { minLength: 2, type: 'string' },
+          a: { type: 'string' },
+          additionalProperties: false,
+          b: { type: 'number' },
         },
       });
-    });
-
-    it('ignores a new property key when the combined additionalProperties is false', () => {
-      expect(mergeSchemas(
-        { properties: { additionalProperties: false } },
-        { properties: { b: { type: 'string' } } }
-      )).toEqual({ properties: { additionalProperties: false } });
     });
 
     it('returns allOf when a properties value is not an object', () => {

--- a/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
+++ b/projects/ajsf-core/src/lib/shared/merge-schemas.function.ts
@@ -28,7 +28,14 @@ export function mergeSchemas(...schemas) {
   schemas = schemas.filter(schema => !isEmpty(schema));
   if (schemas.some(schema => !isObject(schema))) { return null; }
   const combinedSchema: any = {};
-  for (const schema of schemas) {
+  for (let schemaIndex = 0; schemaIndex < schemas.length; schemaIndex++) {
+    const schema = schemas[schemaIndex];
+    // What the schemas already folded in say about additionalProperties. Taken
+    // from the input, because combinedSchema only has it once that key has been
+    // reached, which depends on where it sits in each schema's key order.
+    const priorAdditional = schemas.slice(0, schemaIndex)
+      .filter(prior => hasOwn(prior, 'additionalProperties'))
+      .map(prior => prior.additionalProperties);
     for (const key of Object.keys(schema)) {
       const combinedValue = combinedSchema[key];
       const schemaValue = schema[key];
@@ -154,16 +161,19 @@ export function mergeSchemas(...schemas) {
                 }
               }
               combinedSchema.items = merged;
-            // If both keys are objects, merge them
-            } else if (isObject(combinedValue) && isObject(schemaValue)) {
-              combinedSchema.items = mergeSchemas(combinedValue, schemaValue);
-            // If object + array, combine object with each array item
+            // A single items schema constrains every slot, so it merges into each
+            // one. isArray implies isObject here, so these two have to be tested
+            // before the object pair or they can never run: the tuple was being
+            // merged key by key into an object with numeric keys.
             } else if (isArray(combinedValue) && isObject(schemaValue)) {
               combinedSchema.items =
                 combinedValue.map(item => mergeSchemas(item, schemaValue));
             } else if (isObject(combinedValue) && isArray(schemaValue)) {
               combinedSchema.items =
                 schemaValue.map(item => mergeSchemas(item, combinedValue));
+            // If both keys are objects, merge them
+            } else if (isObject(combinedValue) && isObject(schemaValue)) {
+              combinedSchema.items = mergeSchemas(combinedValue, schemaValue);
             } else {
               return { allOf: [ ...schemas ] };
             }
@@ -244,41 +254,45 @@ export function mergeSchemas(...schemas) {
             // and merge schemas on matching keys
             if (isObject(combinedValue) && isObject(schemaValue)) {
               const combinedObject = { ...combinedValue };
-              // If new schema has additionalProperties,
-              // merge or remove non-matching property keys in combined schema
-              if (hasOwn(schemaValue, 'additionalProperties')) {
+              // additionalProperties sits beside properties, not inside it.
+              // Reading it off schemaValue asked whether a property happened to
+              // be named after the keyword, which both skipped this for every
+              // ordinary schema and mangled the rare one that has such a
+              // property.
+              const newAdditional = hasOwn(schema, 'additionalProperties') ?
+                schema.additionalProperties : undefined;
+              const priorForbids = priorAdditional.indexOf(false) > -1;
+              const priorConstraint = priorAdditional.filter(isObject)[0];
+
+              // A key the new schema does not declare is governed by its
+              // additionalProperties: removed outright, or constrained by it.
+              if (newAdditional !== undefined) {
                 Object.keys(combinedValue)
-                  .filter(combinedKey => !Object.keys(schemaValue).includes(combinedKey))
+                  .filter(combinedKey => !hasOwn(schemaValue, combinedKey))
                   .forEach(nonMatchingKey => {
-                    if (schemaValue.additionalProperties === false) {
+                    if (newAdditional === false) {
                       delete combinedObject[nonMatchingKey];
-                    } else if (isObject(schemaValue.additionalProperties)) {
+                    } else if (isObject(newAdditional)) {
                       combinedObject[nonMatchingKey] = mergeSchemas(
-                        combinedObject[nonMatchingKey],
-                        schemaValue.additionalProperties
+                        combinedObject[nonMatchingKey], newAdditional
                       );
                     }
                   });
               }
               for (const subKey of Object.keys(schemaValue)) {
-                if (deepEqual(combinedObject[subKey], schemaValue[subKey]) || (
-                  !hasOwn(combinedObject, subKey) &&
-                  !hasOwn(combinedObject, 'additionalProperties')
-                )) {
-                  combinedObject[subKey] = schemaValue[subKey];
-                // If combined schema has additionalProperties,
-                // merge or ignore non-matching property keys in new schema
-                } else if (
-                  !hasOwn(combinedObject, subKey) &&
-                  hasOwn(combinedObject, 'additionalProperties')
+                const isNewKey = !hasOwn(combinedObject, subKey);
+                if (deepEqual(combinedObject[subKey], schemaValue[subKey]) ||
+                  (isNewKey && !priorAdditional.length)
                 ) {
-                  // If combinedObject.additionalProperties === false,
-                  // do nothing (don't set key)
-                  // If additionalProperties is object, merge with new key
-                  if (isObject(combinedObject.additionalProperties)) {
-                    combinedObject[subKey] = mergeSchemas(
-                      combinedObject.additionalProperties, schemaValue[subKey]
-                    );
+                  combinedObject[subKey] = schemaValue[subKey];
+                // Symmetrically, a key the earlier schemas did not declare is
+                // governed by their additionalProperties.
+                } else if (isNewKey) {
+                  if (priorConstraint) {
+                    combinedObject[subKey] =
+                      mergeSchemas(priorConstraint, schemaValue[subKey]);
+                  } else if (!priorForbids) {
+                    combinedObject[subKey] = schemaValue[subKey];
                   }
                 // If both keys are objects, merge them
                 } else if (


### PR DESCRIPTION
## Summary

The `properties` case of `mergeSchemas` read `additionalProperties` out of the properties object, where it is a sibling rather than a member. For an ordinary schema the branch never ran; for a schema with a property named after the keyword it ran on the wrong data and dropped fields.

## Changes

`additionalProperties` is now read from the schema, and the accumulated value comes from the input schemas rather than the half built result, so neither the order of the schemas nor the position of the keyword within them changes the answer. The `items` branches are reordered: `isArray` implies `isObject` here, so the array plus object cases sat after the object pair and were unreachable, and a tuple merged with a single `items` schema came back as an object with numeric keys. Five specs described the misfire; they now state the rule.

## Release impact

No release. Last correctness step before the `19.0.0-rc.3` bump.

## Compatibility

Breaking. `additionalProperties: false` in one member now forbids keys the other declares, a single `items` schema applies to each tuple slot, and a property named `additionalProperties` is an ordinary property.

## Validation

All five suites pass: 2,126 core specs plus 76, 76, 87 and 86. Eight specs fail without the change. Corpus delta predicted zero on all 370 and measured zero, and holds by construction: no member of the three `allOf` schemas carries `properties` or `additionalProperties`, so the unit specs are the whole oracle.