### PR TITLE
fix(core)!: count entered values in minProperties and maxProperties

### DIFF
--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -13,7 +13,12 @@ Findings 1, 2, 4, 7, 8, 9, 16, 17, 18, 19, 20 shipped in 18.1.0 through 18.3.0.
 Finding 3 shipped at `19.0.0-rc.2`, finding 13 and the draft work at
 `19.0.0-rc.1`, finding 15 at `19.0.0-rc.3`.
 
-Still open: 5, 6, 21, and the layout residual of 10.
+Findings 5 (the select widget storing the string "null" for the None option),
+6 (disableInvalidSubmit dead for a layout-declared submit) and 21
+(minProperties and maxProperties counting declared rather than entered values)
+shipped at 19.0.0-rc.4.
+
+Still open: the layout residual of 10.
 
 The three allOf defects did not ship together. The two that are contained, the
 `additionalProperties` assignment and the positional tuple merge, went first. The

--- a/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/form-group.functions.spec.ts
@@ -812,7 +812,7 @@ describe('form-group.functions', () => {
       });
 
       expect(group.valid).toBe(false);
-      expect(group.errors).toEqual({ minProperties: { minimumProperties: 3, currentProperties: 1 } });
+      expect(group.errors).toEqual({ minProperties: { minimumProperties: 3, currentProperties: 0 } });
     });
 
     it('composes two group-level validators', () => {

--- a/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.spec.ts
@@ -635,6 +635,30 @@ describe('JsonValidators', () => {
     });
   });
 
+  describe('minProperties and maxProperties count entered values', () => {
+    // A form group's value carries every declared key from the moment the form
+    // is built, nulls included, so counting keys made an untouched group pass
+    // any minProperties and fail a maxProperties below its declared size.
+    it('does not count an untouched control toward the minimum', () => {
+      expect(JsonValidators.minProperties(1)(ctrl({ a: null, b: null })))
+        .toEqual({ minProperties: { minimumProperties: 1, currentProperties: 0 } });
+    });
+
+    it('does not fail a maximum because of untouched controls', () => {
+      expect(JsonValidators.maxProperties(1)(ctrl({ a: 'x', b: null, c: '' })))
+        .toBeNull();
+    });
+
+    it('counts false and zero as entered values', () => {
+      expect(JsonValidators.minProperties(2)(ctrl({ a: false, b: 0 }))).toBeNull();
+    });
+
+    it('reports the entered count in the error', () => {
+      expect(JsonValidators.maxProperties(1)(ctrl({ a: 1, b: 2, c: null })))
+        .toEqual({ maxProperties: { maximumProperties: 1, currentProperties: 2 } });
+    });
+  });
+
   describe('minProperties', () => {
     it('returns the no-op validator when no minimum is given', () => {
       expect(JsonValidators.minProperties(null)(ctrl({ a: 1 }))).toBeNull();

--- a/projects/ajsf-core/src/lib/shared/json.validators.ts
+++ b/projects/ajsf-core/src/lib/shared/json.validators.ts
@@ -505,7 +505,10 @@ export class JsonValidators {
     if (!hasValue(minimumProperties)) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value)) { return null; }
-      const currentProperties = Object.keys(control.value).length || 0;
+      // A group's value carries every declared key from the start, so count
+      // entered values rather than keys, as the description above promises.
+      const currentProperties = Object.keys(control.value)
+        .filter(key => hasValue(control.value[key])).length;
       const isValid = currentProperties >= minimumProperties;
       return xor(isValid, invert) ?
         null : { 'minProperties': { minimumProperties, currentProperties } };
@@ -528,7 +531,8 @@ export class JsonValidators {
     if (!hasValue(maximumProperties)) { return JsonValidators.nullValidator; }
     return (control: AbstractControl, invert = false): ValidationErrors|null => {
       if (isEmpty(control.value)) { return null; }
-      const currentProperties = Object.keys(control.value).length || 0;
+      const currentProperties = Object.keys(control.value)
+        .filter(key => hasValue(control.value[key])).length;
       const isValid = currentProperties <= maximumProperties;
       return xor(isValid, invert) ?
         null : { 'maxProperties': { maximumProperties, currentProperties } };


### PR DESCRIPTION
## Summary

minProperties and maxProperties counted every declared key in a form group, and a group's value carries all of them from the moment the form is built. An untouched group passed any minProperties, and a group with maxProperties below its declared size was permanently invalid.

## Changes

Both validators now count entered values: not undefined, null or the empty string, so false and zero count. This matches the description above the validators and matches ajv, which validates the formatted data after unentered keys are stripped. One characterization spec pinned the old count and moves with the fix: a group of one null control reports zero entered, and stays invalid.

## Release impact

No release. Last of the three findings making up `19.0.0-rc.4`.

## Compatibility

Breaking for a consumer relying on declared-key counting: an untouched group now fails minProperties, and untouched controls no longer push a group over maxProperties.

## Validation

All five suites pass: 2,130 core specs plus 76, 76, 87 and 86. Three of the four new specs fail without the change. Corpus delta predicted zero on all 370 and measured zero: corpus validity comes from ajv, and these validators feed per control error display only.