### PR TITLE
test(primeng): record the 74 entry corpus baseline

### DIFF
--- a/projects/ajsf-primeng/src/lib/corpus.spec.ts
+++ b/projects/ajsf-primeng/src/lib/corpus.spec.ts
@@ -1,0 +1,5 @@
+import { PrimengFrameworkModule } from './primeng-framework.module';
+import { runCorpus } from '../../../../testing/corpus/harness';
+
+// The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
+runCorpus('primeng', [PrimengFrameworkModule]);

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1848,5 +1848,375 @@
     "controls": 2,
     "error": null,
     "valid": true
+  },
+  "primeng/asf-array": {
+    "controls": 4,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-basic-json-schema-type": {
+    "controls": 5,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-bootstrap-grid": {
+    "controls": 4,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-complex-key-support": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/asf-hack-conditional-required": {
+    "controls": 2,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-kitchen-sink": {
+    "controls": 11,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-simple": {
+    "controls": 4,
+    "error": null,
+    "valid": false
+  },
+  "primeng/asf-tab-array": {
+    "controls": 4,
+    "error": null,
+    "valid": true
+  },
+  "primeng/asf-titlemap-examples": {
+    "controls": 15,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-factory-sleek": {
+    "controls": 4,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-ace": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-actions": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-advancedfieldset": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-array": {
+    "controls": 9,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-array-simple": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-authfieldset": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-autocomplete": {
+    "controls": 6,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-checkbox": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-checkboxbuttons": {
+    "controls": 0,
+    "error": "value.forEach is not a function",
+    "valid": null
+  },
+  "primeng/jsf-fields-checkboxes": {
+    "controls": 15,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-color": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-common": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-fieldset": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-help": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-hidden": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-iconselect": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-imageselect": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-password": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-questions": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-radiobuttons": {
+    "controls": 9,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-range": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-section": {
+    "controls": 4,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-selectfieldset": {
+    "controls": 1,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-selectfieldset-key": {
+    "controls": 1,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-submit": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-tabarray": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-tabarray-maxitems": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-tabarray-value": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-fields-textarea": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-gettingstarted": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-previousvalues": {
+    "controls": 10,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-previousvalues-multidimensional": {
+    "controls": 6,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-schema-array": {
+    "controls": 4,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-schema-basic": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-schema-default": {
+    "controls": 13,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-schema-inlineref": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-schema-morecomplex": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-templating-idx": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-templating-tpldata": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-templating-value": {
+    "controls": 2,
+    "error": null,
+    "valid": true
+  },
+  "primeng/jsf-templating-values": {
+    "controls": 4,
+    "error": null,
+    "valid": true
+  },
+  "primeng/json-schema-draft04": {
+    "controls": 19,
+    "error": null,
+    "valid": false
+  },
+  "primeng/json-schema-draft06": {
+    "controls": 21,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-data-only": {
+    "controls": 15,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-deep-ref": {
+    "controls": 6,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-flex-layout": {
+    "controls": 15,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-layout-only": {
+    "controls": 0,
+    "error": null,
+    "valid": null
+  },
+  "primeng/ng-jsf-nested-arrays": {
+    "controls": 5,
+    "error": null,
+    "valid": false
+  },
+  "primeng/ng-jsf-select-list-examples": {
+    "controls": 10,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-select-widget-examples": {
+    "controls": 19,
+    "error": null,
+    "valid": true
+  },
+  "primeng/ng-jsf-simple-array": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-alternatives": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-arrays": {
+    "controls": 31,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-custom": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-date-and-time": {
+    "controls": 5,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-errors": {
+    "controls": 9,
+    "error": null,
+    "valid": false
+  },
+  "primeng/rjsf-files": {
+    "controls": 3,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-large": {
+    "controls": 12,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-nested": {
+    "controls": 8,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-numbers": {
+    "controls": 9,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-ordering": {
+    "controls": 6,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-references": {
+    "controls": 8,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-simple": {
+    "controls": 7,
+    "error": null,
+    "valid": true
+  },
+  "primeng/rjsf-single": {
+    "controls": 2,
+    "error": null,
+    "valid": true
   }
 }


### PR DESCRIPTION
## Summary

Records the corpus baseline for the primeng framework leg, the 74 schema entries that pin control counts, errors and validity flags while every widget still resolves through core.

## Changes

Adds corpus.spec.ts to the primeng package, matching the shape of the other five framework legs. Merges 74 new entries into baseline.json, sorted alphabetically, bringing the total from 370 to 444. No existing entry is modified.

## Release impact

No release. Test infrastructure only.

## Validation

test:primeng passed 76 of 76 (74 corpus entries, 1 "has schemas" guard, 1 existing framework spec). test:core passed 2156 of 2156, confirming existing baselines are unaffected.