### PR TITLE
fix(core)!: hand typed values back from the select widget

### DIFF
--- a/projects/ajsf-core/src/lib/widget-library/select.component.spec.ts
+++ b/projects/ajsf-core/src/lib/widget-library/select.component.spec.ts
@@ -1,0 +1,143 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { JsonSchemaFormModule } from '../json-schema-form.module';
+import { NoFrameworkModule } from '../framework-library/no-framework.module';
+import { SelectComponent } from './select.component';
+
+// The corpus harness presses nothing, so the value a select hands back after a
+// real change event is only covered here.
+
+describe('SelectComponent updateValue (unbound)', () => {
+  const makeComponent = (values: any[]) => {
+    const updates: any[] = [];
+    const component = new SelectComponent({
+      updateValue: (_widget: any, value: any) => updates.push(value),
+    } as any);
+    component.selectList = values.map(value => ({ name: `${value}`, value }));
+    return { component, updates };
+  };
+
+  // The DOM reports every selection as a string, so a numeric enum stored
+  // strings and the None option stored the four-character string "null".
+  it('hands back null for the None option, not the string "null"', () => {
+    const { component, updates } = makeComponent(['a', 'b']);
+    component.selectList.unshift({ name: '<em>None</em>', value: null });
+    component.updateValue({ target: { value: 'null' } });
+    expect(updates).toEqual([null]);
+  });
+
+  it('hands back a number for a numeric enum', () => {
+    const { component, updates } = makeComponent([1, 2, 3]);
+    component.updateValue({ target: { value: '2' } });
+    expect(updates).toEqual([2]);
+  });
+
+  it('hands back a boolean for a boolean enum', () => {
+    const { component, updates } = makeComponent([true, false]);
+    component.updateValue({ target: { value: 'false' } });
+    expect(updates).toEqual([false]);
+  });
+
+  it('still hands back a string for a string enum', () => {
+    const { component, updates } = makeComponent(['red', 'blue']);
+    component.updateValue({ target: { value: 'blue' } });
+    expect(updates).toEqual(['blue']);
+  });
+
+  it('finds a value inside an optgroup', () => {
+    const { component, updates } = makeComponent(['x']);
+    component.selectList.push({ group: 'g', items: [{ name: '7', value: 7 }] });
+    component.updateValue({ target: { value: '7' } });
+    expect(updates).toEqual([7]);
+  });
+
+  it('passes an unmatched value through unchanged', () => {
+    const { component, updates } = makeComponent(['a']);
+    component.updateValue({ target: { value: 'zz' } });
+    expect(updates).toEqual(['zz']);
+  });
+});
+
+describe('SelectComponent bound to a form control', () => {
+  @Component({
+      template: `
+      <json-schema-form
+        [form]="form"
+        framework="no-framework"
+        (onChanges)="data = $event"
+        (isValid)="valid = $event"
+      ></json-schema-form>`,
+      standalone: false
+  })
+  class HostComponent {
+    form: any;
+    data: any;
+    valid: boolean | null = null;
+  }
+
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [JsonSchemaFormModule, NoFrameworkModule],
+    }).compileComponents();
+  }));
+
+  const render = (schema: any, data: any = {}) => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.form = { schema, data };
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  const pickOption = (label: RegExp) => {
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
+    const option = Array.from(select.options)
+      .find(candidate => label.test(candidate.textContent || ''));
+    select.value = option.value;
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    return fixture.componentInstance.data;
+  };
+
+  // Picking None used to write the string "null" into the control, which the
+  // formatter passed through as a real value.
+  it('stores no value when the None option is picked, not the string "null"', () => {
+    render({
+      type: 'object',
+      properties: { color: { type: 'string', enum: ['red', 'blue'] } },
+    }, { color: 'red' });
+    const data = pickOption(/None/);
+    expect(data.color).toBeUndefined();
+  });
+
+  // The string "null" also violated the enum, so clearing an optional field
+  // flipped the whole form invalid.
+  it('stays valid after picking None on an optional enum', () => {
+    render({
+      type: 'object',
+      properties: { color: { type: 'string', enum: ['red', 'blue'] } },
+    }, { color: 'red' });
+    pickOption(/None/);
+    expect(fixture.componentInstance.valid).toBe(true);
+  });
+
+  it('stores the number when a numeric enum option is picked', () => {
+    render({
+      type: 'object',
+      properties: { count: { type: 'number', enum: [1, 2, 3] } },
+    }, { count: 1 });
+    const data = pickOption(/^3$/);
+    expect(data.count).toBe(3);
+  });
+
+  it('shows the initial value as selected', () => {
+    render({
+      type: 'object',
+      properties: { color: { type: 'string', enum: ['red', 'blue'] } },
+    }, { color: 'blue' });
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
+    expect(select.selectedOptions[0].textContent).toContain('blue');
+  });
+});

--- a/projects/ajsf-core/src/lib/widget-library/select.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/select.component.ts
@@ -23,14 +23,17 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [id]="'control' + layoutNode?._id"
         [name]="controlName">
         <ng-template ngFor let-selectItem [ngForOf]="selectList">
+          <!-- ngValue, not value: the DOM coerces value to a string, so the
+               None option wrote the four-character string "null" into the
+               control and a numeric enum stored strings. -->
           <option *ngIf="!isArray(selectItem?.items)"
-            [value]="selectItem?.value">
+            [ngValue]="selectItem?.value">
             <span [innerHTML]="selectItem?.name"></span>
           </option>
           <optgroup *ngIf="isArray(selectItem?.items)"
             [label]="selectItem?.group">
             <option *ngFor="let subItem of selectItem.items"
-              [value]="subItem?.value">
+              [ngValue]="subItem?.value">
               <span [innerHTML]="subItem?.name"></span>
             </option>
           </optgroup>
@@ -91,6 +94,14 @@ export class SelectComponent implements OnInit {
   }
 
   updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+    // The unbound select has no value accessor, so the DOM hands back every
+    // selection as a string. Recover the typed value from the option list.
+    const domValue = event.target.value;
+    const flatItems = [];
+    for (const item of this.selectList) {
+      if (isArray(item.items)) { flatItems.push(...item.items); } else { flatItems.push(item); }
+    }
+    const matched = flatItems.find(item => `${item.value}` === domValue);
+    this.jsf.updateValue(this, matched ? matched.value : domValue);
   }
 }


### PR DESCRIPTION
## Summary

The select widget round-tripped selections through the DOM, which coerces option values to strings. The auto-added None option wrote the string "null" into the control, and since "null" is not in the enum, clearing an optional field flipped the whole form invalid.

## Changes

The bound select binds options with `ngValue`, so the value accessor round-trips real values, null included. The unbound select recovers the typed value by matching the DOM string against the option list, optgroups included, passing an unmatched value through unchanged. A numeric enum stored strings on the same path, repaired only later by output coercion, which is why the audit saw None alone. The checkboxes half of this defect was fixed at #410.

## Release impact

No release. First of the three findings making up `19.0.0-rc.4`.

## Compatibility

Breaking for a consumer reading the string "null" out of a cleared optional field, or relying on the invalid state it caused.

## Validation

All five suites pass: 2,136 core specs plus 76, 76, 87 and 86. Nine new specs press the real select; five fail without the change. Corpus delta predicted zero on all 370 and measured zero: the harness selects nothing.