### PR TITLE
build: release 19.0.0-rc.4

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "19.0.0-rc.3",
+  "version": "19.0.0-rc.4",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.3",
+    "@ajsf/core": "19.0.0-rc.4",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "19.0.0-rc.3",
+  "version": "19.0.0-rc.4",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.3",
+    "@ajsf/core": "19.0.0-rc.4",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "19.0.0-rc.3",
+  "version": "19.0.0-rc.4",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.3",
+    "@ajsf/core": "19.0.0-rc.4",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "19.0.0-rc.3",
+  "version": "19.0.0-rc.4",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "19.0.0-rc.3",
+  "version": "19.0.0-rc.4",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.3",
+    "@ajsf/core": "19.0.0-rc.4",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Publishes `19.0.0-rc.4` for all five packages, the fourth and final candidate of the 19.0.0 series.

## Changes

Only the version. `npm run version:set -- 19.0.0-rc.4 19` moved the five package versions and the internal `@ajsf/core` range together. Angular peer ranges are unchanged at `^19.0.0`.

## Release impact

Publishes at `19.0.0-rc.4`. The version carries a hyphen, so it goes to the `next` dist-tag and `latest` stays on 18.3.0. The candidate covers the select widget storing typed values, disableInvalidSubmit reaching a layout-declared submit, and minProperties and maxProperties counting entered values, each of which had its own reviewed pull request.

## Validation

`main` was verified after the three merges, with the libraries rebuilt first: 2,145 core specs plus 76, 76, 87 and 88 across the four framework packages, and the 370 entry corpus baseline unmoved.