### PR TITLE
build: release 19.0.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "19.0.0-rc.4",
+  "version": "19.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.4",
+    "@ajsf/core": "^19.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "19.0.0-rc.4",
+  "version": "19.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.4",
+    "@ajsf/core": "^19.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "19.0.0-rc.4",
+  "version": "19.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.4",
+    "@ajsf/core": "^19.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "19.0.0-rc.4",
+  "version": "19.0.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "19.0.0-rc.4",
+  "version": "19.0.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "19.0.0-rc.4",
+    "@ajsf/core": "^19.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Promotes the 19.0.0 series to stable, the first stable major on Angular 19. This moves the `latest` dist-tag off 18.3.0, so 19.0.0 becomes the default install.

## Changes

Only the version. `npm run version:set -- 19.0.0 19` set the five package versions together and switched the internal `@ajsf/core` range from the candidate's exact pin to `^19.0.0`, which is how 18.3.0 shipped. Angular peer ranges are unchanged.

## Release impact

Publishes at 19.0.0 to `latest`. The release page generates from v18.3.0 rather than from rc.4 and carries the upgrade note from #439, so the series' twelve behaviour changes appear on the page a consumer lands on.

## Validation

All five suites were green on main at rc.4: 2,145 core specs plus 76, 76, 87 and 88. The published rc.4 installed into a clean consumer project with one deduped core and a strict typecheck at exit 0. Verify reruns everything before the approval gate.