### PR TITLE
docs: record the framework expansion order and its gate

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,6 +208,58 @@ a field that becomes required through a condition is enforced without being
 shown as required until submit. The layout is built once. This is the largest
 item on this page and deserves its own design note before any code.
 
+## Growth
+
+### Four new framework packages, after the 19 release
+
+Decided 2026-08-24, in this order:
+
+    @ajsf/primeng     thick   the largest Angular component library not covered
+    @ajsf/daisyui     thin    the Tailwind ecosystem at Bootstrap package cost
+    @ajsf/ng-zorro    thick   gated on recorded demand
+    @ajsf/ionic       thick   gated on recorded demand
+
+They can start once `19.0.0` is promoted to `latest`. A package started there
+is carried through the 20, 21 and 22 walk together with the existing five,
+three extra upgrade legs, and that cost is accepted: the walk crosses those
+majors regardless, so a sixth package rides the same pull requests. The
+architecture items above (the ajv registry, one validator implementation,
+conditional layout) reshape validation internals more than the widget facing
+API, so the rework exposure for a new package is real but bounded.
+
+Two package models exist and differ by six times. Thin applies classes around
+core's HTML widgets: `@ajsf/bootstrap5` is 5 files, 339 lines. Thick replaces
+widgets with the library's components: `@ajsf/material` is 19 widget components,
+1,892 lines. PrimeNG, NG-ZORRO and Ionic are thick. daisyUI is thin, and like
+the Bootstrap packages needs no dependency on Tailwind or daisyUI itself, since
+the consumer brings the CSS. There is no version coupling to Tailwind majors.
+
+Why this order. PrimeNG is the largest Angular component library AJSF does not
+cover (roughly 771k weekly downloads against Material's 2.34M), its majors track
+Angular's since v18, which fits the package major equals Angular major rule, and
+ngx-formly, the closest competitor, ships PrimeNG, Ionic, Kendo and NG-ZORRO
+integrations. daisyUI is second on cost rather than demand: Tailwind ecosystem
+reach for thin package effort. Kendo was considered and dropped for commercial
+licensing. Raw Tailwind was dropped because it provides no widgets, so a package
+would amount to a house design system.
+
+Demand evidence is thin everywhere: the tracker holds two closed PrimeNG
+mentions (#134 and #151, both from the Angular 5 era) and zero for the others.
+The npm figures measure those libraries' popularity, not demand for AJSF
+integrations of them. A pinned "which framework next" issue collecting reactions
+before ng-zorro and ionic are scheduled would turn the guess into data, and may
+reorder them. Ionic also versions independently of Angular, which the
+release tooling assumes, so it needs a versioning decision before any code.
+
+Each package pays a permanent tax: 74 corpus entries per framework (370 becomes
+444, then 518, 592 and 666), a suite and coverage leg in CI, the lockstep walk
+through every future Angular major, and the OIDC first publish (npm cannot
+configure a trusted publisher for a package that does not exist, so each needs
+one manual placeholder publish, deprecated on the spot, before the workflow
+takes over; the steps are in the agent notes). Widget selector names become
+public API on first release, named in consumer layout schemas, so they are a
+one shot decision.
+
 ## Size and shape
 
 Five files carry most of the library:


### PR DESCRIPTION
## Summary

Records the framework expansion decision in the roadmap: `@ajsf/primeng`, then `@ajsf/daisyui`, then `@ajsf/ng-zorro` and `@ajsf/ionic`, starting once `19.0.0` is promoted to `latest`.

## Changes

Adds a Growth section to `docs/roadmap.md` with the order, the gate, and the reasoning: the thin against thick package models (339 against 1,892 lines), the per package tax (74 corpus entries, a CI leg, the OIDC first publish, lockstep majors), the accepted cost of starting before the walk ends (three extra upgrade legs per package, bounded rework exposure), the demand evidence from the tracker (two closed PrimeNG mentions, zero for the rest), and the open questions (a pinned demand issue, Ionic's independent versioning).

## Release impact

None. Documentation only, no version change, the release workflow does nothing.

## Validation

Nothing to run. The section follows the writing rules: no dash punctuation, concrete numbers.