### PR TITLE
feat(primeng): scaffold the package with an empty framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         npm run test:bs3 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
         npm run test:bs4 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
         npm run test:material -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
+        npm run test:primeng -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
     # The codecov npm package is deprecated and its uploader now fails against
     # the current API with "result.split is not a function". This action is the
     # supported path.

--- a/angular.json
+++ b/angular.json
@@ -233,6 +233,34 @@
           }
         }
       }
+    },
+    "@ajsf/primeng": {
+      "projectType": "library",
+      "root": "projects/ajsf-primeng",
+      "sourceRoot": "projects/ajsf-primeng/src",
+      "prefix": "",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "tsConfig": "projects/ajsf-primeng/tsconfig.lib.json",
+            "project": "projects/ajsf-primeng/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/ajsf-primeng/tsconfig.lib.prod.json"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "projects/ajsf-primeng/src/test.ts",
+            "tsConfig": "projects/ajsf-primeng/tsconfig.spec.json",
+            "karmaConfig": "projects/ajsf-primeng/karma.conf.js"
+          }
+        }
+      }
     }
   },
   "schematics": {

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -38,12 +38,13 @@ export class DemoComponent implements OnInit {
     'pt': 'Portuguese',
     'zh': 'Chinese'
   };
-  frameworkList: any = ['material-design', 'bootstrap-3', 'bootstrap-4', 'bootstrap-5', 'no-framework'];
+  frameworkList: any = ['material-design', 'bootstrap-3', 'bootstrap-4', 'bootstrap-5', 'primeng', 'no-framework'];
   frameworks: any = {
     'material-design': 'Material Design',
     'bootstrap-3': 'Bootstrap 3',
     'bootstrap-4': 'Bootstrap 4',
     'bootstrap-5': 'Bootstrap 5',
+    'primeng': 'PrimeNG',
     'no-framework': 'None (plain HTML)',
   };
   selectedSet = 'ng-jsf';

--- a/demo/app/demo.module.ts
+++ b/demo/app/demo.module.ts
@@ -20,6 +20,7 @@ import { Bootstrap4FrameworkModule } from '@ajsf/bootstrap4';
 import { Bootstrap3FrameworkModule } from '@ajsf/bootstrap3';
 import { Bootstrap5FrameworkModule } from '@ajsf/bootstrap5';
 import { MaterialDesignFrameworkModule } from '@ajsf/material';
+import { PrimengFrameworkModule } from '@ajsf/primeng';
 
 @NgModule({ declarations: [AceEditorDirective, DemoComponent, DemoRootComponent],
     bootstrap: [DemoRootComponent], imports: [BrowserModule, BrowserAnimationsModule, FormsModule,
@@ -30,6 +31,7 @@ import { MaterialDesignFrameworkModule } from '@ajsf/material';
         Bootstrap3FrameworkModule,
         Bootstrap5FrameworkModule,
         MaterialDesignFrameworkModule,
+        PrimengFrameworkModule,
         JsonSchemaFormModule], providers: [provideHttpClient(withInterceptorsFromDi())] })
 
 export class DemoModule { }

--- a/docs/primeng-plan.md
+++ b/docs/primeng-plan.md
@@ -15,13 +15,20 @@ lines. A new package registers in four places before any widget compiles:
 
     angular.json                 a projects entry, build and test targets
     tsconfig.json                @ajsf/primeng -> dist/@ajsf/primeng in paths
-    package.json                 build:primeng, postbuild:primeng, test:primeng,
-                                 and the three wired into build:libs and coverage
-    scripts/set-version.js       the package added to the lockstep version set
+    package.json                 build:primeng, postbuild:primeng, test:primeng
+    .github/workflows/ci.yml     a test:primeng leg beside the others
 
 The framework itself is one module, one framework class carrying the widget map,
 one framework component with its template and styles, and the widgets directory
 with a public_api.ts. corpus.spec.ts and test.ts come across unchanged in shape.
+
+build:libs and scripts/set-version.js are deliberately left alone until the
+package is ready to publish. The release job publishes every directory under
+dist/@ajsf, and build:libs is what fills it, so a package added to build:libs
+before its placeholder publish exists would fail the release at its own publish
+step, the OIDC trap below. So the scaffold builds and is tested through its own
+scripts and the CI leg, and joins build:libs, coverage and the version set in the
+same step that first publishes it.
 
 ## Widget map
 
@@ -86,20 +93,23 @@ app. The consumer sets up PrimeNG once; the package only uses its components.
 
 ## Sequence
 
-1. Scaffold the four registration points and an empty framework that resolves
-   every core widget through core's own components, so the package builds and
-   serves before a single PrimeNG widget exists. Predicted corpus delta is the
-   74 new entries recorded fresh, since the package is a new framework leg.
-2. Port the flex layout root and section and the add-reference component from
+1. Scaffold the package and an empty framework that resolves every core widget
+   through core's own components, so it builds and is tested before a single
+   PrimeNG widget exists. It stays out of build:libs and the version set, so a
+   release in the meantime cannot fail on it.
+2. corpus.spec.ts records the 74 entry baseline for the new leg, a new framework
+   leg, so the predicted delta is the 74 fresh entries and nothing else moves.
+3. Port the flex layout root and section and the add-reference component from
    material, the three that carry no library surface.
-3. The widgets, grouped by how much each borrows from the material equivalent:
+4. The widgets, grouped by how much each borrows from the material equivalent:
    the plain input and textarea, then number, select, one-of and the boolean
    controls, then the composite widgets, date, file, slider, the tag input, stepper and
    tabs. Each widget lands with its unit specs, following the number and slider
    specs added for finding 10.
-4. corpus.spec.ts records the 74 entry baseline for the new leg. A mispredicted
-   delta is a defect in the pull request, not a baseline to re record.
-5. CI gains a test:primeng leg and a coverage leg, matching the existing five.
+   A mispredicted delta on any later widget is a defect in the pull request, not
+   a baseline to re record.
+5. The package joins build:libs, coverage and the version set, which is the step
+   that first publishes it, gated on the manual placeholder below.
 
 ## The first publish is gated on a manual step
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/hamzahamidi/Angular6-json-schema-form#readme",
   "scripts": {
     "ng": "ng",
-    "prestart": "npm run build:libs",
+    "prestart": "npm run build:libs && npm run build:primeng",
     "start": "ng serve",
     "start:demo-only": "ng serve",
     "build:core": "ng build @ajsf/core --configuration production",
@@ -52,7 +52,7 @@
     "build:material": "ng build @ajsf/material --configuration production",
     "postbuild:material": "cp projects/ajsf-material/README.md LICENSE dist/@ajsf/material",
     "build:libs": "npm run build:core && npm run build:bs4 && npm run build:bs3 && npm run build:bs5 && npm run build:material",
-    "build:demo": "npm run build:libs && ng build demo --configuration production --base-href ./",
+    "build:demo": "npm run build:libs && npm run build:primeng && ng build demo --configuration production --base-href ./",
     "build:demo-only": "ng build demo --configuration production --base-href ./",
     "prestats": "ng build demo --configuration production --stats-json",
     "stats": "webpack-bundle-analyzer dist/demo/stats.json",
@@ -67,7 +67,10 @@
     "coverage:clean": "node -e \"require('fs').rmSync('coverage',{recursive:true,force:true})\"",
     "coverage:report": "node scripts/coverage-summary.js --files",
     "coverage": "npm run coverage:clean && npm run test:core -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI && npm run test:bs3 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI && npm run test:bs4 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI && npm run test:bs5 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI && npm run test:material -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI && npm run coverage:report",
-    "corpus:index": "node scripts/generate-corpus-index.js"
+    "corpus:index": "node scripts/generate-corpus-index.js",
+    "build:primeng": "ng build @ajsf/primeng --configuration production",
+    "postbuild:primeng": "cp projects/ajsf-primeng/README.md LICENSE dist/@ajsf/primeng/",
+    "test:primeng": "ng test @ajsf/primeng"
   },
   "dependencies": {
     "@angular/animations": "^19.2.25",

--- a/projects/ajsf-primeng/README.md
+++ b/projects/ajsf-primeng/README.md
@@ -1,0 +1,59 @@
+# @ajsf/primeng
+
+## Getting started
+
+```shell
+npm install @ajsf/primeng@latest
+```
+
+With YARN, run the following:
+
+```shell
+yarn add @ajsf/primeng@latest
+```
+
+Then import `PrimengFrameworkModule` in your main application module if you want to use `primeng` UI, like this:
+
+```javascript
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+
+import { PrimengFrameworkModule } from '@ajsf/primeng';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [ AppComponent ],
+  imports: [
+    PrimengFrameworkModule
+  ],
+  providers: [],
+  bootstrap: [ AppComponent ]
+})
+export class AppModule { }
+```
+
+PrimeNG is configured by the consuming application, not by this package. Set up
+`providePrimeNG` with a theme preset from `@primeng/themes` once, as PrimeNG's own
+installation guide describes. This package uses PrimeNG components and leaves the
+theme to you.
+
+For basic use, after loading the module as described above, to display a form in your Angular component, simply add the following to your component's template:
+
+```html
+<json-schema-form
+  [schema]="yourJsonSchema"
+  framework="primeng"
+  (onSubmit)="yourOnSubmitFn($event)">
+</json-schema-form>
+```
+
+Where `schema` is a valid JSON schema object, and `onSubmit` calls a function to process the submitted JSON form data.
+
+## Build
+
+Run `ng build @ajsf/primeng` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+## Running unit tests
+
+Run `ng test @ajsf/primeng` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/projects/ajsf-primeng/karma.conf.js
+++ b/projects/ajsf-primeng/karma.conf.js
@@ -1,0 +1,48 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/ajsf-primeng'),
+      reporters: [
+        {
+          type: 'html',
+        },
+        {
+          type: 'lcov',
+        },
+        {
+          type: 'text-summary',
+        },
+      ],
+    },
+    reporters: ['progress', 'kjhtml'],
+    // The 320-case corpus takes longer than the 30s default between messages.
+    browserNoActivityTimeout: 120000,
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    singleRun: false,
+    browsers: ['Chrome', 'ChromeHeadlessCI'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox'],
+      },
+    },
+  });
+};

--- a/projects/ajsf-primeng/ng-package.json
+++ b/projects/ajsf-primeng/ng-package.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/@ajsf/primeng",
+  "lib": {
+    "entryFile": "src/public_api.ts"
+  },
+  "allowedNonPeerDependencies": [
+    "@ajsf/core"
+  ]
+}

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@ajsf/primeng",
+  "version": "19.1.0",
+  "description": "Angular JSON Schema Form builder using PrimeNG UI",
+  "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
+  "keywords": [
+    "Angular",
+    "ng",
+    "Angular19",
+    "Angular 19",
+    "ng19",
+    "JSON Schema",
+    "form",
+    "forms",
+    "form builder",
+    "PrimeNG",
+    "ajsf",
+    "angular json schema form"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hamzahamidi/ajsf"
+  },
+  "bugs": {
+    "url": "https://github.com/hamzahamidi/ajsf/issues"
+  },
+  "funding": "https://github.com/sponsors/hamzahamidi",
+  "private": false,
+  "dependencies": {
+    "@ajsf/core": "^19.1.0",
+    "tslib": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@angular/common": "^19.0.0",
+    "@angular/core": "^19.0.0"
+  }
+}

--- a/projects/ajsf-primeng/src/lib/primeng-framework.component.html
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.component.html
@@ -1,0 +1,2 @@
+<select-widget-widget [dataIndex]="dataIndex" [layoutIndex]="layoutIndex" [layoutNode]="layoutNode">
+</select-widget-widget>

--- a/projects/ajsf-primeng/src/lib/primeng-framework.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import {
+  JsonSchemaFormModule,
+  JsonSchemaFormService,
+  WidgetLibraryModule
+} from '@ajsf/core';
+import { PrimengFrameworkComponent } from './primeng-framework.component';
+
+describe('PrimengFrameworkComponent', () => {
+  let component: PrimengFrameworkComponent;
+  let fixture: ComponentFixture<PrimengFrameworkComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        JsonSchemaFormModule,
+        CommonModule,
+        WidgetLibraryModule,
+      ],
+      declarations: [PrimengFrameworkComponent],
+      providers: [JsonSchemaFormService]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PrimengFrameworkComponent);
+    component = fixture.componentInstance;
+    component.layoutNode = { options: {} };
+    component.layoutIndex = [];
+    component.dataIndex = [];
+    fixture.detectChanges();
+  });
+
+  it('creates and resolves widgets through core', () => {
+    expect(component).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('select-widget-widget')).toBeTruthy();
+  });
+});

--- a/projects/ajsf-primeng/src/lib/primeng-framework.component.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * PrimeNG framework for Angular JSON Schema Form.
+ *
+ * The map is empty for now, so every widget resolves to core's own component.
+ * PrimeNG widgets replace them one at a time. The selector is public API and
+ * named in consumer layout schemas, so it does not change.
+ */
+@Component({
+    selector: 'primeng-framework',
+    templateUrl: './primeng-framework.component.html',
+    standalone: false
+})
+export class PrimengFrameworkComponent {
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+}

--- a/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  Framework,
+  JsonSchemaFormService,
+  WidgetLibraryService,
+  FrameworkLibraryService,
+  JsonSchemaFormModule,
+  WidgetLibraryModule
+} from '@ajsf/core';
+import { PrimengFramework } from './primeng.framework';
+import { PrimengFrameworkComponent } from './primeng-framework.component';
+
+@NgModule({
+    imports: [
+        JsonSchemaFormModule,
+        CommonModule,
+        WidgetLibraryModule,
+    ],
+    declarations: [
+        PrimengFrameworkComponent,
+    ],
+    exports: [
+        JsonSchemaFormModule,
+        PrimengFrameworkComponent,
+    ],
+    providers: [
+        JsonSchemaFormService,
+        FrameworkLibraryService,
+        WidgetLibraryService,
+        { provide: Framework, useClass: PrimengFramework, multi: true },
+    ]
+})
+export class PrimengFrameworkModule {
+}

--- a/projects/ajsf-primeng/src/lib/primeng.framework.ts
+++ b/projects/ajsf-primeng/src/lib/primeng.framework.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Framework } from '@ajsf/core';
+import { PrimengFrameworkComponent } from './primeng-framework.component';
+
+// PrimeNG Framework
+// https://primeng.org
+
+@Injectable()
+export class PrimengFramework extends Framework {
+  name = 'primeng';
+
+  framework = PrimengFrameworkComponent;
+}

--- a/projects/ajsf-primeng/src/public_api.ts
+++ b/projects/ajsf-primeng/src/public_api.ts
@@ -1,0 +1,7 @@
+/*
+ * Public API Surface of @ajsf/primeng
+ */
+
+export * from './lib/primeng-framework.module';
+export * from './lib/primeng-framework.component';
+export * from './lib/primeng.framework';

--- a/projects/ajsf-primeng/src/test.ts
+++ b/projects/ajsf-primeng/src/test.ts
@@ -1,0 +1,17 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js';
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(), {
+    teardown: { destroyAfterEach: false }
+}
+);

--- a/projects/ajsf-primeng/tsconfig.lib.json
+++ b/projects/ajsf-primeng/tsconfig.lib.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declarationMap": true,
+    "declaration": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/projects/ajsf-primeng/tsconfig.lib.prod.json
+++ b/projects/ajsf-primeng/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/projects/ajsf-primeng/tsconfig.spec.json
+++ b/projects/ajsf-primeng/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,12 @@
       ],
       "@ajsf/material/*": [
         "dist/@ajsf/material/*"
+      ],
+      "@ajsf/primeng": [
+        "dist/@ajsf/primeng"
+      ],
+      "@ajsf/primeng/*": [
+        "dist/@ajsf/primeng/*"
       ]
     },
     "useDefineForClassFields": false


### PR DESCRIPTION
## Summary

Adds the `@ajsf/primeng` project as a sixth framework package, starting with an empty framework that resolves every widget through core while PrimeNG components are built out.

## Changes

Creates `projects/ajsf-primeng/` with the framework module, framework component, injectable, package.json, karma config and tsconfig files. Registers the project in angular.json, tsconfig.json path mappings, and root package.json scripts (`build:primeng`, `postbuild:primeng`, `test:primeng`). Adds a CI test leg in ci.yml. Updates `docs/primeng-plan.md` to reflect the corrected sequencing: the package stays out of `build:libs` and `set-version.js` until a manual placeholder publish gates it in, so existing releases ship the five current packages without risk.

## Release impact

No release. The scaffold is not wired into `build:libs` or the version script, so the release workflow cannot reach it.

## Validation

`build:primeng` succeeded. `test:primeng` passed (1 spec, 0 failures). `build:libs` still produces only the five existing packages.