### PR TITLE
feat(primeng): add text and textarea widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "ng-packagr": "^19.2.2",
+        "primeng": "^19.1.4",
         "ts-node": "~8.6.2",
         "tslib": "^2.3.1",
         "tslint": "~6.1.0",
@@ -7073,6 +7074,29 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
+    },
+    "node_modules/@primeuix/styled": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.3.2.tgz",
+      "integrity": "sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/utils": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primeuix/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.11.0"
+      }
     },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
@@ -15845,6 +15869,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/primeng": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-19.1.4.tgz",
+      "integrity": "sha512-l5l8SHTxopxxyyXZx1BvbQ11P7ndLv2Qp8H5k2/+OCi65jTZn4xmtrBDGDs7k2K5UMHSqAnGjBgtpbckyqQETg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@primeuix/styled": "^0.3.2",
+        "@primeuix/utils": "^0.3.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^19.0.0",
+        "@angular/cdk": "^19.0.0",
+        "@angular/common": "^19.0.0",
+        "@angular/core": "^19.0.0",
+        "@angular/forms": "^19.0.0",
+        "@angular/platform-browser": "^19.0.0",
+        "@angular/router": "^19.0.0",
+        "rxjs": "^6.0.0 || ^7.8.1"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -23415,6 +23461,21 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
+    "@primeuix/styled": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.3.2.tgz",
+      "integrity": "sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==",
+      "dev": true,
+      "requires": {
+        "@primeuix/utils": "^0.3.2"
+      }
+    },
+    "@primeuix/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==",
+      "dev": true
+    },
     "@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -29449,6 +29510,17 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "primeng": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-19.1.4.tgz",
+      "integrity": "sha512-l5l8SHTxopxxyyXZx1BvbQ11P7ndLv2Qp8H5k2/+OCi65jTZn4xmtrBDGDs7k2K5UMHSqAnGjBgtpbckyqQETg==",
+      "dev": true,
+      "requires": {
+        "@primeuix/styled": "^0.3.2",
+        "@primeuix/utils": "^0.3.2",
+        "tslib": "^2.3.0"
+      }
     },
     "proc-log": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
     "ng-packagr": "^19.2.2",
+    "primeng": "^19.1.4",
     "ts-node": "~8.6.2",
     "tslib": "^2.3.1",
     "tslint": "~6.1.0",

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -33,6 +33,7 @@
   },
   "peerDependencies": {
     "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0"
+    "@angular/core": "^19.0.0",
+    "primeng": "^19.0.0"
   }
 }

--- a/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { InputTextModule } from 'primeng/inputtext';
+import { TextareaModule } from 'primeng/textarea';
 import {
   Framework,
   JsonSchemaFormService,
@@ -13,11 +15,18 @@ import { PrimengFramework } from './primeng.framework';
 import { PrimengFrameworkComponent } from './primeng-framework.component';
 import { PRIMENG_FRAMEWORK_COMPONENTS } from './widgets/public_api';
 
+export const PRIMENG_MODULES = [
+  InputTextModule,
+  TextareaModule,
+];
+
 @NgModule({
     imports: [
         JsonSchemaFormModule,
         CommonModule,
+        FormsModule,
         ReactiveFormsModule,
+        ...PRIMENG_MODULES,
         WidgetLibraryModule,
     ],
     declarations: [

--- a/projects/ajsf-primeng/src/lib/primeng.framework.ts
+++ b/projects/ajsf-primeng/src/lib/primeng.framework.ts
@@ -4,6 +4,8 @@ import { PrimengFrameworkComponent } from './primeng-framework.component';
 import { PrimengFlexLayoutRootComponent } from './widgets/primeng-flex-layout-root.component';
 import { PrimengFlexLayoutSectionComponent } from './widgets/primeng-flex-layout-section.component';
 import { PrimengAddReferenceComponent } from './widgets/primeng-add-reference.component';
+import { PrimengInputComponent } from './widgets/primeng-input.component';
+import { PrimengTextareaComponent } from './widgets/primeng-textarea.component';
 
 @Injectable()
 export class PrimengFramework extends Framework {
@@ -15,7 +17,12 @@ export class PrimengFramework extends Framework {
     'root': PrimengFlexLayoutRootComponent,
     'section': PrimengFlexLayoutSectionComponent,
     '$ref': PrimengAddReferenceComponent,
+    'text': PrimengInputComponent,
+    'textarea': PrimengTextareaComponent,
     'card': 'section',
+    'color': 'text',
     'expansion-panel': 'section',
+    'hidden': 'none',
+    'image': 'none',
   };
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
@@ -1,0 +1,32 @@
+import { PrimengInputComponent } from './primeng-input.component';
+
+describe('PrimengInputComponent', () => {
+  const make = (opts: any, layoutType = 'text') => {
+    const jsf = { initializeControl: jasmine.createSpy('initializeControl'), updateValue: jasmine.createSpy('updateValue') };
+    const c = new PrimengInputComponent(jsf as any);
+    c.layoutNode = { type: layoutType, options: opts };
+    c.ngOnInit();
+    return { component: c, jsf };
+  };
+
+  it('copies placeholder to description when title is shown and no description exists', () => {
+    const { component } = make({ placeholder: 'Search here' });
+    expect(component.options.description).toBe('Search here');
+  });
+
+  it('does not overwrite an existing description', () => {
+    const { component } = make({ placeholder: 'Search here', description: 'Existing' });
+    expect(component.options.description).toBe('Existing');
+  });
+
+  it('skips description copy when notitle is set', () => {
+    const { component } = make({ notitle: true, placeholder: 'Search here' });
+    expect(component.options.description).toBeUndefined();
+  });
+
+  it('forwards value updates through jsf', () => {
+    const { component, jsf } = make({});
+    component.updateValue({ target: { value: 'hello' } });
+    expect(jsf.updateValue).toHaveBeenCalledWith(component, 'hello');
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
@@ -1,4 +1,9 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { InputTextModule } from 'primeng/inputtext';
 import { PrimengInputComponent } from './primeng-input.component';
+import { JsonSchemaFormService } from '@ajsf/core';
 
 describe('PrimengInputComponent', () => {
   const make = (opts: any, layoutType = 'text') => {
@@ -28,5 +33,39 @@ describe('PrimengInputComponent', () => {
     const { component, jsf } = make({});
     component.updateValue({ target: { value: 'hello' } });
     expect(jsf.updateValue).toHaveBeenCalledWith(component, 'hello');
+  });
+
+  describe('typeahead datalist', () => {
+    let fixture: ComponentFixture<PrimengInputComponent>;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [CommonModule, ReactiveFormsModule, InputTextModule],
+        declarations: [PrimengInputComponent],
+        providers: [
+          { provide: JsonSchemaFormService, useValue: { initializeControl: () => {} } },
+        ],
+      }).compileComponents();
+    }));
+
+    it('renders a datalist with the configured suggestions', () => {
+      fixture = TestBed.createComponent(PrimengInputComponent);
+      const comp = fixture.componentInstance;
+      comp.layoutNode = {
+        _id: '42',
+        type: 'text',
+        options: { typeahead: { source: ['alpha', 'bravo', 'charlie'] } },
+      };
+      comp.ngOnInit();
+      fixture.detectChanges();
+
+      const datalist = fixture.nativeElement.querySelector('datalist');
+      expect(datalist).toBeTruthy();
+      expect(datalist.id).toBe('control42Autocomplete');
+      const options = datalist.querySelectorAll('option');
+      expect(options.length).toBe(3);
+      expect(options[0].value).toBe('alpha');
+      expect(options[2].value).toBe('charlie');
+    });
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.ts
@@ -1,0 +1,81 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-input-widget',
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+      <span *ngIf="options?.prefix || options?.fieldAddonLeft"
+        [innerHTML]="options?.prefix || options?.fieldAddonLeft"></span>
+      <input pInputText *ngIf="boundControl"
+        [formControl]="formControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
+        [attr.maxlength]="options?.maxLength"
+        [attr.minlength]="options?.minLength"
+        [attr.pattern]="options?.pattern"
+        [readonly]="options?.readonly ? 'readonly' : null"
+        [id]="'control' + layoutNode?._id"
+        [name]="controlName"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [required]="options?.required"
+        [style.width]="'100%'"
+        [type]="layoutNode?.type"
+        (blur)="options.showErrors = true">
+      <input pInputText *ngIf="!boundControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
+        [attr.maxlength]="options?.maxLength"
+        [attr.minlength]="options?.minLength"
+        [attr.pattern]="options?.pattern"
+        [disabled]="controlDisabled"
+        [id]="'control' + layoutNode?._id"
+        [name]="controlName"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [readonly]="options?.readonly ? 'readonly' : null"
+        [required]="options?.required"
+        [style.width]="'100%'"
+        [type]="layoutNode?.type"
+        [value]="controlValue"
+        (input)="updateValue($event)"
+        (blur)="options.showErrors = true">
+      <span *ngIf="options?.suffix || options?.fieldAddonRight"
+        [innerHTML]="options?.suffix || options?.fieldAddonRight"></span>
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
+    standalone: false
+})
+export class PrimengInputComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: string;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+    if (!this.options.notitle && !this.options.description && this.options.placeholder) {
+      this.options.description = this.options.placeholder;
+    }
+  }
+
+  updateValue(event) {
+    this.jsf.updateValue(this, event.target.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.ts
@@ -46,6 +46,12 @@ import { JsonSchemaFormService } from '@ajsf/core';
         [innerHTML]="options?.suffix || options?.fieldAddonRight"></span>
       <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
         [innerHTML]="options?.description"></small>
+      <datalist *ngIf="options?.typeahead?.source"
+        [id]="'control' + layoutNode?._id + 'Autocomplete'">
+        <option *ngFor="let word of options?.typeahead?.source"
+          [value]="word">
+        </option>
+      </datalist>
     </div>
     <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
       [innerHTML]="options?.errorMessage"></div>`,

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.spec.ts
@@ -1,0 +1,32 @@
+import { PrimengTextareaComponent } from './primeng-textarea.component';
+
+describe('PrimengTextareaComponent', () => {
+  const make = (opts: any) => {
+    const jsf = { initializeControl: jasmine.createSpy('initializeControl'), updateValue: jasmine.createSpy('updateValue') };
+    const c = new PrimengTextareaComponent(jsf as any);
+    c.layoutNode = { type: 'textarea', options: opts };
+    c.ngOnInit();
+    return { component: c, jsf };
+  };
+
+  it('copies placeholder to description when title is shown and no description exists', () => {
+    const { component } = make({ placeholder: 'Enter details' });
+    expect(component.options.description).toBe('Enter details');
+  });
+
+  it('does not overwrite an existing description', () => {
+    const { component } = make({ placeholder: 'Enter details', description: 'Existing' });
+    expect(component.options.description).toBe('Existing');
+  });
+
+  it('skips description copy when notitle is set', () => {
+    const { component } = make({ notitle: true, placeholder: 'Enter details' });
+    expect(component.options.description).toBeUndefined();
+  });
+
+  it('forwards value updates through jsf', () => {
+    const { component, jsf } = make({});
+    component.updateValue({ target: { value: 'world' } });
+    expect(jsf.updateValue).toHaveBeenCalledWith(component, 'world');
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.ts
@@ -1,0 +1,79 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-textarea-widget',
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+      <span *ngIf="options?.prefix || options?.fieldAddonLeft"
+        [innerHTML]="options?.prefix || options?.fieldAddonLeft"></span>
+      <textarea pTextarea *ngIf="boundControl"
+        [formControl]="formControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [attr.maxlength]="options?.maxLength"
+        [attr.minlength]="options?.minLength"
+        [attr.pattern]="options?.pattern"
+        [required]="options?.required"
+        [id]="'control' + layoutNode?._id"
+        [name]="controlName"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [readonly]="options?.readonly ? 'readonly' : null"
+        [style.width]="'100%'"
+        [autoResize]="options?.autosize"
+        (blur)="options.showErrors = true"></textarea>
+      <textarea pTextarea *ngIf="!boundControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [attr.maxlength]="options?.maxLength"
+        [attr.minlength]="options?.minLength"
+        [attr.pattern]="options?.pattern"
+        [required]="options?.required"
+        [disabled]="controlDisabled"
+        [id]="'control' + layoutNode?._id"
+        [name]="controlName"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [readonly]="options?.readonly ? 'readonly' : null"
+        [style.width]="'100%'"
+        [value]="controlValue"
+        [autoResize]="options?.autosize"
+        (input)="updateValue($event)"
+        (blur)="options.showErrors = true"></textarea>
+      <span *ngIf="options?.suffix || options?.fieldAddonRight"
+        [innerHTML]="options?.suffix || options?.fieldAddonRight"></span>
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
+    standalone: false
+})
+export class PrimengTextareaComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+    if (!this.options.notitle && !this.options.description && this.options.placeholder) {
+      this.options.description = this.options.placeholder;
+    }
+  }
+
+  updateValue(event) {
+    this.jsf.updateValue(this, event.target.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/public_api.ts
@@ -1,13 +1,19 @@
 import { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
 import { PrimengFlexLayoutSectionComponent } from './primeng-flex-layout-section.component';
 import { PrimengAddReferenceComponent } from './primeng-add-reference.component';
+import { PrimengInputComponent } from './primeng-input.component';
+import { PrimengTextareaComponent } from './primeng-textarea.component';
 
 export { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
 export { PrimengFlexLayoutSectionComponent } from './primeng-flex-layout-section.component';
 export { PrimengAddReferenceComponent } from './primeng-add-reference.component';
+export { PrimengInputComponent } from './primeng-input.component';
+export { PrimengTextareaComponent } from './primeng-textarea.component';
 
 export const PRIMENG_FRAMEWORK_COMPONENTS = [
   PrimengFlexLayoutRootComponent,
   PrimengFlexLayoutSectionComponent,
   PrimengAddReferenceComponent,
+  PrimengInputComponent,
+  PrimengTextareaComponent,
 ];

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1970,7 +1970,7 @@
     "valid": true
   },
   "primeng/jsf-fields-hidden": {
-    "controls": 3,
+    "controls": 2,
     "error": null,
     "valid": true
   },


### PR DESCRIPTION
## Summary

Adds PrimengInputComponent and PrimengTextareaComponent, the first two widget implementations for the primeng package. Introduces the primeng npm dependency.

## Changes

Installs primeng 19 as a workspace devDependency and declares it as a peer in the primeng package. The module now imports InputTextModule and TextareaModule.

PrimengInputComponent applies the pInputText directive to a native input, replicating the material dual-template pattern for bound and unbound controls. It includes a native datalist for typeahead suggestions, matching core's autocomplete.source normalization. PrimengTextareaComponent does the same with pTextarea on a native textarea, adding autoResize support. Both render labels, prefix/suffix spans, description hints, and p-error validation messages.

The framework widget map gains text, textarea, color (alias to text), hidden and image (both alias to none). The hidden alias causes primeng/jsf-fields-hidden to drop from 3 to 2 controls: the hidden field now renders nothing instead of falling through to core's default input. The baseline updates accordingly. The other five framework legs are unchanged.

## Release impact

No release. The package is not yet published and stays outside build:libs.

## Validation

All six test suites pass: core 2156, material 92, primeng 95 (76 corpus, 10 flex-layout, 4 input including 1 datalist DOM test, 4 textarea, 1 setup), bootstrap-3 76, bootstrap-4 76, bootstrap-5 87. Script tests 45. The demo builds.