### PR TITLE
fix(core)!: stop a default from disarming disableInvalidSubmit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,14 @@ The corpus baseline pins **current** behaviour including bugs, so a corpus failu
 
 Each of these cost real debugging time. They look like bugs in your code and are not.
 
+- **The framework suites test `dist/@ajsf/core`, not the core source.**
+  `tsconfig.json` maps `@ajsf/core` to `dist/@ajsf/core`, so `test:material` and
+  the three Bootstrap suites run whatever `build:libs` last wrote there, however
+  old. A core fix can pass `test:core` and then appear not to work in a
+  framework suite that is really running a week old build. Run
+  `npm run build:libs` after touching core and before reading a framework
+  suite's verdict. CI is immune: the workflow builds before it tests.
+
 - **`npm view pkg@missing-version` exits 0** with empty stdout. Only a missing *package* exits non-zero. Any "is this published" check must test the output, not the exit code, or it reports "already published" forever.
 - **`private: true` cannot be verified locally.** npm authenticates before it checks the flag, so an unauthenticated `npm publish` reports `ENEEDAUTH` whether or not the package is private, and `--dry-run` packs and exits 0 regardless. `scripts/package-guards.spec.js` asserts it instead.
 - **A tag pushed with `GITHUB_TOKEN` does not trigger another workflow**, by design, to prevent recursion. Any "create a tag, let the tag start a release" design silently never runs.

--- a/projects/ajsf-core/src/lib/json-schema-form.service.ts
+++ b/projects/ajsf-core/src/lib/json-schema-form.service.ts
@@ -141,7 +141,10 @@ export class JsonSchemaFormService {
       feedback: false, // Show inline feedback icons?
       feedbackOnRender: false, // Show errorMessage on Render?
       notitle: false, // Hide title?
-      disabled: false, // Set control as disabled? (not editable, and excluded from output)
+      // No 'disabled' default: updateInputOptions copies these defaults into
+      // every layout node, and the submit widgets read hasOwn(options,
+      // 'disabled') as an explicit override, so a default made
+      // disableInvalidSubmit unreachable for any layout-declared submit.
       readonly: false, // Set control as read only? (not editable, but included in output)
       returnEmptyFields: true, // return values for fields that contain no data?
       validationMessages: {} // set by setLanguage()

--- a/projects/ajsf-core/src/lib/widget-library/submit.component.spec.ts
+++ b/projects/ajsf-core/src/lib/widget-library/submit.component.spec.ts
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { JsonSchemaFormModule } from '../json-schema-form.module';
+import { NoFrameworkModule } from '../framework-library/no-framework.module';
+
+// disableInvalidSubmit was dead for any layout-declared submit: the widget
+// treats an explicit `disabled` option as an override, and the default options
+// used to carry `disabled: false` into every layout node, so the override
+// branch always won. The corpus presses nothing, so only these tests see it.
+describe('SubmitComponent with a layout-declared submit', () => {
+  @Component({
+      template: `
+      <json-schema-form
+        [form]="form"
+        framework="no-framework"
+      ></json-schema-form>`,
+      standalone: false
+  })
+  class HostComponent {
+    form: any;
+  }
+
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [JsonSchemaFormModule, NoFrameworkModule],
+    }).compileComponents();
+  }));
+
+  const requiredName = {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+  };
+
+  const render = (layout: any[], data: any = {}) => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.form = { schema: requiredName, layout, data };
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('input[type=submit]') as HTMLInputElement;
+  };
+
+  it('disables a layout-declared submit while the form is invalid', () => {
+    const submit = render(['*', { type: 'submit', title: 'Save' }]);
+    expect(submit.disabled).toBe(true);
+  });
+
+  it('enables the submit once the form becomes valid', () => {
+    const submit = render(['*', { type: 'submit', title: 'Save' }]);
+    const name: HTMLInputElement = fixture.nativeElement.querySelector('input[type=text]');
+    name.value = 'Ada';
+    name.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('lets an explicit disabled false keep the submit enabled while invalid', () => {
+    const submit = render(['*', { type: 'submit', title: 'Save', disabled: false }]);
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('honours an explicit disabled true whatever the validity', () => {
+    const submit = render(['*', { type: 'submit', title: 'Save', disabled: true }], { name: 'Ada' });
+    expect(submit.disabled).toBe(true);
+  });
+
+  it('disables the auto-added submit the same way', () => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.form = {
+      schema: requiredName, data: {}, options: { addSubmit: true },
+    };
+    fixture.detectChanges();
+    const submit = fixture.nativeElement.querySelector('input[type=submit]') as HTMLInputElement;
+    expect(submit.disabled).toBe(true);
+  });
+});

--- a/projects/ajsf-material/src/lib/widgets/material-button.component.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-button.component.spec.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { JsonSchemaFormModule } from '@ajsf/core';
+import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
+
+// The material submit renders through material-button, which carried the same
+// dead disableInvalidSubmit branch as the core submit widget.
+describe('MaterialButtonComponent as a layout-declared submit', () => {
+  @Component({
+      template: `
+      <json-schema-form
+        [form]="form"
+        framework="material-design"
+      ></json-schema-form>`,
+      standalone: false
+  })
+  class HostComponent {
+    form: any;
+  }
+
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [JsonSchemaFormModule, MaterialDesignFrameworkModule, NoopAnimationsModule],
+    }).compileComponents();
+  }));
+
+  const render = (layout: any[], data: any = {}) => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.form = {
+      schema: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      },
+      layout, data,
+    };
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('material-button-widget button') as HTMLButtonElement;
+  };
+
+  it('disables a layout-declared submit while the form is invalid', () => {
+    const button = render(['*', { type: 'submit', title: 'Save' }]);
+    expect(button.disabled).toBe(true);
+  });
+
+  it('honours an explicit disabled true whatever the validity', () => {
+    const button = render(['*', { type: 'submit', title: 'Save', disabled: true }], { name: 'Ada' });
+    expect(button.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

disableInvalidSubmit was dead for any layout-declared submit: the widget treats an explicit `disabled` option as an override, and the default widget options carried `disabled: false` into every layout node, so the override always won, the button stayed enabled on an invalid form, and clicking it emitted null through onSubmit.

## Changes

Removes the `disabled` default rather than changing the widget: every other reader treats absence as false already, and an explicit `disabled` in a layout keeps meaning what it says. The material submit renders through material-button, which carries the same override branch, so one removal repairs both. Also records a trap found while validating: the framework suites resolve `@ajsf/core` to `dist`, so they run whatever `build:libs` last wrote.

## Release impact

No release. Second of the three findings making up `19.0.0-rc.4`.

## Compatibility

Breaking for a consumer relying on a layout-declared submit staying enabled while the form is invalid. The auto-added submit already behaved this way.

## Validation

All five suites pass against rebuilt libraries: 2,131 core specs plus 76, 76, 87 and 88. Seven new component specs press real forms in core and material; one fails without the change and the auto-added submit spec passes either way, pinning the asymmetry. Corpus delta predicted zero on all 370 and measured zero.