### PR TITLE
docs: stop calling the flex-layout demo schema a widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ which is deprecated and has no Angular 16 release. You can uninstall it unless s
 else in your project uses it.
 
 No code change is needed. `FlexLayoutRootComponent`, `FlexLayoutSectionComponent`, the
-`ng-jsf-flex-layout` widget and layout options such as `fxFlex`, `fxFlexAlign` and
+`flex` and `section` layout types and options such as `fxFlex`, `fxFlexAlign` and
 `fxLayoutGap` all behave as before. The version jump is the Angular-aligned scheme
 starting, not a rewrite: `14.0.0` targets the same Angular 14 that `0.8.0` did.
 


### PR DESCRIPTION
## Summary

Corrects the 0.8.0 to 14.0.0 upgrade note in the root `README.md`, which listed `ng-jsf-flex-layout` as a widget that behaves as before.

## Changes

`ng-jsf-flex-layout` is a demo example schema filename, not a widget. The sentence now names what a consumer actually writes in a layout, the `flex` and `section` types, alongside the `fx` options it already listed, which is the reassurance the note is making. This matches the frozen API note corrected in #441.

## Release impact

No release is triggered: merging leaves the version unchanged. Note that `postbuild:core` copies this root README into `dist/@ajsf/core`, so it is the `@ajsf/core` package README on npm and the correction reaches that package page with the next version bump, not immediately. The four framework packages ship their own per-package READMEs, which never carried this line.

## Validation

Confirmed against the demo flex-layout schema, which references the feature by `type: flex` and `type: section`, and against the published 19.0.0 `@ajsf/core` README, which carries the line this corrects. No `ng-jsf-flex-layout` widget name occurs in any library source.