### PR TITLE
fix(core): honour a numeric exclusive bound in the number widgets

### DIFF
--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -18,13 +18,12 @@ Findings 5 (the select widget storing the string "null" for the None option),
 (minProperties and maxProperties counting declared rather than entered values)
 shipped at 19.0.0-rc.4.
 
-Still open: the layout residual of 10.
+The layout residual of 10, the numeric widgets setting no native `min` or `max` for an `exclusiveMinimum` or `exclusiveMaximum` bound, shipped at 19.1.0. Its validator half shipped at 18.3.0. All findings have now shipped.
 
-The three allOf defects did not ship together. The two that are contained, the
-`additionalProperties` assignment and the positional tuple merge, went first. The
-`properties` level confusion is held back because fixing it activates a branch
-that has never run, so a consumer bisecting a regression can land on one change
-rather than three.
+The three allOf defects shipped as separate changes at `19.0.0-rc.3` rather than
+one commit: the `additionalProperties` assignment and the positional tuple merge
+in #428, and the `properties` level confusion in #429, so a consumer bisecting a
+regression lands on one change rather than three.
 
 ## The allOf merging findings, 11, 12 and 14
 

--- a/projects/ajsf-core/src/lib/shared/index.ts
+++ b/projects/ajsf-core/src/lib/shared/index.ts
@@ -25,7 +25,8 @@ export {
   buildSchemaFromLayout, buildSchemaFromData, getFromSchema,
   removeRecursiveReferences, getInputType, checkInlineType, isInputRequired,
   updateInputOptions, getTitleMapFromOneOf, getControlValidators,
-  resolveSchemaReferences, getSubSchema, combineAllOf, fixRequiredArrayProperties
+  resolveSchemaReferences, getSubSchema, combineAllOf, fixRequiredArrayProperties,
+  effectiveMinimum, effectiveMaximum
 } from './json-schema.functions';
 
 export { convertSchemaToDraft6 } from './schema-draft.functions';

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.spec.ts
@@ -3,6 +3,8 @@ import {
   buildSchemaFromLayout,
   checkInlineType,
   combineAllOf,
+  effectiveMaximum,
+  effectiveMinimum,
   fixRequiredArrayProperties,
   getControlValidators,
   getFromSchema,
@@ -1522,5 +1524,41 @@ describe('getControlValidators, exclusive bounds and nullable types', () => {
   it('is unchanged for a plain single type', () => {
     expect(getControlValidators({ type: 'string', minLength: 2 }))
       .toEqual({ minLength: [2] } as any);
+  });
+});
+
+describe('effectiveMinimum and effectiveMaximum', () => {
+  // Draft 6 lets minimum and exclusiveMinimum coexist as independent bounds,
+  // so the native attribute must carry the strongest of the two.
+  it('takes the larger of minimum and exclusiveMinimum', () => {
+    expect(effectiveMinimum(2, 5)).toBe(5);
+    expect(effectiveMinimum(8, 5)).toBe(8);
+  });
+
+  it('takes the smaller of maximum and exclusiveMaximum', () => {
+    expect(effectiveMaximum(8, 4)).toBe(4);
+    expect(effectiveMaximum(8, 12)).toBe(8);
+  });
+
+  it('uses whichever bound is present alone', () => {
+    expect(effectiveMinimum(3, undefined)).toBe(3);
+    expect(effectiveMinimum(undefined, 5)).toBe(5);
+    expect(effectiveMaximum(9, undefined)).toBe(9);
+    expect(effectiveMaximum(undefined, 6)).toBe(6);
+  });
+
+  it('is undefined when neither bound is numeric', () => {
+    expect(effectiveMinimum(undefined, undefined)).toBeUndefined();
+    expect(effectiveMaximum(null, undefined)).toBeUndefined();
+  });
+
+  it('ignores a non-numeric bound such as a draft 4 boolean', () => {
+    expect(effectiveMinimum(5, true as any)).toBe(5);
+    expect(effectiveMinimum(undefined, true as any)).toBeUndefined();
+  });
+
+  it('keeps a zero bound rather than treating it as absent', () => {
+    expect(effectiveMinimum(0, undefined)).toBe(0);
+    expect(effectiveMaximum(0, undefined)).toBe(0);
   });
 });

--- a/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
+++ b/projects/ajsf-core/src/lib/shared/json-schema.functions.ts
@@ -569,6 +569,21 @@ export function getControlValidators(schema) {
   if (hasOwn(schema, 'enum')) { validators.enum = [schema.enum]; }
   return validators;
 }
+/**
+ * Draft 6 treats minimum and exclusiveMinimum as independent bounds that both
+ * apply, so the strongest lower bound is the larger of the two and the
+ * strongest upper bound the smaller. A non-numeric bound, such as a draft 4
+ * boolean, is ignored.
+ */
+export function effectiveMinimum(minimum, exclusiveMinimum) {
+  const bounds = [minimum, exclusiveMinimum].filter(bound => typeof bound === 'number');
+  return bounds.length ? Math.max(...bounds) : undefined;
+}
+
+export function effectiveMaximum(maximum, exclusiveMaximum) {
+  const bounds = [maximum, exclusiveMaximum].filter(bound => typeof bound === 'number');
+  return bounds.length ? Math.min(...bounds) : undefined;
+}
 
 /**
  * 'resolveSchemaReferences' function

--- a/projects/ajsf-core/src/lib/widget-library/number.component.spec.ts
+++ b/projects/ajsf-core/src/lib/widget-library/number.component.spec.ts
@@ -1,0 +1,79 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { JsonSchemaFormModule } from '../json-schema-form.module';
+import { NoFrameworkModule } from '../framework-library/no-framework.module';
+
+// The corpus counts input elements, not their attributes, so the native min and
+// max a number input carries for an exclusive bound is only covered here.
+
+describe('NumberComponent min and max attributes', () => {
+  @Component({
+      template: `
+      <json-schema-form
+        [form]="form"
+        framework="no-framework"
+      ></json-schema-form>`,
+      standalone: false
+  })
+  class HostComponent {
+    form: any;
+  }
+
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [JsonSchemaFormModule, NoFrameworkModule],
+    }).compileComponents();
+  }));
+
+  const render = (schema: any) => {
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.form = { schema };
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('input');
+  };
+
+  it('sets min from an inclusive minimum', () => {
+    const input = render({
+      type: 'object',
+      properties: { n: { type: 'number', minimum: 2 } },
+    });
+    expect(input.getAttribute('min')).toBe('2');
+  });
+
+  it('sets min from a draft 6 numeric exclusiveMinimum', () => {
+    const input = render({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMinimum: 5 } },
+    });
+    expect(input.getAttribute('min')).toBe('5');
+  });
+
+  it('sets max from a draft 6 numeric exclusiveMaximum', () => {
+    const input = render({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMaximum: 10 } },
+    });
+    expect(input.getAttribute('max')).toBe('10');
+  });
+
+  it('uses the stronger bound when minimum and exclusiveMinimum are both present', () => {
+    const input = render({
+      type: 'object',
+      properties: { n: { type: 'number', minimum: 2, exclusiveMinimum: 5 } },
+    });
+    expect(input.getAttribute('min')).toBe('5');
+  });
+
+  // A draft 4 boolean exclusiveMinimum converts to a numeric one with the
+  // minimum removed, so a boolean must never reach the binding as "true".
+  it('sets a numeric min from a draft 4 boolean exclusiveMinimum', () => {
+    const input = render({
+      type: 'object',
+      properties: { n: { type: 'number', minimum: 5, exclusiveMinimum: true } },
+    });
+    expect(input.getAttribute('min')).toBe('5');
+  });
+});

--- a/projects/ajsf-core/src/lib/widget-library/number.component.ts
+++ b/projects/ajsf-core/src/lib/widget-library/number.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 
 import { JsonSchemaFormService } from '../json-schema-form.service';
+import { effectiveMinimum, effectiveMaximum } from '../shared';
 
 @Component({
     selector: 'number-widget',
@@ -15,8 +16,8 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
       <input *ngIf="boundControl"
         [formControl]="formControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
-        [attr.max]="options?.maximum"
-        [attr.min]="options?.minimum"
+        [attr.max]="maxValue"
+        [attr.min]="minValue"
         [attr.placeholder]="options?.placeholder"
         [attr.required]="options?.required"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
@@ -29,8 +30,8 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [type]="layoutNode?.type === 'range' ? 'range' : 'number'">
       <input *ngIf="!boundControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
-        [attr.max]="options?.maximum"
-        [attr.min]="options?.minimum"
+        [attr.max]="maxValue"
+        [attr.min]="minValue"
         [attr.placeholder]="options?.placeholder"
         [attr.required]="options?.required"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
@@ -59,6 +60,9 @@ export class NumberComponent implements OnInit {
   allowDecimal = true;
   allowExponents = false;
   lastValidNumber = '';
+
+  get minValue() { return effectiveMinimum(this.options?.minimum, this.options?.exclusiveMinimum); }
+  get maxValue() { return effectiveMaximum(this.options?.maximum, this.options?.exclusiveMaximum); }
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];

--- a/projects/ajsf-material/src/lib/widgets/material-number.component.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-number.component.spec.ts
@@ -1,0 +1,21 @@
+import { MaterialNumberComponent } from './material-number.component';
+
+// effectiveMinimum and effectiveMaximum are unit tested in core; these confirm
+// the widget wires its native min and max through them.
+
+describe('MaterialNumberComponent minValue and maxValue', () => {
+  const make = (options: any) => {
+    const component = new MaterialNumberComponent(null, {} as any);
+    component.options = options;
+    return component;
+  };
+
+  it('reads an inclusive or exclusive bound', () => {
+    expect(make({ minimum: 2, maximum: 8 }).minValue).toBe(2);
+    expect(make({ exclusiveMinimum: 5 }).minValue).toBe(5);
+  });
+
+  it('uses the stronger bound when both are present', () => {
+    expect(make({ maximum: 8, exclusiveMaximum: 4 }).maxValue).toBe(4);
+  });
+});

--- a/projects/ajsf-material/src/lib/widgets/material-number.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-number.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, Input, OnInit, Optional} from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { JsonSchemaFormService } from '@ajsf/core';
+import { JsonSchemaFormService, effectiveMinimum, effectiveMaximum } from '@ajsf/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
@@ -17,8 +17,8 @@ import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
       <input matInput *ngIf="boundControl"
         [formControl]="formControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
-        [attr.max]="options?.maximum"
-        [attr.min]="options?.minimum"
+        [attr.max]="maxValue"
+        [attr.min]="minValue"
         [attr.step]="options?.multipleOf || options?.step || 'any'"
         [id]="'control' + layoutNode?._id"
         [name]="controlName"
@@ -30,8 +30,8 @@ import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
         (blur)="options.showErrors = true">
       <input matInput *ngIf="!boundControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
-        [attr.max]="options?.maximum"
-        [attr.min]="options?.minimum"
+        [attr.max]="maxValue"
+        [attr.min]="minValue"
         [attr.step]="options?.multipleOf || options?.step || 'any'"
         [disabled]="controlDisabled"
         [id]="'control' + layoutNode?._id"
@@ -71,6 +71,9 @@ export class MaterialNumberComponent implements OnInit {
   allowDecimal = true;
   allowExponents = false;
   lastValidNumber = '';
+
+  get minValue() { return effectiveMinimum(this.options?.minimum, this.options?.exclusiveMinimum); }
+  get maxValue() { return effectiveMaximum(this.options?.maximum, this.options?.exclusiveMaximum); }
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];

--- a/projects/ajsf-material/src/lib/widgets/material-slider.component.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-slider.component.spec.ts
@@ -1,0 +1,22 @@
+import { MaterialSliderComponent } from './material-slider.component';
+
+// effectiveMinimum and effectiveMaximum are unit tested in core; these confirm
+// the slider wires its track min and max through them.
+
+describe('MaterialSliderComponent minValue and maxValue', () => {
+  const make = (options: any) => {
+    const component = new MaterialSliderComponent({} as any);
+    component.options = options;
+    return component;
+  };
+
+  it('reads an inclusive or exclusive bound', () => {
+    expect(make({ minimum: 1, maximum: 10 }).minValue).toBe(1);
+    expect(make({ exclusiveMaximum: 100 }).maxValue).toBe(100);
+  });
+
+  it('uses the stronger bound when both are present', () => {
+    const c = make({ minimum: 1, exclusiveMinimum: 3 });
+    expect(c.minValue).toBe(3);
+  });
+});

--- a/projects/ajsf-material/src/lib/widgets/material-slider.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-slider.component.ts
@@ -1,6 +1,6 @@
 import { AbstractControl } from '@angular/forms';
 import { Component, Input, OnInit } from '@angular/core';
-import { JsonSchemaFormService } from '@ajsf/core';
+import { JsonSchemaFormService, effectiveMinimum, effectiveMaximum } from '@ajsf/core';
 
 @Component({
     selector: 'material-slider-widget',
@@ -8,8 +8,8 @@ import { JsonSchemaFormService } from '@ajsf/core';
     <mat-slider discrete *ngIf="boundControl"
       [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
       [id]="'control' + layoutNode?._id"
-      [max]="options?.maximum"
-      [min]="options?.minimum"
+      [max]="maxValue"
+      [min]="minValue"
       [step]="options?.multipleOf || options?.step || 'any'"
       [style.width]="'100%'"
       ><input matSliderThumb [formControl]="formControl" (blur)="options.showErrors = true" /></mat-slider>
@@ -17,8 +17,8 @@ import { JsonSchemaFormService } from '@ajsf/core';
       [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
       [disabled]="controlDisabled || options?.readonly"
       [id]="'control' + layoutNode?._id"
-      [max]="options?.maximum"
-      [min]="options?.minimum"
+      [max]="maxValue"
+      [min]="minValue"
       [step]="options?.multipleOf || options?.step || 'any'"
       [style.width]="'100%'"
       (blur)="options.showErrors = true" #ngSlider><input matSliderThumb [value]="controlValue" (change)="updateValue({source: ngSliderThumb, parent: ngSlider, value: ngSliderThumb.value})" #ngSliderThumb="matSliderThumb" /></mat-slider>
@@ -38,6 +38,9 @@ export class MaterialSliderComponent implements OnInit {
   allowDecimal = true;
   allowExponents = false;
   lastValidNumber = '';
+
+  get minValue() { return effectiveMinimum(this.options?.minimum, this.options?.exclusiveMinimum); }
+  get maxValue() { return effectiveMaximum(this.options?.maximum, this.options?.exclusiveMaximum); }
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];


### PR DESCRIPTION
## Summary

Closes the layout residual of audit finding 10: the number, material number and slider widgets ignored a numeric `exclusiveMinimum` or `exclusiveMaximum`, so a draft 6 schema declaring one rendered an input with no native `min` or `max`.

## Changes

Draft 6 treats `minimum` and `exclusiveMinimum` as independent bounds that both apply, so the native attribute now takes the strongest: the larger for min, the smaller for max. One pair of functions, `effectiveMinimum` and `effectiveMaximum`, holds that rule and all three widgets call it rather than repeating a getter. A non-numeric bound, such as a draft 4 boolean, is filtered out. HTML bounds are inclusive, so the control validator stays authoritative at the exclusive edge, and widget selection is untouched.

## Compatibility

A number input that carried no native bound, or a weaker one, now carries the correct one. Form validity is unchanged, since the validator already enforced these. Shipped as a minor.

## Validation

Core 2156 and material 92, both green, with the helpers unit tested, the attribute covered end to end, and a wiring spec per material widget. Bootstrap stays at 76, 76 and 87, and the corpus baseline is unmoved.