### PR TITLE
feat(primeng): add root, section, and add-reference layout components

### DIFF
--- a/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import {
   Framework,
   JsonSchemaFormService,
@@ -10,19 +11,23 @@ import {
 } from '@ajsf/core';
 import { PrimengFramework } from './primeng.framework';
 import { PrimengFrameworkComponent } from './primeng-framework.component';
+import { PRIMENG_FRAMEWORK_COMPONENTS } from './widgets/public_api';
 
 @NgModule({
     imports: [
         JsonSchemaFormModule,
         CommonModule,
+        ReactiveFormsModule,
         WidgetLibraryModule,
     ],
     declarations: [
         PrimengFrameworkComponent,
+        ...PRIMENG_FRAMEWORK_COMPONENTS,
     ],
     exports: [
         JsonSchemaFormModule,
         PrimengFrameworkComponent,
+        ...PRIMENG_FRAMEWORK_COMPONENTS,
     ],
     providers: [
         JsonSchemaFormService,

--- a/projects/ajsf-primeng/src/lib/primeng.framework.ts
+++ b/projects/ajsf-primeng/src/lib/primeng.framework.ts
@@ -15,5 +15,7 @@ export class PrimengFramework extends Framework {
     'root': PrimengFlexLayoutRootComponent,
     'section': PrimengFlexLayoutSectionComponent,
     '$ref': PrimengAddReferenceComponent,
+    'card': 'section',
+    'expansion-panel': 'section',
   };
 }

--- a/projects/ajsf-primeng/src/lib/primeng.framework.ts
+++ b/projects/ajsf-primeng/src/lib/primeng.framework.ts
@@ -1,13 +1,19 @@
 import { Injectable } from '@angular/core';
 import { Framework } from '@ajsf/core';
 import { PrimengFrameworkComponent } from './primeng-framework.component';
-
-// PrimeNG Framework
-// https://primeng.org
+import { PrimengFlexLayoutRootComponent } from './widgets/primeng-flex-layout-root.component';
+import { PrimengFlexLayoutSectionComponent } from './widgets/primeng-flex-layout-section.component';
+import { PrimengAddReferenceComponent } from './widgets/primeng-add-reference.component';
 
 @Injectable()
 export class PrimengFramework extends Framework {
   name = 'primeng';
 
   framework = PrimengFrameworkComponent;
+
+  widgets = {
+    'root': PrimengFlexLayoutRootComponent,
+    'section': PrimengFlexLayoutSectionComponent,
+    '$ref': PrimengAddReferenceComponent,
+  };
 }

--- a/projects/ajsf-primeng/src/lib/widgets/flex-layout-options.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/flex-layout-options.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PrimengFrameworkModule } from '../primeng-framework.module';
+import { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
+
+describe('flex layout options (primeng)', () => {
+  let fixture: ComponentFixture<PrimengFlexLayoutRootComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [PrimengFrameworkModule, NoopAnimationsModule],
+    }).compileComponents();
+  }));
+
+  function itemFor(options: any): HTMLElement {
+    fixture = TestBed.createComponent(PrimengFlexLayoutRootComponent);
+    fixture.componentInstance.layout = [{ name: 'x', type: 'text', options }];
+    fixture.componentInstance.layoutIndex = [];
+    fixture.componentInstance.dataIndex = [];
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('div');
+  }
+
+  it('renders an item wrapper for a layout node', () => {
+    expect(itemFor({})).toBeTruthy();
+  });
+
+  it('applies fxFlex as flex-basis', () => {
+    expect(itemFor({ fxFlex: '50%' }).style.flexBasis).toEqual('50%');
+  });
+
+  it('caps a percentage fxFlex with max-width, as the directive did', () => {
+    expect(itemFor({ fxFlex: '50%' }).style.maxWidth).toEqual('50%');
+  });
+
+  it('does not cap a non-percentage fxFlex', () => {
+    const item = itemFor({ fxFlex: '200px' });
+    expect(item.style.flexBasis).toEqual('200px');
+    expect(item.style.maxWidth).toEqual('');
+  });
+
+  it('applies fxFlexOrder as order', () => {
+    expect(itemFor({ fxFlexOrder: '2' }).style.order).toEqual('2');
+  });
+
+  it('applies fxFlexOffset as margin-left', () => {
+    expect(itemFor({ fxFlexOffset: '10px' }).style.marginLeft).toEqual('10px');
+  });
+
+  it('maps fxFlexAlign onto align-self', () => {
+    expect(itemFor({ fxFlexAlign: 'start' }).style.alignSelf).toEqual('flex-start');
+    expect(itemFor({ fxFlexAlign: 'end' }).style.alignSelf).toEqual('flex-end');
+  });
+
+  it('lets an explicit align-self win over fxFlexAlign', () => {
+    expect(itemFor({ fxFlexAlign: 'start', 'align-self': 'center' }).style.alignSelf)
+      .toEqual('center');
+  });
+
+  it('falls back to the flex-basis option when fxFlex is absent', () => {
+    expect(itemFor({ 'flex-basis': '30%' }).style.flexBasis).toEqual('30%');
+  });
+
+  it('ignores an unknown fxFlexAlign rather than emitting it raw', () => {
+    expect(itemFor({ fxFlexAlign: 'nonsense' }).style.alignSelf).toEqual('');
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-add-reference.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-add-reference.component.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+
+@Component({
+    selector: 'primeng-add-reference-widget',
+    template: `
+    <section [class]="options?.htmlClass || ''" align="end">
+      <button type="button" *ngIf="showAddButton"
+        [disabled]="options?.readonly"
+        (click)="addItem($event)">
+        <span *ngIf="options?.icon" [class]="options?.icon"></span>
+        <span *ngIf="options?.title" [innerHTML]="buttonText"></span>
+      </button>
+    </section>`,
+    changeDetection: ChangeDetectionStrategy.Default,
+    standalone: false
+})
+export class PrimengAddReferenceComponent implements OnInit {
+  options: any;
+  itemCount: number;
+  previousLayoutIndex: number[];
+  previousDataIndex: number[];
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+  }
+
+  get showAddButton(): boolean {
+    return !this.layoutNode.arrayItem ||
+      this.layoutIndex[this.layoutIndex.length - 1] < this.options.maxItems;
+  }
+
+  addItem(event) {
+    event.preventDefault();
+    this.jsf.addItem(this);
+  }
+
+  get buttonText(): string {
+    const parent: any = {
+      dataIndex: this.dataIndex.slice(0, -1),
+      layoutIndex: this.layoutIndex.slice(0, -1),
+      layoutNode: this.jsf.getParentNode(this),
+    };
+    return parent.layoutNode.add ||
+      this.jsf.setArrayItemTitle(parent, this.layoutNode, this.itemCount);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-flex-layout-root.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-flex-layout-root.component.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+
+@Component({
+    selector: 'primeng-flex-layout-root-widget',
+    template: `
+    <div *ngFor="let layoutNode of layout; let i = index"
+      [class.form-flex-item]="isFlexItem"
+      [style.flex-grow]="getFlexAttribute(layoutNode, 'flex-grow')"
+      [style.flex-shrink]="getFlexAttribute(layoutNode, 'flex-shrink')"
+      [style.flex-basis]="getFlexBasis(layoutNode)"
+      [style.align-self]="getAlignSelf(layoutNode)"
+      [style.order]="getOrder(layoutNode)"
+      [style.max-width]="getMaxWidth(layoutNode)"
+      [style.margin-left]="getOffset(layoutNode)">
+      <select-framework-widget *ngIf="showWidget(layoutNode)"
+        [dataIndex]="layoutNode?.arrayItem ? (dataIndex || []).concat(i) : (dataIndex || [])"
+        [layoutIndex]="(layoutIndex || []).concat(i)"
+        [layoutNode]="layoutNode"></select-framework-widget>
+    </div>`,
+    changeDetection: ChangeDetectionStrategy.Default,
+    standalone: false
+})
+export class PrimengFlexLayoutRootComponent {
+  @Input() dataIndex: number[];
+  @Input() layoutIndex: number[];
+  @Input() layout: any[];
+  @Input() isFlexItem = false;
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  removeItem(item) {
+    this.jsf.removeItem(item);
+  }
+
+  private static readonly SELF_ALIGN = {
+    start: 'flex-start', end: 'flex-end', center: 'center',
+    baseline: 'baseline', stretch: 'stretch',
+  };
+
+  getFlexBasis(node: any): string {
+    return (node?.options || {}).fxFlex || this.getFlexAttribute(node, 'flex-basis');
+  }
+
+  getMaxWidth(node: any): string {
+    const fxFlex = (node?.options || {}).fxFlex;
+    return fxFlex && `${fxFlex}`.trim().endsWith('%') ? fxFlex : null;
+  }
+
+  getAlignSelf(node: any): string {
+    const options = node?.options || {};
+    return options['align-self'] ||
+      PrimengFlexLayoutRootComponent.SELF_ALIGN[options.fxFlexAlign] || null;
+  }
+
+  getOrder(node: any): string {
+    const options = node?.options || {};
+    return options.order || options.fxFlexOrder || null;
+  }
+
+  getOffset(node: any): string {
+    return (node?.options || {}).fxFlexOffset || null;
+  }
+
+  getFlexAttribute(node: any, attribute: string) {
+    const index = ['flex-grow', 'flex-shrink', 'flex-basis'].indexOf(attribute);
+    return ((node.options || {}).flex || '').split(/\s+/)[index] ||
+      (node.options || {})[attribute] || ['1', '1', 'auto'][index];
+  }
+
+  showWidget(layoutNode: any): boolean {
+    return this.jsf.evaluateCondition(layoutNode, this.dataIndex);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-flex-layout-section.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-flex-layout-section.component.ts
@@ -1,0 +1,233 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-flex-layout-section-widget',
+    template: `
+    <div *ngIf="containerType === 'div'"
+      [class]="options?.htmlClass || ''"
+      [class.expandable]="options?.expandable && !expanded"
+      [class.expanded]="options?.expandable && expanded">
+      <label *ngIf="sectionTitle"
+        [class]="'legend ' + (options?.labelHtmlClass || '')"
+        [innerHTML]="sectionTitle"
+        (click)="toggleExpanded()"></label>
+      <primeng-flex-layout-root-widget *ngIf="expanded"
+        [layout]="layoutNode.items"
+        [dataIndex]="dataIndex"
+        [layoutIndex]="layoutIndex"
+        [isFlexItem]="getFlexAttribute('is-flex')"
+        [class.form-flex-column]="getFlexAttribute('flex-direction') === 'column'"
+        [class.form-flex-row]="getFlexAttribute('flex-direction') === 'row'"
+        [style.display]="getFlexAttribute('display')"
+        [style.flex-direction]="getFlexAttribute('flex-direction')"
+        [style.flex-wrap]="getFlexAttribute('flex-wrap')"
+        [style.justify-content]="getFlexAttribute('justify-content')"
+        [style.align-items]="getFlexAttribute('align-items')"
+        [style.align-content]="getFlexAttribute('align-content')"
+        [style.gap]="options?.fxLayoutGap"
+        [style.justify-content]="getJustifyContent()"
+        [style.align-items]="getAlignItems()"></primeng-flex-layout-root-widget>
+      <div *ngIf="options?.showErrors && options?.errorMessage"
+        class="p-error"
+        [innerHTML]="options?.errorMessage"></div>
+    </div>
+
+    <fieldset *ngIf="containerType === 'fieldset'"
+      [class]="options?.htmlClass || ''"
+      [class.expandable]="options?.expandable && !expanded"
+      [class.expanded]="options?.expandable && expanded"
+      [disabled]="options?.readonly">
+      <legend *ngIf="sectionTitle"
+        [class]="'legend ' + (options?.labelHtmlClass || '')"
+        [innerHTML]="sectionTitle"
+        (click)="toggleExpanded()"></legend>
+      <primeng-flex-layout-root-widget *ngIf="expanded"
+        [layout]="layoutNode.items"
+        [dataIndex]="dataIndex"
+        [layoutIndex]="layoutIndex"
+        [isFlexItem]="getFlexAttribute('is-flex')"
+        [class.form-flex-column]="getFlexAttribute('flex-direction') === 'column'"
+        [class.form-flex-row]="getFlexAttribute('flex-direction') === 'row'"
+        [style.display]="getFlexAttribute('display')"
+        [style.flex-direction]="getFlexAttribute('flex-direction')"
+        [style.flex-wrap]="getFlexAttribute('flex-wrap')"
+        [style.justify-content]="getFlexAttribute('justify-content')"
+        [style.align-items]="getFlexAttribute('align-items')"
+        [style.align-content]="getFlexAttribute('align-content')"
+        [style.gap]="options?.fxLayoutGap"
+        [style.justify-content]="getJustifyContent()"
+        [style.align-items]="getAlignItems()"></primeng-flex-layout-root-widget>
+      <div *ngIf="options?.showErrors && options?.errorMessage"
+        class="p-error"
+        [innerHTML]="options?.errorMessage"></div>
+    </fieldset>
+
+    <div *ngIf="containerType === 'card'"
+      class="p-card"
+      [ngClass]="options?.htmlClass || ''"
+      [class.expandable]="options?.expandable && !expanded"
+      [class.expanded]="options?.expandable && expanded">
+      <div *ngIf="sectionTitle" class="p-card-header">
+        <legend
+          [class]="'legend ' + (options?.labelHtmlClass || '')"
+          [innerHTML]="sectionTitle"
+          (click)="toggleExpanded()"></legend>
+      </div>
+      <div *ngIf="expanded" class="p-card-content">
+        <fieldset [disabled]="options?.readonly">
+          <primeng-flex-layout-root-widget *ngIf="expanded"
+            [layout]="layoutNode.items"
+            [dataIndex]="dataIndex"
+            [layoutIndex]="layoutIndex"
+            [isFlexItem]="getFlexAttribute('is-flex')"
+            [class.form-flex-column]="getFlexAttribute('flex-direction') === 'column'"
+            [class.form-flex-row]="getFlexAttribute('flex-direction') === 'row'"
+            [style.display]="getFlexAttribute('display')"
+            [style.flex-direction]="getFlexAttribute('flex-direction')"
+            [style.flex-wrap]="getFlexAttribute('flex-wrap')"
+            [style.justify-content]="getFlexAttribute('justify-content')"
+            [style.align-items]="getFlexAttribute('align-items')"
+            [style.align-content]="getFlexAttribute('align-content')"
+            [style.gap]="options?.fxLayoutGap"
+            [style.justify-content]="getJustifyContent()"
+            [style.align-items]="getAlignItems()"></primeng-flex-layout-root-widget>
+          </fieldset>
+      </div>
+      <div class="p-card-footer">
+        <div *ngIf="options?.showErrors && options?.errorMessage"
+          class="p-error"
+          [innerHTML]="options?.errorMessage"></div>
+      </div>
+    </div>
+
+    <div *ngIf="containerType === 'expansion-panel'"
+      class="p-panel"
+      [class.expanded]="expanded"
+      [class.collapsed]="!expanded">
+      <div class="p-panel-header" (click)="toggleExpanded()">
+        <span *ngIf="sectionTitle"
+          [class]="options?.labelHtmlClass"
+          [innerHTML]="sectionTitle"></span>
+        <span *ngIf="options?.expandable" class="p-panel-toggler">
+          {{ expanded ? '&#x25BC;' : '&#x25B6;' }}
+        </span>
+      </div>
+      <div *ngIf="expanded" class="p-panel-content">
+        <fieldset [disabled]="options?.readonly">
+          <primeng-flex-layout-root-widget
+            [layout]="layoutNode.items"
+            [dataIndex]="dataIndex"
+            [layoutIndex]="layoutIndex"
+            [isFlexItem]="getFlexAttribute('is-flex')"
+            [class.form-flex-column]="getFlexAttribute('flex-direction') === 'column'"
+            [class.form-flex-row]="getFlexAttribute('flex-direction') === 'row'"
+            [style.display]="getFlexAttribute('display')"
+            [style.flex-direction]="getFlexAttribute('flex-direction')"
+            [style.flex-wrap]="getFlexAttribute('flex-wrap')"
+            [style.justify-content]="getFlexAttribute('justify-content')"
+            [style.align-items]="getFlexAttribute('align-items')"
+            [style.align-content]="getFlexAttribute('align-content')"
+            [style.gap]="options?.fxLayoutGap"
+            [style.justify-content]="getJustifyContent()"
+            [style.align-items]="getAlignItems()"></primeng-flex-layout-root-widget>
+        </fieldset>
+      </div>
+      <div *ngIf="options?.showErrors && options?.errorMessage"
+        class="p-error"
+        [innerHTML]="options?.errorMessage"></div>
+    </div>`,
+    styles: [`
+    fieldset { border: 0; margin: 0; padding: 0; }
+    .legend { font-weight: bold; }
+    .expandable > .legend:before { content: '▶'; padding-right: .3em; }
+    .expanded > .legend:before { content: '▼'; padding-right: .2em; }
+  `],
+    standalone: false
+})
+export class PrimengFlexLayoutSectionComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  expanded = true;
+  containerType = 'div';
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  get sectionTitle() {
+    return this.options.notitle ? null : this.jsf.setItemTitle(this);
+  }
+
+  ngOnInit() {
+    this.jsf.initializeControl(this);
+    this.options = this.layoutNode.options || {};
+    this.expanded = typeof this.options.expanded === 'boolean' ?
+      this.options.expanded : !this.options.expandable;
+    switch (this.layoutNode.type) {
+      case 'section': case 'array': case 'fieldset': case 'advancedfieldset':
+      case 'authfieldset': case 'optionfieldset': case 'selectfieldset':
+        this.containerType = 'fieldset';
+        break;
+      case 'card':
+        this.containerType = 'card';
+        break;
+      case 'expansion-panel':
+        this.containerType = 'expansion-panel';
+        break;
+      default: // 'div', 'flex', 'tab', 'conditional', 'actions'
+        this.containerType = 'div';
+    }
+  }
+
+  toggleExpanded() {
+    if (this.options.expandable) { this.expanded = !this.expanded; }
+  }
+
+  private static readonly ALIGN = {
+    start: 'flex-start', end: 'flex-end', center: 'center',
+    'space-between': 'space-between', 'space-around': 'space-around',
+    'space-evenly': 'space-evenly', stretch: 'stretch', baseline: 'baseline',
+  };
+
+  private fxAlign(position: number): string {
+    const value = `${(this.options || {}).fxLayoutAlign || ''}`.trim().split(/\s+/)[position];
+    return PrimengFlexLayoutSectionComponent.ALIGN[value] || null;
+  }
+
+  getJustifyContent(): string {
+    return this.getFlexAttribute('justify-content') || this.fxAlign(0);
+  }
+
+  getAlignItems(): string {
+    return this.getFlexAttribute('align-items') || this.fxAlign(1);
+  }
+
+  getFlexAttribute(attribute: string) {
+    const flexActive: boolean =
+      this.layoutNode.type === 'flex' ||
+      !!this.options.displayFlex ||
+      this.options.display === 'flex';
+    // if (attribute !== 'flex' && !flexActive) { return null; }
+    switch (attribute) {
+      case 'is-flex':
+        return flexActive;
+      case 'display':
+        return flexActive ? 'flex' : 'initial';
+      case 'flex-direction': case 'flex-wrap':
+        const index = ['flex-direction', 'flex-wrap'].indexOf(attribute);
+        return (this.options['flex-flow'] || '').split(/\s+/)[index] ||
+          this.options[attribute] || ['column', 'nowrap'][index];
+      case 'justify-content': case 'align-items': case 'align-content':
+        return this.options[attribute];
+    }
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/public_api.ts
@@ -1,0 +1,13 @@
+import { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
+import { PrimengFlexLayoutSectionComponent } from './primeng-flex-layout-section.component';
+import { PrimengAddReferenceComponent } from './primeng-add-reference.component';
+
+export { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
+export { PrimengFlexLayoutSectionComponent } from './primeng-flex-layout-section.component';
+export { PrimengAddReferenceComponent } from './primeng-add-reference.component';
+
+export const PRIMENG_FRAMEWORK_COMPONENTS = [
+  PrimengFlexLayoutRootComponent,
+  PrimengFlexLayoutSectionComponent,
+  PrimengAddReferenceComponent,
+];

--- a/projects/ajsf-primeng/src/public_api.ts
+++ b/projects/ajsf-primeng/src/public_api.ts
@@ -5,3 +5,4 @@
 export * from './lib/primeng-framework.module';
 export * from './lib/primeng-framework.component';
 export * from './lib/primeng.framework';
+export * from './lib/widgets/public_api';


### PR DESCRIPTION
## Summary

Adds the three structural layout components that every framework package needs: flex-layout root, flex-layout section, and add-reference. Ported from material with Material elements replaced by plain HTML.

## Changes

Three new components under `projects/ajsf-primeng/src/lib/widgets/`: `PrimengFlexLayoutRootComponent` (near-verbatim copy of material, no library surface), `PrimengFlexLayoutSectionComponent` (card and expansion-panel branches render as plain divs with CSS classes instead of mat-card and mat-expansion-panel), and `PrimengAddReferenceComponent` (plain button instead of mat-raised-button). The primeng framework class registers three widget map entries (root, section, $ref). Aliases are deferred to the widget PRs.

Selectors follow the `primeng-<name>-widget` convention. The section template references `primeng-flex-layout-root-widget` internally (not the material selector), so both frameworks coexist in the demo without collision.

A `widgets/public_api.ts` exports the components and a `PRIMENG_FRAMEWORK_COMPONENTS` array. The module declares and exports them alongside `ReactiveFormsModule`.

## Release impact

No release. The package is not published yet.

## Validation

All six packages build. Core 2156/2156, material 92/92, primeng 86/86 (76 corpus, 10 flex-layout-options). Corpus baseline unchanged. Demo builds without errors.