### PR TITLE
build: release 19.1.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.0.1",
+    "@ajsf/core": "^19.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.0.1",
+    "@ajsf/core": "^19.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.0.1",
+    "@ajsf/core": "^19.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.0.1",
+    "@ajsf/core": "^19.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Publishes 19.1.0 for all five packages, the first minor of the 19 line. It ships the finding 10 fix merged in #445 and closes the audit backlog.

## Changes

Only the version. `npm run version:set -- 19.1.0 19` moved the five package versions and the internal `@ajsf/core` range to `^19.1.0` together. Angular peer ranges are unchanged.

## Release impact

Publishes at 19.1.0 to `latest`. The release page generates from the last stable tag, v19.0.1, so it lists the number widget fix rather than the version bump alone. The `X.0.0` upgrade note is not repeated on a minor.

## Validation

All five suites were green on main at the merge: core 2156, material 92, and 76, 76 and 87 across the three Bootstrap packages, with the 370 entry corpus baseline unmoved. Verify rebuilds and reruns everything before the approval gate.