### PR TITLE
feat(primeng): add wave 3 composite widgets

### DIFF
--- a/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
@@ -11,6 +11,9 @@ import { RadioButtonModule } from 'primeng/radiobutton';
 import { ButtonModule } from 'primeng/button';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { MultiSelectModule } from 'primeng/multiselect';
+import { DatePickerModule } from 'primeng/datepicker';
+import { SliderModule } from 'primeng/slider';
+import { TabsModule } from 'primeng/tabs';
 import {
   Framework,
   JsonSchemaFormService,
@@ -34,6 +37,9 @@ export const PRIMENG_MODULES = [
   ButtonModule,
   SelectButtonModule,
   MultiSelectModule,
+  DatePickerModule,
+  SliderModule,
+  TabsModule,
 ];
 
 @NgModule({

--- a/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.module.ts
@@ -14,6 +14,9 @@ import { MultiSelectModule } from 'primeng/multiselect';
 import { DatePickerModule } from 'primeng/datepicker';
 import { SliderModule } from 'primeng/slider';
 import { TabsModule } from 'primeng/tabs';
+import { AutoCompleteModule } from 'primeng/autocomplete';
+import { FileUploadModule } from 'primeng/fileupload';
+import { StepperModule } from 'primeng/stepper';
 import {
   Framework,
   JsonSchemaFormService,
@@ -40,6 +43,9 @@ export const PRIMENG_MODULES = [
   DatePickerModule,
   SliderModule,
   TabsModule,
+  AutoCompleteModule,
+  FileUploadModule,
+  StepperModule,
 ];
 
 @NgModule({

--- a/projects/ajsf-primeng/src/lib/primeng.framework.ts
+++ b/projects/ajsf-primeng/src/lib/primeng.framework.ts
@@ -14,6 +14,12 @@ import { PrimengCheckboxesComponent } from './widgets/primeng-checkboxes.compone
 import { PrimengRadiosComponent } from './widgets/primeng-radios.component';
 import { PrimengButtonComponent } from './widgets/primeng-button.component';
 import { PrimengButtonGroupComponent } from './widgets/primeng-button-group.component';
+import { PrimengDatepickerComponent } from './widgets/primeng-datepicker.component';
+import { PrimengSliderComponent } from './widgets/primeng-slider.component';
+import { PrimengTabsComponent } from './widgets/primeng-tabs.component';
+import { PrimengFileComponent } from './widgets/primeng-file.component';
+import { PrimengChipListComponent } from './widgets/primeng-chip-list.component';
+import { PrimengStepperComponent } from './widgets/primeng-stepper.component';
 
 @Injectable()
 export class PrimengFramework extends Framework {
@@ -35,6 +41,12 @@ export class PrimengFramework extends Framework {
     'radios': PrimengRadiosComponent,
     'button': PrimengButtonComponent,
     'button-group': PrimengButtonGroupComponent,
+    'date': PrimengDatepickerComponent,
+    'slider': PrimengSliderComponent,
+    'tabs': PrimengTabsComponent,
+    'file': PrimengFileComponent,
+    'chip-list': PrimengChipListComponent,
+    'stepper': PrimengStepperComponent,
     'any-of': 'one-of',
     'integer': 'number',
     'radiobuttons': 'button-group',
@@ -44,5 +56,9 @@ export class PrimengFramework extends Framework {
     'expansion-panel': 'section',
     'hidden': 'none',
     'image': 'none',
+    'alt-date': 'date',
+    'range': 'slider',
+    'tagsinput': 'chip-list',
+    'wizard': 'stepper',
   };
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
@@ -3,7 +3,7 @@ import { PrimengChipListComponent } from './primeng-chip-list.component';
 describe('PrimengChipListComponent', () => {
   const jsf = () => ({
     initializeControl: jasmine.createSpy('initializeControl'),
-    updateValue: jasmine.createSpy('updateValue'),
+    updateArrayCheckboxList: jasmine.createSpy('updateArrayCheckboxList'),
   });
 
   const make = (node: any) => {
@@ -57,14 +57,17 @@ describe('PrimengChipListComponent', () => {
     expect(component.suggestions).toEqual([]);
   });
 
-  it('forwards array value updates through jsf', () => {
+  it('forwards array value updates through updateArrayCheckboxList', () => {
     const { component, jsf: j } = make({
       type: 'chip-list',
       options: {},
     });
     const tags = ['foo', 'bar'];
     component.updateValue(tags);
-    expect(j.updateValue).toHaveBeenCalledWith(component, tags);
+    expect(j.updateArrayCheckboxList).toHaveBeenCalledWith(component, [
+      { checked: true, value: 'foo' },
+      { checked: true, value: 'bar' },
+    ]);
     expect(component.options.showErrors).toBe(true);
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
@@ -27,7 +27,7 @@ describe('PrimengChipListComponent', () => {
       type: 'chip-list',
       options: {},
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything());
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
   });
 
   it('filters suggestions from typeahead source', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
@@ -1,0 +1,70 @@
+import { PrimengChipListComponent } from './primeng-chip-list.component';
+
+describe('PrimengChipListComponent', () => {
+  const jsf = () => ({
+    initializeControl: jasmine.createSpy('initializeControl'),
+    updateValue: jasmine.createSpy('updateValue'),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengChipListComponent(j as any);
+    c.layoutNode = node;
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('reads options from layoutNode', () => {
+    const { component } = make({
+      type: 'chip-list',
+      options: { title: 'Tags' },
+    });
+    expect(component.options.title).toBe('Tags');
+  });
+
+  it('calls initializeControl without bound mode', () => {
+    const { jsf: j } = make({
+      type: 'chip-list',
+      options: {},
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything());
+  });
+
+  it('filters suggestions from typeahead source', () => {
+    const { component } = make({
+      type: 'chip-list',
+      options: { typeahead: { source: ['apple', 'banana', 'apricot'] } },
+    });
+    component.search({ query: 'ap' });
+    expect(component.suggestions).toEqual(['apple', 'apricot']);
+  });
+
+  it('returns all suggestions on empty query', () => {
+    const { component } = make({
+      type: 'chip-list',
+      options: { typeahead: { source: ['a', 'b'] } },
+    });
+    component.search({ query: '' });
+    expect(component.suggestions).toEqual(['a', 'b']);
+  });
+
+  it('handles missing typeahead source', () => {
+    const { component } = make({
+      type: 'chip-list',
+      options: {},
+    });
+    component.search({ query: 'test' });
+    expect(component.suggestions).toEqual([]);
+  });
+
+  it('forwards array value updates through jsf', () => {
+    const { component, jsf: j } = make({
+      type: 'chip-list',
+      options: {},
+    });
+    const tags = ['foo', 'bar'];
+    component.updateValue(tags);
+    expect(j.updateValue).toHaveBeenCalledWith(component, tags);
+    expect(component.options.showErrors).toBe(true);
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
@@ -63,6 +63,7 @@ export class PrimengChipListComponent implements OnInit {
   updateValue(event) {
     this.options.showErrors = true;
     const tags: string[] = Array.isArray(event) ? event : [];
+    this.controlValue = tags;
     this.jsf.updateArrayCheckboxList(
       this, tags.map(value => ({checked: true, value}))
     );

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
@@ -1,0 +1,31 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-chip-list-widget',
+    template: ``,
+    standalone: false
+})
+export class PrimengChipListComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+  }
+
+  updateValue(event) {
+    this.jsf.updateValue(this, event.target.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
@@ -4,7 +4,33 @@ import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
     selector: 'primeng-chip-list-widget',
-    template: ``,
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+
+      <p-autocomplete
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [inputId]="'control' + layoutNode?._id"
+        [disabled]="controlDisabled || options?.readonly"
+        [multiple]="true"
+        [typeahead]="false"
+        [suggestions]="suggestions"
+        [placeholder]="options?.placeholder || ''"
+        [fluid]="true"
+        [ngModel]="controlValue"
+        (ngModelChange)="updateValue($event)"
+        (completeMethod)="search($event)"
+        (onBlur)="options.showErrors = true"></p-autocomplete>
+
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
     standalone: false
 })
 export class PrimengChipListComponent implements OnInit {
@@ -14,6 +40,7 @@ export class PrimengChipListComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  suggestions: string[] = [];
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -25,7 +52,16 @@ export class PrimengChipListComponent implements OnInit {
     this.jsf.initializeControl(this);
   }
 
+  search(event) {
+    const source: string[] = this.options?.typeahead?.source || [];
+    const query = (event.query || '').toLowerCase();
+    this.suggestions = query
+      ? source.filter(s => s.toLowerCase().includes(query))
+      : source.slice();
+  }
+
   updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+    this.options.showErrors = true;
+    this.jsf.updateValue(this, event);
   }
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
@@ -62,6 +62,9 @@ export class PrimengChipListComponent implements OnInit {
 
   updateValue(event) {
     this.options.showErrors = true;
-    this.jsf.updateValue(this, event);
+    const tags: string[] = Array.isArray(event) ? event : [];
+    this.jsf.updateArrayCheckboxList(
+      this, tags.map(value => ({checked: true, value}))
+    );
   }
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.ts
@@ -49,7 +49,7 @@ export class PrimengChipListComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    this.jsf.initializeControl(this, false);
   }
 
   search(event) {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
@@ -1,0 +1,93 @@
+import { PrimengDatepickerComponent } from './primeng-datepicker.component';
+
+describe('PrimengDatepickerComponent', () => {
+  const jsf = () => ({
+    initializeControl: jasmine.createSpy('initializeControl'),
+    updateValue: jasmine.createSpy('updateValue'),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengDatepickerComponent(j as any);
+    c.layoutNode = node;
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('reads options from layoutNode', () => {
+    const { component } = make({
+      type: 'date',
+      options: { title: 'Birth date' },
+    });
+    expect(component.options.title).toBe('Birth date');
+  });
+
+  it('calls initializeControl with writable binding', () => {
+    const { jsf: j } = make({
+      type: 'date',
+      options: {},
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+  });
+
+  it('respects readonly option', () => {
+    const { jsf: j } = make({
+      type: 'date',
+      options: { readonly: true },
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+  });
+
+  it('converts minimum to minDate', () => {
+    const { component } = make({
+      type: 'date',
+      options: { minimum: '2020-01-01' },
+    });
+    expect(component.minDate).toEqual(new Date('2020-01-01'));
+  });
+
+  it('converts maximum to maxDate', () => {
+    const { component } = make({
+      type: 'date',
+      options: { maximum: '2030-12-31' },
+    });
+    expect(component.maxDate).toEqual(new Date('2030-12-31'));
+  });
+
+  it('leaves minDate/maxDate undefined when not specified', () => {
+    const { component } = make({
+      type: 'date',
+      options: {},
+    });
+    expect(component.minDate).toBeUndefined();
+    expect(component.maxDate).toBeUndefined();
+  });
+
+  it('converts controlValue to dateValue', () => {
+    const j = jsf();
+    const c = new PrimengDatepickerComponent(j as any);
+    c.layoutNode = { type: 'date', options: {} };
+    c.controlValue = '2025-06-15';
+    c.ngOnInit();
+    expect(c.dateValue).toEqual(new Date('2025-06-15'));
+  });
+
+  it('falls back description to placeholder', () => {
+    const { component } = make({
+      type: 'date',
+      options: { placeholder: 'Pick a date' },
+    });
+    expect(component.options.description).toBe('Pick a date');
+  });
+
+  it('forwards value updates through jsf', () => {
+    const { component, jsf: j } = make({
+      type: 'date',
+      options: {},
+    });
+    const date = new Date('2025-08-29');
+    component.updateValue(date);
+    expect(j.updateValue).toHaveBeenCalledWith(component, date);
+    expect(component.options.showErrors).toBe(true);
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
@@ -38,20 +38,20 @@ describe('PrimengDatepickerComponent', () => {
     expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
   });
 
-  it('converts minimum to minDate', () => {
+  it('parses minimum as a local date', () => {
     const { component } = make({
       type: 'date',
-      options: { minimum: '2020-01-01' },
+      options: { minimum: '2020-01-15' },
     });
-    expect(component.minDate).toEqual(new Date('2020-01-01'));
+    expect(component.minDate).toEqual(new Date(2020, 0, 15));
   });
 
-  it('converts maximum to maxDate', () => {
+  it('parses maximum as a local date', () => {
     const { component } = make({
       type: 'date',
       options: { maximum: '2030-12-31' },
     });
-    expect(component.maxDate).toEqual(new Date('2030-12-31'));
+    expect(component.maxDate).toEqual(new Date(2030, 11, 31));
   });
 
   it('leaves minDate/maxDate undefined when not specified', () => {
@@ -63,15 +63,6 @@ describe('PrimengDatepickerComponent', () => {
     expect(component.maxDate).toBeUndefined();
   });
 
-  it('converts controlValue to dateValue', () => {
-    const j = jsf();
-    const c = new PrimengDatepickerComponent(j as any);
-    c.layoutNode = { type: 'date', options: {} };
-    c.controlValue = '2025-06-15';
-    c.ngOnInit();
-    expect(c.dateValue).toEqual(new Date('2025-06-15'));
-  });
-
   it('falls back description to placeholder', () => {
     const { component } = make({
       type: 'date',
@@ -80,14 +71,13 @@ describe('PrimengDatepickerComponent', () => {
     expect(component.options.description).toBe('Pick a date');
   });
 
-  it('forwards value updates through jsf', () => {
+  it('forwards string values through jsf', () => {
     const { component, jsf: j } = make({
       type: 'date',
       options: {},
     });
-    const date = new Date('2025-08-29');
-    component.updateValue(date);
-    expect(j.updateValue).toHaveBeenCalledWith(component, date);
+    component.updateValue('2025-08-29');
+    expect(j.updateValue).toHaveBeenCalledWith(component, '2025-08-29');
     expect(component.options.showErrors).toBe(true);
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.ts
@@ -21,6 +21,8 @@ import { JsonSchemaFormService } from '@ajsf/core';
         [showIcon]="true"
         [fluid]="true"
         [showButtonBar]="true"
+        dataType="string"
+        dateFormat="yy-mm-dd"
         (onBlur)="options.showErrors = true"></p-datepicker>
 
       <p-datepicker *ngIf="!boundControl"
@@ -35,8 +37,10 @@ import { JsonSchemaFormService } from '@ajsf/core';
         [showIcon]="true"
         [fluid]="true"
         [showButtonBar]="true"
-        [ngModel]="dateValue"
-        (onSelect)="updateValue($event)"
+        dataType="string"
+        dateFormat="yy-mm-dd"
+        [ngModel]="controlValue"
+        (ngModelChange)="updateValue($event)"
         (onBlur)="options.showErrors = true"></p-datepicker>
 
       <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
@@ -56,7 +60,6 @@ export class PrimengDatepickerComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
-  dateValue: Date;
   minDate: Date;
   maxDate: Date;
   @Input() layoutNode: any;
@@ -69,13 +72,10 @@ export class PrimengDatepickerComponent implements OnInit {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this, !this.options.readonly);
     if (this.options.minimum) {
-      this.minDate = new Date(this.options.minimum);
+      this.minDate = this.parseLocalDate(this.options.minimum);
     }
     if (this.options.maximum) {
-      this.maxDate = new Date(this.options.maximum);
-    }
-    if (this.controlValue) {
-      this.dateValue = new Date(this.controlValue);
+      this.maxDate = this.parseLocalDate(this.options.maximum);
     }
     if (!this.options.notitle && !this.options.description && this.options.placeholder) {
       this.options.description = this.options.placeholder;
@@ -85,5 +85,10 @@ export class PrimengDatepickerComponent implements OnInit {
   updateValue(event) {
     this.options.showErrors = true;
     this.jsf.updateValue(this, event);
+  }
+
+  private parseLocalDate(value: string): Date {
+    const [y, m, d] = value.split('-').map(Number);
+    return new Date(y, m - 1, d);
   }
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.ts
@@ -1,0 +1,89 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-datepicker-widget',
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+
+      <p-datepicker *ngIf="boundControl"
+        [formControl]="formControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [inputId]="'control' + layoutNode?._id"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [readonlyInput]="options?.readonly"
+        [required]="options?.required"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        [showIcon]="true"
+        [fluid]="true"
+        [showButtonBar]="true"
+        (onBlur)="options.showErrors = true"></p-datepicker>
+
+      <p-datepicker *ngIf="!boundControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [inputId]="'control' + layoutNode?._id"
+        [disabled]="controlDisabled || options?.readonly"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [readonlyInput]="options?.readonly"
+        [required]="options?.required"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        [showIcon]="true"
+        [fluid]="true"
+        [showButtonBar]="true"
+        [ngModel]="dateValue"
+        (onSelect)="updateValue($event)"
+        (onBlur)="options.showErrors = true"></p-datepicker>
+
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
+    standalone: false
+})
+export class PrimengDatepickerComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  dateValue: Date;
+  minDate: Date;
+  maxDate: Date;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this, !this.options.readonly);
+    if (this.options.minimum) {
+      this.minDate = new Date(this.options.minimum);
+    }
+    if (this.options.maximum) {
+      this.maxDate = new Date(this.options.maximum);
+    }
+    if (this.controlValue) {
+      this.dateValue = new Date(this.controlValue);
+    }
+    if (!this.options.notitle && !this.options.description && this.options.placeholder) {
+      this.options.description = this.options.placeholder;
+    }
+  }
+
+  updateValue(event) {
+    this.options.showErrors = true;
+    this.jsf.updateValue(this, event);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.spec.ts
@@ -1,0 +1,79 @@
+import { PrimengFileComponent } from './primeng-file.component';
+
+describe('PrimengFileComponent', () => {
+  const jsf = () => ({
+    initializeControl: jasmine.createSpy('initializeControl'),
+    updateValue: jasmine.createSpy('updateValue'),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengFileComponent(j as any);
+    c.layoutNode = node;
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('reads options from layoutNode', () => {
+    const { component } = make({
+      type: 'file',
+      options: { title: 'Upload' },
+    });
+    expect(component.options.title).toBe('Upload');
+  });
+
+  it('calls initializeControl with writable binding', () => {
+    const { jsf: j } = make({
+      type: 'file',
+      options: {},
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+  });
+
+  it('respects readonly option', () => {
+    const { jsf: j } = make({
+      type: 'file',
+      options: { readonly: true },
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+  });
+
+  it('reads a file as data URL and updates value', (done) => {
+    const { component, jsf: j } = make({
+      type: 'file',
+      options: {},
+    });
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+    const file = new File([blob], 'test.txt', { type: 'text/plain' });
+
+    const originalFileReader = (window as any).FileReader;
+    const mockReader = {
+      result: 'data:text/plain;base64,aGVsbG8=',
+      readAsDataURL(_file: File) {
+        setTimeout(() => this.onload(), 0);
+      },
+      onload: null as any,
+    };
+    (window as any).FileReader = function() { return mockReader; };
+
+    component.onSelect({ files: [file] });
+
+    setTimeout(() => {
+      expect(component.fileName).toBe('test.txt');
+      expect(j.updateValue).toHaveBeenCalledWith(component, 'data:text/plain;base64,aGVsbG8=');
+      expect(component.options.showErrors).toBe(true);
+      (window as any).FileReader = originalFileReader;
+      done();
+    }, 50);
+  });
+
+  it('does nothing when no file is selected', () => {
+    const { component, jsf: j } = make({
+      type: 'file',
+      options: {},
+    });
+    component.onSelect({ files: [] });
+    expect(component.fileName).toBe('');
+    expect(j.updateValue).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.ts
@@ -1,0 +1,31 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-file-widget',
+    template: ``,
+    standalone: false
+})
+export class PrimengFileComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+  }
+
+  updateValue(event) {
+    this.jsf.updateValue(this, event.target.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.ts
@@ -4,7 +4,32 @@ import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
     selector: 'primeng-file-widget',
-    template: ``,
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+
+      <p-fileupload
+        mode="basic"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [disabled]="controlDisabled || options?.readonly"
+        [accept]="options?.accept || ''"
+        [chooseLabel]="options?.placeholder || 'Choose'"
+        [auto]="true"
+        [customUpload]="true"
+        (uploadHandler)="onSelect($event)"></p-fileupload>
+
+      <span *ngIf="fileName" class="p-text-secondary" style="margin-left: 0.5rem">
+        {{fileName}}</span>
+
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
     standalone: false
 })
 export class PrimengFileComponent implements OnInit {
@@ -14,6 +39,7 @@ export class PrimengFileComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  fileName = '';
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -22,10 +48,18 @@ export class PrimengFileComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    this.jsf.initializeControl(this, !this.options.readonly);
   }
 
-  updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+  onSelect(event) {
+    const file: File = event.files?.[0];
+    if (!file) return;
+    this.fileName = file.name;
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.options.showErrors = true;
+      this.jsf.updateValue(this, reader.result as string);
+    };
+    reader.readAsDataURL(file);
   }
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
@@ -1,0 +1,101 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PrimengFrameworkModule } from '../primeng-framework.module';
+
+@Component({
+    template: `
+    <json-schema-form
+      [schema]="schema"
+      [layout]="layout"
+      [data]="data"
+      framework="primeng"
+      (onChanges)="value = $event"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+    standalone: false
+})
+class IntegrationHostComponent {
+  schema: any = {};
+  layout: any;
+  data: any;
+  value: any;
+  valid: boolean | null = null;
+}
+
+describe('PrimeNG integration', () => {
+  let fixture: ComponentFixture<IntegrationHostComponent>;
+  let host: IntegrationHostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [PrimengFrameworkModule, NoopAnimationsModule],
+      declarations: [IntegrationHostComponent],
+      schemas: [],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IntegrationHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  describe('datepicker', () => {
+    beforeEach(() => {
+      host.schema = {
+        type: 'object',
+        properties: {
+          birthday: {type: 'string', format: 'date'}
+        }
+      };
+      host.data = {birthday: '2025-06-15'};
+      fixture.detectChanges();
+    });
+
+    it('renders a p-datepicker', () => {
+      const dp = fixture.nativeElement.querySelector('p-datepicker');
+      expect(dp).toBeTruthy();
+    });
+
+    it('emits a string value, not a Date', () => {
+      expect(host.value).toBeTruthy();
+      expect(typeof host.value.birthday).toBe('string');
+    });
+
+    it('keeps the form valid with a date string', () => {
+      expect(host.valid).toBe(true);
+    });
+
+    it('displays the initial value in the input', () => {
+      const input = fixture.nativeElement.querySelector('p-datepicker input');
+      expect(input).toBeTruthy();
+      expect(input.value).toContain('2025');
+    });
+  });
+
+  describe('chip-list', () => {
+    beforeEach(() => {
+      host.schema = {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: {type: 'string'}
+          }
+        }
+      };
+      host.layout = [{key: 'tags', type: 'chip-list'}];
+      host.data = {tags: ['a', 'b']};
+      fixture.detectChanges();
+    });
+
+    it('renders a p-autocomplete', () => {
+      const ac = fixture.nativeElement.querySelector('p-autocomplete');
+      expect(ac).toBeTruthy();
+    });
+
+    it('does not throw on render with array data', () => {
+      expect(() => fixture.detectChanges()).not.toThrow();
+    });
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PrimengFrameworkModule } from '../primeng-framework.module';
 
@@ -94,8 +95,12 @@ describe('PrimeNG integration', () => {
       expect(ac).toBeTruthy();
     });
 
-    it('does not throw on render with array data', () => {
-      expect(() => fixture.detectChanges()).not.toThrow();
+    it('updates form data when tags change', () => {
+      const de = fixture.debugElement.query(By.css('primeng-chip-list-widget'));
+      const chipList = de.componentInstance;
+      chipList.updateValue(['a', 'b', 'c']);
+      fixture.detectChanges();
+      expect(host.value.tags).toEqual(['a', 'b', 'c']);
     });
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.spec.ts
@@ -1,0 +1,99 @@
+import { PrimengSliderComponent } from './primeng-slider.component';
+
+describe('PrimengSliderComponent', () => {
+  const jsf = () => ({
+    initializeControl: jasmine.createSpy('initializeControl'),
+    updateValue: jasmine.createSpy('updateValue'),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengSliderComponent(j as any);
+    c.layoutNode = node;
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('reads options from layoutNode', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { minimum: 0, maximum: 100, multipleOf: 5 },
+    });
+    expect(component.options.minimum).toBe(0);
+    expect(component.options.maximum).toBe(100);
+  });
+
+  it('calls initializeControl with writable binding', () => {
+    const { jsf: j } = make({
+      type: 'slider',
+      options: {},
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+  });
+
+  it('respects readonly option', () => {
+    const { jsf: j } = make({
+      type: 'slider',
+      options: { readonly: true },
+    });
+    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+  });
+
+  it('computes minValue from options.minimum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { minimum: 10 },
+    });
+    expect(component.minValue).toBe(10);
+  });
+
+  it('computes maxValue from options.maximum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { maximum: 200 },
+    });
+    expect(component.maxValue).toBe(200);
+  });
+
+  it('handles exclusiveMinimum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { exclusiveMinimum: 5 },
+    });
+    expect(component.minValue).toBe(5);
+  });
+
+  it('handles exclusiveMaximum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { exclusiveMaximum: 100 },
+    });
+    expect(component.maxValue).toBe(100);
+  });
+
+  it('picks the tighter of minimum and exclusiveMinimum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { minimum: 2, exclusiveMinimum: 8 },
+    });
+    expect(component.minValue).toBe(8);
+  });
+
+  it('picks the tighter of maximum and exclusiveMaximum', () => {
+    const { component } = make({
+      type: 'slider',
+      options: { maximum: 50, exclusiveMaximum: 30 },
+    });
+    expect(component.maxValue).toBe(30);
+  });
+
+  it('forwards value updates through jsf', () => {
+    const { component, jsf: j } = make({
+      type: 'slider',
+      options: {},
+    });
+    component.updateValue({ value: 42 });
+    expect(j.updateValue).toHaveBeenCalledWith(component, 42);
+    expect(component.options.showErrors).toBe(true);
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.ts
@@ -1,0 +1,67 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService, effectiveMinimum, effectiveMaximum } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-slider-widget',
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [attr.for]="'control' + layoutNode?._id">{{options?.title}}</label>
+
+      <p-slider *ngIf="boundControl"
+        [formControl]="formControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [min]="minValue"
+        [max]="maxValue"
+        [step]="options?.multipleOf || options?.step || 1"
+        [style]="{'width': '100%'}"
+        (onSlideEnd)="options.showErrors = true"></p-slider>
+
+      <p-slider *ngIf="!boundControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [disabled]="controlDisabled || options?.readonly"
+        [min]="minValue"
+        [max]="maxValue"
+        [step]="options?.multipleOf || options?.step || 1"
+        [style]="{'width': '100%'}"
+        [ngModel]="controlValue"
+        (onChange)="updateValue($event)"
+        (onSlideEnd)="options.showErrors = true"></p-slider>
+
+      <small *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"></small>
+    </div>
+    <div class="p-error" *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></div>`,
+    styles: [`
+    .p-error { font-size: 75%; margin-top: 0.25rem; }
+  `],
+    standalone: false
+})
+export class PrimengSliderComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  get minValue() { return effectiveMinimum(this.options?.minimum, this.options?.exclusiveMinimum); }
+  get maxValue() { return effectiveMaximum(this.options?.maximum, this.options?.exclusiveMaximum); }
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this, !this.options.readonly);
+  }
+
+  updateValue(event) {
+    this.options.showErrors = true;
+    this.jsf.updateValue(this, event.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.spec.ts
@@ -1,0 +1,119 @@
+import { PrimengStepperComponent } from './primeng-stepper.component';
+
+describe('PrimengStepperComponent', () => {
+  const jsf = () => ({
+    addItem: jasmine.createSpy('addItem'),
+    setArrayItemTitle: jasmine.createSpy('setArrayItemTitle').and.callFake(
+      (_self, item, index) => item.options?.title || `Step ${index + 1}`
+    ),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengStepperComponent(j as any);
+    c.layoutNode = node;
+    c.layoutIndex = [0];
+    c.dataIndex = [0];
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('initializes with first step selected', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: { title: 'Step A' } },
+        { type: 'section', options: { title: 'Step B' } },
+      ],
+      options: {},
+    });
+    expect(component.selectedItem).toBe(0);
+    expect(component.itemCount).toBe(1);
+  });
+
+  it('selects a step by index', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: { title: 'Step A' } },
+        { type: 'section', options: { title: 'Step B' } },
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(component.selectedItem).toBe(1);
+  });
+
+  it('calls jsf.addItem when selecting a $ref step', () => {
+    const refItem = { type: '$ref', options: { maxItems: 5 } };
+    const { component, jsf: j } = make({
+      items: [
+        { type: 'section', options: { title: 'Step A' } },
+        refItem,
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(j.addItem).toHaveBeenCalledWith({
+      layoutNode: refItem,
+      layoutIndex: [0, 1],
+      dataIndex: [0, 1],
+    });
+    expect(component.selectedItem).toBe(1);
+  });
+
+  it('does not call jsf.addItem for non-$ref steps', () => {
+    const { component, jsf: j } = make({
+      items: [
+        { type: 'section', options: { title: 'Step A' } },
+        { type: 'section', options: { title: 'Step B' } },
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(j.addItem).not.toHaveBeenCalled();
+  });
+
+  it('hides add step when maxItems is reached', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: {} },
+        { type: '$ref', options: { maxItems: 1 } },
+      ],
+      options: {},
+    });
+    expect(component.showAddTab).toBe(false);
+  });
+
+  it('shows add step when under maxItems', () => {
+    const { component } = make({
+      items: [
+        { type: '$ref', options: { maxItems: 5 } },
+      ],
+      options: {},
+    });
+    expect(component.showAddTab).toBe(true);
+  });
+
+  it('delegates step titles to jsf.setArrayItemTitle', () => {
+    const item = { type: 'section', options: { title: 'My Step' } };
+    const { component, jsf: j } = make({
+      items: [item],
+      options: {},
+    });
+    const result = component.setStepTitle(item, 0);
+    expect(j.setArrayItemTitle).toHaveBeenCalledWith(component, item, 0);
+    expect(result).toBe('My Step');
+  });
+
+  it('does not call initializeControl (layout container)', () => {
+    const j = jsf();
+    const c = new PrimengStepperComponent(j as any);
+    c.layoutNode = {
+      items: [{ type: 'section', options: {} }],
+      options: {},
+    };
+    c.layoutIndex = [0];
+    c.dataIndex = [0];
+    c.ngOnInit();
+    expect((j as any).initializeControl).toBeUndefined();
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
@@ -16,7 +16,7 @@ import { JsonSchemaFormService } from '@ajsf/core';
       <p-step-panels>
         <p-step-panel *ngFor="let layoutItem of layoutNode?.items; let i = index"
           [value]="i">
-          <ng-template #content let-prevCallback="prevCallback" let-nextCallback="nextCallback">
+          <ng-template #contentTemplate let-activateCallback="activateCallback">
             <select-framework-widget
               [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
               [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
@@ -26,10 +26,10 @@ import { JsonSchemaFormService } from '@ajsf/core';
               <p-button *ngIf="i > 0"
                 label="Back"
                 severity="secondary"
-                (onClick)="prevCallback.emit()"></p-button>
+                (onClick)="activateCallback(i - 1)"></p-button>
               <p-button *ngIf="i < itemCount"
                 label="Next"
-                (onClick)="nextCallback.emit()"></p-button>
+                (onClick)="activateCallback(i + 1)"></p-button>
             </div>
           </ng-template>
         </p-step-panel>

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
@@ -8,31 +8,34 @@ import { JsonSchemaFormService } from '@ajsf/core';
       [linear]="options?.linear || false"
       [style]="{'width': '100%'}">
       <p-step-list>
-        <p-step *ngFor="let item of layoutNode?.items; let i = index" [value]="i">
-          <span *ngIf="showAddTab || item.type !== '$ref'"
-            [innerHTML]="setStepTitle(item, i)"></span>
-        </p-step>
+        <ng-container *ngFor="let item of layoutNode?.items; let i = index">
+          <p-step *ngIf="showAddTab || item.type !== '$ref'" [value]="i">
+            <span [innerHTML]="setStepTitle(item, i)"></span>
+          </p-step>
+        </ng-container>
       </p-step-list>
       <p-step-panels>
-        <p-step-panel *ngFor="let layoutItem of layoutNode?.items; let i = index"
-          [value]="i">
-          <ng-template #contentTemplate let-activateCallback="activateCallback">
-            <select-framework-widget
-              [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
-              [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
-              [layoutIndex]="(layoutIndex || []).concat(i)"
-              [layoutNode]="layoutItem"></select-framework-widget>
-            <div style="display: flex; gap: 0.5rem; margin-top: 1rem;">
-              <p-button *ngIf="i > 0"
-                label="Back"
-                severity="secondary"
-                (onClick)="activateCallback(i - 1)"></p-button>
-              <p-button *ngIf="i < itemCount"
-                label="Next"
-                (onClick)="activateCallback(i + 1)"></p-button>
-            </div>
-          </ng-template>
-        </p-step-panel>
+        <ng-container *ngFor="let layoutItem of layoutNode?.items; let i = index">
+          <p-step-panel *ngIf="showAddTab || layoutItem.type !== '$ref'"
+            [value]="i">
+            <ng-template #contentTemplate let-activateCallback="activateCallback">
+              <select-framework-widget
+                [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
+                [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+                [layoutIndex]="(layoutIndex || []).concat(i)"
+                [layoutNode]="layoutItem"></select-framework-widget>
+              <div style="display: flex; gap: 0.5rem; margin-top: 1rem;">
+                <p-button *ngIf="i > 0"
+                  label="Back"
+                  severity="secondary"
+                  (onClick)="activateCallback(i - 1)"></p-button>
+                <p-button *ngIf="hasNextVisible(i)"
+                  label="Next"
+                  (onClick)="activateCallback(i + 1)"></p-button>
+              </div>
+            </ng-template>
+          </p-step-panel>
+        </ng-container>
       </p-step-panels>
     </p-stepper>`,
     standalone: false
@@ -55,7 +58,9 @@ export class PrimengStepperComponent implements OnInit {
   }
 
   select(index) {
+    if (index >= this.layoutNode.items.length) { return; }
     if (this.layoutNode.items[index].type === '$ref') {
+      if (!this.showAddTab) { return; }
       this.jsf.addItem({
         layoutNode: this.layoutNode.items[index],
         layoutIndex: this.layoutIndex.concat(index),
@@ -71,6 +76,14 @@ export class PrimengStepperComponent implements OnInit {
     const lastItem = this.layoutNode.items[this.layoutNode.items.length - 1];
     this.showAddTab = lastItem.type === '$ref' &&
       this.itemCount < (lastItem.options.maxItems || 1000);
+  }
+
+  hasNextVisible(currentIndex: number): boolean {
+    const next = currentIndex + 1;
+    if (next > this.itemCount) { return false; }
+    const nextItem = this.layoutNode.items[next];
+    if (nextItem?.type === '$ref' && !this.showAddTab) { return false; }
+    return true;
   }
 
   setStepTitle(item: any, index: number): string {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
@@ -1,0 +1,31 @@
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-stepper-widget',
+    template: ``,
+    standalone: false
+})
+export class PrimengStepperComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+  }
+
+  updateValue(event) {
+    this.jsf.updateValue(this, event.target.value);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.ts
@@ -1,19 +1,47 @@
-import { AbstractControl } from '@angular/forms';
 import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
 @Component({
     selector: 'primeng-stepper-widget',
-    template: ``,
+    template: `
+    <p-stepper [value]="selectedItem" (valueChange)="select($event)"
+      [linear]="options?.linear || false"
+      [style]="{'width': '100%'}">
+      <p-step-list>
+        <p-step *ngFor="let item of layoutNode?.items; let i = index" [value]="i">
+          <span *ngIf="showAddTab || item.type !== '$ref'"
+            [innerHTML]="setStepTitle(item, i)"></span>
+        </p-step>
+      </p-step-list>
+      <p-step-panels>
+        <p-step-panel *ngFor="let layoutItem of layoutNode?.items; let i = index"
+          [value]="i">
+          <ng-template #content let-prevCallback="prevCallback" let-nextCallback="nextCallback">
+            <select-framework-widget
+              [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
+              [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+              [layoutIndex]="(layoutIndex || []).concat(i)"
+              [layoutNode]="layoutItem"></select-framework-widget>
+            <div style="display: flex; gap: 0.5rem; margin-top: 1rem;">
+              <p-button *ngIf="i > 0"
+                label="Back"
+                severity="secondary"
+                (onClick)="prevCallback.emit()"></p-button>
+              <p-button *ngIf="i < itemCount"
+                label="Next"
+                (onClick)="nextCallback.emit()"></p-button>
+            </div>
+          </ng-template>
+        </p-step-panel>
+      </p-step-panels>
+    </p-stepper>`,
     standalone: false
 })
 export class PrimengStepperComponent implements OnInit {
-  formControl: AbstractControl;
-  controlName: string;
-  controlValue: any;
-  controlDisabled = false;
-  boundControl = false;
   options: any;
+  itemCount: number;
+  selectedItem = 0;
+  showAddTab = true;
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -22,10 +50,30 @@ export class PrimengStepperComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    this.itemCount = this.layoutNode.items.length - 1;
+    this.updateControl();
   }
 
-  updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+  select(index) {
+    if (this.layoutNode.items[index].type === '$ref') {
+      this.jsf.addItem({
+        layoutNode: this.layoutNode.items[index],
+        layoutIndex: this.layoutIndex.concat(index),
+        dataIndex: this.dataIndex.concat(index)
+      });
+      this.updateControl();
+    }
+    this.selectedItem = index;
+  }
+
+  updateControl() {
+    this.itemCount = this.layoutNode.items.length - 1;
+    const lastItem = this.layoutNode.items[this.layoutNode.items.length - 1];
+    this.showAddTab = lastItem.type === '$ref' &&
+      this.itemCount < (lastItem.options.maxItems || 1000);
+  }
+
+  setStepTitle(item: any, index: number): string {
+    return this.jsf.setArrayItemTitle(this, item, index);
   }
 }

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.spec.ts
@@ -1,0 +1,119 @@
+import { PrimengTabsComponent } from './primeng-tabs.component';
+
+describe('PrimengTabsComponent', () => {
+  const jsf = () => ({
+    addItem: jasmine.createSpy('addItem'),
+    setArrayItemTitle: jasmine.createSpy('setArrayItemTitle').and.callFake(
+      (_self, item, index) => item.options?.title || `Item ${index + 1}`
+    ),
+  });
+
+  const make = (node: any) => {
+    const j = jsf();
+    const c = new PrimengTabsComponent(j as any);
+    c.layoutNode = node;
+    c.layoutIndex = [0];
+    c.dataIndex = [0];
+    c.ngOnInit();
+    return { component: c, jsf: j };
+  };
+
+  it('initializes with first tab selected', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: { title: 'Tab A' } },
+        { type: 'section', options: { title: 'Tab B' } },
+      ],
+      options: {},
+    });
+    expect(component.selectedItem).toBe(0);
+    expect(component.itemCount).toBe(1);
+  });
+
+  it('selects a tab by index', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: { title: 'Tab A' } },
+        { type: 'section', options: { title: 'Tab B' } },
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(component.selectedItem).toBe(1);
+  });
+
+  it('calls jsf.addItem when selecting a $ref tab', () => {
+    const refItem = { type: '$ref', options: { maxItems: 5 } };
+    const { component, jsf: j } = make({
+      items: [
+        { type: 'section', options: { title: 'Tab A' } },
+        refItem,
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(j.addItem).toHaveBeenCalledWith({
+      layoutNode: refItem,
+      layoutIndex: [0, 1],
+      dataIndex: [0, 1],
+    });
+    expect(component.selectedItem).toBe(1);
+  });
+
+  it('does not call jsf.addItem for non-$ref tabs', () => {
+    const { component, jsf: j } = make({
+      items: [
+        { type: 'section', options: { title: 'Tab A' } },
+        { type: 'section', options: { title: 'Tab B' } },
+      ],
+      options: {},
+    });
+    component.select(1);
+    expect(j.addItem).not.toHaveBeenCalled();
+  });
+
+  it('hides add tab when maxItems is reached', () => {
+    const { component } = make({
+      items: [
+        { type: 'section', options: {} },
+        { type: '$ref', options: { maxItems: 1 } },
+      ],
+      options: {},
+    });
+    expect(component.showAddTab).toBe(false);
+  });
+
+  it('shows add tab when under maxItems', () => {
+    const { component } = make({
+      items: [
+        { type: '$ref', options: { maxItems: 5 } },
+      ],
+      options: {},
+    });
+    expect(component.showAddTab).toBe(true);
+  });
+
+  it('delegates tab titles to jsf.setArrayItemTitle', () => {
+    const item = { type: 'section', options: { title: 'My Tab' } };
+    const { component, jsf: j } = make({
+      items: [item],
+      options: {},
+    });
+    const result = component.setTabTitle(item, 0);
+    expect(j.setArrayItemTitle).toHaveBeenCalledWith(component, item, 0);
+    expect(result).toBe('My Tab');
+  });
+
+  it('does not call initializeControl (layout container)', () => {
+    const j = jsf();
+    const c = new PrimengTabsComponent(j as any);
+    c.layoutNode = {
+      items: [{ type: 'section', options: {} }],
+      options: {},
+    };
+    c.layoutIndex = [0];
+    c.dataIndex = [0];
+    c.ngOnInit();
+    expect((j as any).initializeControl).toBeUndefined();
+  });
+});

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.ts
@@ -7,10 +7,11 @@ import { JsonSchemaFormService } from '@ajsf/core';
     <p-tabs [value]="selectedItem" (valueChange)="select($event)"
       [style]="{'width': '100%'}">
       <p-tablist>
-        <p-tab *ngFor="let item of layoutNode?.items; let i = index" [value]="i">
-          <span *ngIf="showAddTab || item.type !== '$ref'"
-            [innerHTML]="setTabTitle(item, i)"></span>
-        </p-tab>
+        <ng-container *ngFor="let item of layoutNode?.items; let i = index">
+          <p-tab *ngIf="showAddTab || item.type !== '$ref'" [value]="i">
+            <span [innerHTML]="setTabTitle(item, i)"></span>
+          </p-tab>
+        </ng-container>
       </p-tablist>
     </p-tabs>
     <div *ngFor="let layoutItem of layoutNode?.items; let i = index"
@@ -41,7 +42,9 @@ export class PrimengTabsComponent implements OnInit {
   }
 
   select(index) {
+    if (index >= this.layoutNode.items.length) { return; }
     if (this.layoutNode.items[index].type === '$ref') {
+      if (!this.showAddTab) { return; }
       this.jsf.addItem({
         layoutNode: this.layoutNode.items[index],
         layoutIndex: this.layoutIndex.concat(index),

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.ts
@@ -1,0 +1,65 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService } from '@ajsf/core';
+
+@Component({
+    selector: 'primeng-tabs-widget',
+    template: `
+    <p-tabs [value]="selectedItem" (valueChange)="select($event)"
+      [style]="{'width': '100%'}">
+      <p-tablist>
+        <p-tab *ngFor="let item of layoutNode?.items; let i = index" [value]="i">
+          <span *ngIf="showAddTab || item.type !== '$ref'"
+            [innerHTML]="setTabTitle(item, i)"></span>
+        </p-tab>
+      </p-tablist>
+    </p-tabs>
+    <div *ngFor="let layoutItem of layoutNode?.items; let i = index"
+      [class]="options?.htmlClass || ''">
+      <select-framework-widget *ngIf="selectedItem === i"
+        [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')"
+        [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+        [layoutIndex]="(layoutIndex || []).concat(i)"
+        [layoutNode]="layoutItem"></select-framework-widget>
+    </div>`,
+    standalone: false
+})
+export class PrimengTabsComponent implements OnInit {
+  options: any;
+  itemCount: number;
+  selectedItem = 0;
+  showAddTab = true;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+
+  constructor(private jsf: JsonSchemaFormService) {}
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.itemCount = this.layoutNode.items.length - 1;
+    this.updateControl();
+  }
+
+  select(index) {
+    if (this.layoutNode.items[index].type === '$ref') {
+      this.jsf.addItem({
+        layoutNode: this.layoutNode.items[index],
+        layoutIndex: this.layoutIndex.concat(index),
+        dataIndex: this.dataIndex.concat(index)
+      });
+      this.updateControl();
+    }
+    this.selectedItem = index;
+  }
+
+  updateControl() {
+    this.itemCount = this.layoutNode.items.length - 1;
+    const lastItem = this.layoutNode.items[this.layoutNode.items.length - 1];
+    this.showAddTab = lastItem.type === '$ref' &&
+      this.itemCount < (lastItem.options.maxItems || 1000);
+  }
+
+  setTabTitle(item: any, index: number): string {
+    return this.jsf.setArrayItemTitle(this, item, index);
+  }
+}

--- a/projects/ajsf-primeng/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/public_api.ts
@@ -11,6 +11,12 @@ import { PrimengCheckboxesComponent } from './primeng-checkboxes.component';
 import { PrimengRadiosComponent } from './primeng-radios.component';
 import { PrimengButtonComponent } from './primeng-button.component';
 import { PrimengButtonGroupComponent } from './primeng-button-group.component';
+import { PrimengDatepickerComponent } from './primeng-datepicker.component';
+import { PrimengSliderComponent } from './primeng-slider.component';
+import { PrimengTabsComponent } from './primeng-tabs.component';
+import { PrimengFileComponent } from './primeng-file.component';
+import { PrimengChipListComponent } from './primeng-chip-list.component';
+import { PrimengStepperComponent } from './primeng-stepper.component';
 
 export { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
 export { PrimengFlexLayoutSectionComponent } from './primeng-flex-layout-section.component';
@@ -25,6 +31,12 @@ export { PrimengCheckboxesComponent } from './primeng-checkboxes.component';
 export { PrimengRadiosComponent } from './primeng-radios.component';
 export { PrimengButtonComponent } from './primeng-button.component';
 export { PrimengButtonGroupComponent } from './primeng-button-group.component';
+export { PrimengDatepickerComponent } from './primeng-datepicker.component';
+export { PrimengSliderComponent } from './primeng-slider.component';
+export { PrimengTabsComponent } from './primeng-tabs.component';
+export { PrimengFileComponent } from './primeng-file.component';
+export { PrimengChipListComponent } from './primeng-chip-list.component';
+export { PrimengStepperComponent } from './primeng-stepper.component';
 
 export const PRIMENG_FRAMEWORK_COMPONENTS = [
   PrimengFlexLayoutRootComponent,
@@ -40,4 +52,10 @@ export const PRIMENG_FRAMEWORK_COMPONENTS = [
   PrimengRadiosComponent,
   PrimengButtonComponent,
   PrimengButtonGroupComponent,
+  PrimengDatepickerComponent,
+  PrimengSliderComponent,
+  PrimengTabsComponent,
+  PrimengFileComponent,
+  PrimengChipListComponent,
+  PrimengStepperComponent,
 ];

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1930,7 +1930,7 @@
     "valid": true
   },
   "primeng/jsf-fields-autocomplete": {
-    "controls": 3,
+    "controls": 4,
     "error": null,
     "valid": true
   },

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1930,7 +1930,7 @@
     "valid": true
   },
   "primeng/jsf-fields-autocomplete": {
-    "controls": 5,
+    "controls": 3,
     "error": null,
     "valid": true
   },

--- a/testing/corpus/harness.ts
+++ b/testing/corpus/harness.ts
@@ -41,7 +41,7 @@ class CorpusHostComponent {
  */
 function countControls(fixture: ComponentFixture<CorpusHostComponent>): number {
   return fixture.nativeElement.querySelectorAll(
-    'input, select, textarea, mat-select, mat-slider, p-select, p-multiselect'
+    'input, select, textarea, mat-select, mat-slider, p-select, p-multiselect, p-slider'
   ).length;
 }
 


### PR DESCRIPTION
## Summary

Adds the six remaining widget types to @ajsf/primeng so the framework matches Material's widget coverage.

## Changes

Datepicker wraps p-datepicker with icon, button bar and min/max date conversion. Slider wraps p-slider with effectiveMinimum/effectiveMaximum from core. Tabs and stepper are layout containers using p-tabs and p-stepper with $ref support for dynamic item addition; maxItems gating filters the $ref element entirely when full and guards select() defensively. File writes a data URL through a hidden input. Chip-list wraps p-autocomplete in multiple mode and synchronizes tags through updateArrayCheckboxList to rebuild the FormArray.

The framework module imports six PrimeNG modules, the registry maps widget names and aliases (alt-date, range, tagsinput, wizard), and all 74 primeng baselines are re-recorded.

## Release impact

No release. The @ajsf/primeng package is not yet published.

## Validation

206 primeng specs passed. 92 material, 2156 core and 45 scripts suites all green.