### PR TITLE
feat(material): implement missing widget stubs

### DIFF
--- a/projects/ajsf-material/src/lib/widgets/material-chip-list.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-chip-list.component.ts
@@ -1,12 +1,41 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { JsonSchemaFormService } from '@ajsf/core';
-
-// TODO: Add this control
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
 
 @Component({
     selector: 'material-chip-list-widget',
-    template: ``,
+    template: `
+    <mat-form-field
+      [appearance]="options?.appearance || 'fill'"
+      [class]="options?.htmlClass || ''"
+      [floatLabel]="options?.floatLabel || 'auto'"
+      [style.width]="'100%'">
+      <mat-label *ngIf="!options?.notitle">{{options?.title}}</mat-label>
+      <mat-chip-grid #chipGrid
+        [attr.aria-label]="options?.title"
+        [disabled]="controlDisabled || options?.readonly">
+        <mat-chip-row *ngFor="let tag of tags; let i = index"
+          (removed)="remove(i)">
+          {{tag}}
+          <button matChipRemove aria-label="Remove">
+            <mat-icon>cancel</mat-icon>
+          </button>
+        </mat-chip-row>
+      </mat-chip-grid>
+      <input [matChipInputFor]="chipGrid"
+        [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+        [matChipInputAddOnBlur]="true"
+        [placeholder]="options?.placeholder || ''"
+        (matChipInputTokenEnd)="add($event)">
+      <mat-hint *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        align="end" [innerHTML]="options?.description"></mat-hint>
+    </mat-form-field>
+    <mat-error *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></mat-error>`,
+    styles: [`
+    mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
+  `],
     standalone: false
 })
 export class MaterialChipListComponent implements OnInit {
@@ -16,6 +45,8 @@ export class MaterialChipListComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  tags: string[] = [];
+  separatorKeyCodes = [ENTER, COMMA];
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -26,10 +57,27 @@ export class MaterialChipListComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    this.jsf.initializeControl(this, false);
+    this.tags = Array.isArray(this.controlValue) ? [...this.controlValue] : [];
   }
 
-  updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+  add(event) {
+    const value = (event.value || '').trim();
+    if (value) {
+      this.tags.push(value);
+      this.syncFormArray();
+    }
+    event.chipInput.clear();
+  }
+
+  remove(index: number) {
+    this.tags.splice(index, 1);
+    this.syncFormArray();
+  }
+
+  private syncFormArray() {
+    this.jsf.updateArrayCheckboxList(
+      this, this.tags.map(value => ({checked: true, value}))
+    );
   }
 }

--- a/projects/ajsf-material/src/lib/widgets/material-file.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-file.component.ts
@@ -2,11 +2,34 @@ import { AbstractControl } from '@angular/forms';
 import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
-// TODO: Add this control
-
 @Component({
     selector: 'material-file-widget',
-    template: ``,
+    template: `
+    <div [class]="options?.htmlClass || ''" [style.width]="'100%'">
+      <label *ngIf="!options?.notitle"
+        [class]="options?.labelHtmlClass || ''">{{options?.title}}</label>
+      <div>
+        <button mat-raised-button type="button"
+          [disabled]="controlDisabled || options?.readonly"
+          (click)="fileInput.click()">
+          <mat-icon>upload_file</mat-icon>
+          {{options?.buttonLabel || 'Choose File'}}
+        </button>
+        <span style="margin-left: 8px">{{fileName || 'No file chosen'}}</span>
+        <input #fileInput type="file"
+          [attr.accept]="options?.accept || null"
+          [hidden]="true"
+          (change)="onFileSelect($event)">
+      </div>
+      <mat-hint *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        [innerHTML]="options?.description"
+        style="display:block; font-size:75%; color:rgba(0,0,0,.6); margin-top:4px;"></mat-hint>
+    </div>
+    <mat-error *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></mat-error>`,
+    styles: [`
+    mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
+  `],
     standalone: false
 })
 export class MaterialFileComponent implements OnInit {
@@ -16,6 +39,7 @@ export class MaterialFileComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  fileName = '';
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -29,7 +53,14 @@ export class MaterialFileComponent implements OnInit {
     this.jsf.initializeControl(this);
   }
 
-  updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+  onFileSelect(event) {
+    const file: File = event.target?.files?.[0];
+    if (!file) { return; }
+    this.fileName = file.name;
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.jsf.updateValue(this, reader.result as string);
+    };
+    reader.readAsDataURL(file);
   }
 }

--- a/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
 
@@ -79,6 +80,7 @@ describe('Material widget integration', () => {
       const rows = fixture.nativeElement.querySelectorAll('mat-chip-row');
       expect(rows.length).toBe(1);
       expect(rows[0].textContent).toContain('keep');
+      expect(host.value.tags).toEqual(['keep']);
     });
   });
 
@@ -101,6 +103,23 @@ describe('Material widget integration', () => {
       const input = fixture.nativeElement.querySelector('input[type="file"]');
       expect(input).toBeTruthy();
       expect(input.hidden).toBe(true);
+    });
+
+    it('writes data URL to control after file selection', (done) => {
+      create(fileSchema);
+      const de = fixture.debugElement.query(By.css('material-file-widget'));
+      const fileComp = de.componentInstance;
+      const updateSpy = spyOn(fileComp.jsf, 'updateValue');
+      const blob = new Blob(['hello'], { type: 'text/plain' });
+      const file = new File([blob], 'test.txt', { type: 'text/plain' });
+      fileComp.onFileSelect({ target: { files: [file] } });
+      setTimeout(() => {
+        expect(fileComp.fileName).toBe('test.txt');
+        expect(updateSpy).toHaveBeenCalledWith(
+          fileComp, jasmine.stringMatching(/^data:text\/plain;base64,/)
+        );
+        done();
+      }, 50);
     });
   });
 
@@ -136,6 +155,24 @@ describe('Material widget integration', () => {
       const nextBtn = fixture.nativeElement.querySelector('button[matsteppernext]');
       expect(nextBtn).toBeTruthy();
     });
+
+    it('hides $ref step and Next button when maxItems is reached', () => {
+      const layoutAtCapacity = [{
+        type: 'stepper',
+        title: 'Wizard',
+        dataType: 'array',
+        items: [
+          { type: 'section', title: 'Step 1', items: ['name'] },
+          { type: 'section', title: 'Step 2', items: ['age'] },
+          { type: '$ref', options: { maxItems: 2 } }
+        ]
+      }];
+      create(stepperSchema, undefined, layoutAtCapacity);
+      const de = fixture.debugElement.query(By.css('material-stepper-widget'));
+      const stepper = de.componentInstance;
+      expect(stepper.showAddTab).toBe(false);
+      expect(stepper.hasNextVisible(1)).toBe(false);
+    });
   });
 
   describe('one-of (selectfieldset)', () => {
@@ -168,6 +205,36 @@ describe('Material widget integration', () => {
       create(fieldsetSchema, undefined, fieldsetLayout);
       const widgets = fixture.nativeElement.querySelectorAll('select-framework-widget');
       expect(widgets.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('one-of (readonly keyed fieldset)', () => {
+    it('preserves initial value and selects the correct child', () => {
+      create(
+        {
+          type: 'object',
+          properties: { cat_type: { type: 'string' } }
+        },
+        { cat_type: 'cat' },
+        [{
+          type: 'selectfieldset',
+          key: 'cat_type',
+          title: 'Type',
+          readonly: true,
+          titleMap: [
+            { value: 'text', name: 'Text Input' },
+            { value: 'cat', name: 'Category' }
+          ],
+          items: [
+            { type: 'section', title: 'Text', items: [] },
+            { type: 'section', title: 'Category', items: [] }
+          ]
+        }]
+      );
+      const de = fixture.debugElement.query(By.css('material-one-of-widget'));
+      const oneOf = de.componentInstance;
+      expect(oneOf.selectedItem).toBe(1);
+      expect(oneOf.selectedValue).toBe('cat');
     });
   });
 

--- a/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
@@ -1,0 +1,194 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
+
+@Component({
+    template: `
+    <json-schema-form
+      [schema]="schema"
+      [layout]="layout"
+      [data]="data"
+      [framework]="'material-design'"
+      (onChanges)="value = $event"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+    standalone: false
+})
+class TestHostComponent {
+  schema: any = {};
+  layout: any;
+  data: any;
+  value: any;
+  valid: boolean | null = null;
+}
+
+describe('Material widget integration', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MaterialDesignFrameworkModule, NoopAnimationsModule],
+      declarations: [TestHostComponent],
+      schemas: [],
+    }).compileComponents();
+  }));
+
+  function create(schema: any, data?: any, layout?: any) {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.schema = schema;
+    if (data !== undefined) { host.data = data; }
+    if (layout !== undefined) { host.layout = layout; }
+    fixture.detectChanges();
+  }
+
+  describe('chip-list', () => {
+    const tagsSchema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          'x-schema-form': { type: 'tagsinput' }
+        }
+      }
+    };
+
+    it('renders a mat-chip-grid', () => {
+      create(tagsSchema, { tags: ['a', 'b'] });
+      const grid = fixture.nativeElement.querySelector('mat-chip-grid');
+      expect(grid).toBeTruthy();
+    });
+
+    it('displays initial values as chip rows', () => {
+      create(tagsSchema, { tags: ['alpha', 'beta'] });
+      const rows = fixture.nativeElement.querySelectorAll('mat-chip-row');
+      expect(rows.length).toBe(2);
+      expect(rows[0].textContent).toContain('alpha');
+      expect(rows[1].textContent).toContain('beta');
+    });
+
+    it('removes a chip and updates the form data', () => {
+      create(tagsSchema, { tags: ['keep', 'remove'] });
+      const removeButtons = fixture.nativeElement.querySelectorAll('button[matchipremove]');
+      expect(removeButtons.length).toBe(2);
+      removeButtons[1].click();
+      fixture.detectChanges();
+      const rows = fixture.nativeElement.querySelectorAll('mat-chip-row');
+      expect(rows.length).toBe(1);
+      expect(rows[0].textContent).toContain('keep');
+    });
+  });
+
+  describe('file', () => {
+    const fileSchema = {
+      type: 'object',
+      properties: {
+        doc: {
+          type: 'string',
+          'x-schema-form': { type: 'file' }
+        }
+      }
+    };
+
+    it('renders an upload button and hidden file input', () => {
+      create(fileSchema);
+      const button = fixture.nativeElement.querySelector('button[mat-raised-button]');
+      expect(button).toBeTruthy();
+      expect(button.textContent).toContain('Choose File');
+      const input = fixture.nativeElement.querySelector('input[type="file"]');
+      expect(input).toBeTruthy();
+      expect(input.hidden).toBe(true);
+    });
+  });
+
+  describe('stepper', () => {
+    const stepperLayout = [
+      {
+        type: 'stepper',
+        title: 'Wizard',
+        items: [
+          { type: 'section', title: 'Step 1', items: ['name'] },
+          { type: 'section', title: 'Step 2', items: ['age'] }
+        ]
+      }
+    ];
+    const stepperSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' }
+      }
+    };
+
+    it('renders mat-stepper with steps', () => {
+      create(stepperSchema, undefined, stepperLayout);
+      const stepper = fixture.nativeElement.querySelector('mat-stepper');
+      expect(stepper).toBeTruthy();
+      const labels = fixture.nativeElement.querySelectorAll('.mat-step-label');
+      expect(labels.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('renders Back/Next navigation buttons', () => {
+      create(stepperSchema, undefined, stepperLayout);
+      const nextBtn = fixture.nativeElement.querySelector('button[matsteppernext]');
+      expect(nextBtn).toBeTruthy();
+    });
+  });
+
+  describe('one-of (selectfieldset)', () => {
+    const fieldsetSchema = {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'string'
+        }
+      }
+    };
+    const fieldsetLayout = [
+      {
+        type: 'selectfieldset',
+        title: 'Pick one',
+        items: [
+          { type: 'section', title: 'Option A', items: ['choice'] },
+          { type: 'section', title: 'Option B', items: [] }
+        ]
+      }
+    ];
+
+    it('renders a mat-select for the fieldset picker', () => {
+      create(fieldsetSchema, undefined, fieldsetLayout);
+      const select = fixture.nativeElement.querySelector('mat-select');
+      expect(select).toBeTruthy();
+    });
+
+    it('renders the first child by default', () => {
+      create(fieldsetSchema, undefined, fieldsetLayout);
+      const widgets = fixture.nativeElement.querySelectorAll('select-framework-widget');
+      expect(widgets.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('one-of (simple enum)', () => {
+    const enumSchema = {
+      type: 'object',
+      properties: {
+        color: {
+          type: 'string',
+          oneOf: [
+            { const: 'red', title: 'Red' },
+            { const: 'blue', title: 'Blue' }
+          ]
+        }
+      }
+    };
+
+    it('renders a mat-select for oneOf enum', () => {
+      create(enumSchema);
+      const select = fixture.nativeElement.querySelector('mat-select');
+      expect(select).toBeTruthy();
+    });
+  });
+});

--- a/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
@@ -44,6 +44,7 @@ import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
       <mat-select *ngIf="!boundControl && isFieldset"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [id]="'control' + layoutNode?._id"
+        [disabled]="controlDisabled || options?.readonly"
         [style.width]="'100%'"
         [value]="selectedValue"
         (selectionChange)="selectChild($event)">
@@ -91,9 +92,9 @@ export class MaterialOneOfComponent implements OnInit {
   ) { }
 
   get selectedItem(): number {
-    if (this.isFieldset && this.boundControl) {
-      const val = this.formControl?.value ?? this.controlValue;
-      return this.fieldsetValueMap.get(val) ?? 0;
+    if (this.isFieldset && this.formControl) {
+      const val = this.formControl.value ?? this.controlValue;
+      return this.fieldsetValueMap.get(val) ?? this._selectedItem;
     }
     return this._selectedItem;
   }
@@ -128,6 +129,12 @@ export class MaterialOneOfComponent implements OnInit {
 
     if (!this.isFieldset || this.options.titleMap || this.options.enum) {
       this.jsf.initializeControl(this, !this.options.readonly);
+    }
+
+    if (this.isFieldset && this.controlValue != null) {
+      this.selectedValue = this.controlValue;
+      this._selectedItem = this.fieldsetValueMap.get(this.controlValue)
+        ?? (typeof this.controlValue === 'number' ? this.controlValue : 0);
     }
   }
 

--- a/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-one-of.component.ts
@@ -1,12 +1,72 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnInit, Optional } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { JsonSchemaFormService } from '@ajsf/core';
-
-// TODO: Add this control
+import { JsonSchemaFormService, buildTitleMap } from '@ajsf/core';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 @Component({
     selector: 'material-one-of-widget',
-    template: ``,
+    template: `
+    <mat-form-field
+      [appearance]="options?.appearance || matFormFieldDefaultOptions?.appearance || 'fill'"
+      [class]="options?.htmlClass || ''"
+      [floatLabel]="options?.floatLabel || matFormFieldDefaultOptions?.floatLabel || 'auto'"
+      [style.width]="'100%'">
+      <mat-label *ngIf="!options?.notitle">{{options?.title}}</mat-label>
+
+      <mat-select *ngIf="boundControl"
+        [formControl]="formControl"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [id]="'control' + layoutNode?._id"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [required]="options?.required"
+        [style.width]="'100%'"
+        (blur)="options.showErrors = true">
+        <mat-option *ngFor="let item of selectList" [value]="item?.value">
+          <span [innerHTML]="item?.name"></span>
+        </mat-option>
+      </mat-select>
+
+      <mat-select *ngIf="!boundControl && !isFieldset"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [id]="'control' + layoutNode?._id"
+        [disabled]="controlDisabled || options?.readonly"
+        [placeholder]="options?.notitle ? options?.placeholder : options?.title"
+        [required]="options?.required"
+        [style.width]="'100%'"
+        [value]="controlValue"
+        (selectionChange)="updateValue($event)"
+        (blur)="options.showErrors = true">
+        <mat-option *ngFor="let item of selectList" [value]="item?.value">
+          <span [innerHTML]="item?.name"></span>
+        </mat-option>
+      </mat-select>
+
+      <mat-select *ngIf="!boundControl && isFieldset"
+        [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [id]="'control' + layoutNode?._id"
+        [style.width]="'100%'"
+        [value]="selectedValue"
+        (selectionChange)="selectChild($event)">
+        <mat-option *ngFor="let item of selectList" [value]="item?.value">
+          <span [innerHTML]="item?.name"></span>
+        </mat-option>
+      </mat-select>
+
+      <mat-hint *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+        align="end" [innerHTML]="options?.description"></mat-hint>
+    </mat-form-field>
+    <mat-error *ngIf="options?.showErrors && options?.errorMessage"
+      [innerHTML]="options?.errorMessage"></mat-error>
+
+    <div *ngFor="let layoutItem of layoutNode?.items; let i = index">
+      <select-framework-widget *ngIf="isFieldset && selectedItem === i"
+        [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+        [layoutIndex]="(layoutIndex || []).concat(i)"
+        [layoutNode]="layoutItem"></select-framework-widget>
+    </div>`,
+    styles: [`
+    mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
+  `],
     standalone: false
 })
 export class MaterialOneOfComponent implements OnInit {
@@ -16,20 +76,69 @@ export class MaterialOneOfComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  selectList: any[] = [];
+  isFieldset = false;
+  selectedValue: any = 0;
+  private _selectedItem = 0;
+  private fieldsetValueMap: Map<any, number> = new Map();
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
 
   constructor(
+    @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS) @Optional() public matFormFieldDefaultOptions,
     private jsf: JsonSchemaFormService
   ) { }
 
+  get selectedItem(): number {
+    if (this.isFieldset && this.boundControl) {
+      const val = this.formControl?.value ?? this.controlValue;
+      return this.fieldsetValueMap.get(val) ?? 0;
+    }
+    return this._selectedItem;
+  }
+
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    const type = this.layoutNode.type;
+    this.isFieldset = (type === 'selectfieldset' || type === 'optionfieldset')
+      && Array.isArray(this.layoutNode.items) && this.layoutNode.items.length > 0;
+
+    if (this.isFieldset && !this.options.titleMap && !this.options.enum) {
+      this.selectList = this.layoutNode.items.map((item, i) => ({
+        name: item.options?.legend || item.options?.title || item.name || `Option ${i + 1}`,
+        value: i
+      }));
+    } else {
+      this.selectList = buildTitleMap(
+        this.options.titleMap || this.options.enumNames,
+        this.options.enum, !!this.options.required, !!this.options.flatList
+      );
+    }
+
+    if (this.isFieldset && (this.options.titleMap || this.options.enum)) {
+      let idx = 0;
+      for (const entry of this.selectList) {
+        if (entry.value != null && entry.value !== '') {
+          if (idx === 0) { this.selectedValue = entry.value; }
+          this.fieldsetValueMap.set(entry.value, idx++);
+        }
+      }
+    }
+
+    if (!this.isFieldset || this.options.titleMap || this.options.enum) {
+      this.jsf.initializeControl(this, !this.options.readonly);
+    }
+  }
+
+  selectChild(event) {
+    this.selectedValue = event.value;
+    this._selectedItem =
+      this.fieldsetValueMap.get(event.value) ?? event.value;
   }
 
   updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+    this.options.showErrors = true;
+    this.jsf.updateValue(this, event.value);
   }
 }

--- a/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
@@ -9,23 +9,24 @@ import { JsonSchemaFormService } from '@ajsf/core';
       [selectedIndex]="selectedItem"
       [linear]="options?.linear || false"
       (selectionChange)="select($event.selectedIndex)">
-      <mat-step *ngFor="let item of layoutNode?.items; let i = index">
-        <ng-template matStepLabel>
-          <span *ngIf="showAddTab || item.type !== '$ref'"
-            [innerHTML]="setStepTitle(item, i)"></span>
-        </ng-template>
-        <ng-template matStepContent>
-          <select-framework-widget
-            [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
-            [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
-            [layoutIndex]="(layoutIndex || []).concat(i)"
-            [layoutNode]="item"></select-framework-widget>
-          <div style="margin-top: 16px">
-            <button mat-button matStepperPrevious *ngIf="i > 0" type="button">Back</button>
-            <button mat-button matStepperNext *ngIf="i < itemCount" type="button">Next</button>
-          </div>
-        </ng-template>
-      </mat-step>
+      <ng-container *ngFor="let item of layoutNode?.items; let i = index">
+        <mat-step *ngIf="showAddTab || item.type !== '$ref'">
+          <ng-template matStepLabel>
+            <span [innerHTML]="setStepTitle(item, i)"></span>
+          </ng-template>
+          <ng-template matStepContent>
+            <select-framework-widget
+              [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
+              [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+              [layoutIndex]="(layoutIndex || []).concat(i)"
+              [layoutNode]="item"></select-framework-widget>
+            <div style="margin-top: 16px">
+              <button mat-button matStepperPrevious *ngIf="i > 0" type="button">Back</button>
+              <button mat-button matStepperNext *ngIf="hasNextVisible(i)" type="button">Next</button>
+            </div>
+          </ng-template>
+        </mat-step>
+      </ng-container>
     </mat-stepper>`,
     standalone: false
 })
@@ -54,7 +55,9 @@ export class MaterialStepperComponent implements OnInit {
   }
 
   select(index) {
+    if (index >= this.layoutNode.items.length) { return; }
     if (this.layoutNode.items[index].type === '$ref') {
+      if (!this.showAddTab) { return; }
       this.jsf.addItem({
         layoutNode: this.layoutNode.items[index],
         layoutIndex: this.layoutIndex.concat(index),
@@ -70,6 +73,14 @@ export class MaterialStepperComponent implements OnInit {
     const lastItem = this.layoutNode.items[this.layoutNode.items.length - 1];
     this.showAddTab = lastItem.type === '$ref' &&
       this.itemCount < (lastItem.options.maxItems || 1000);
+  }
+
+  hasNextVisible(currentIndex: number): boolean {
+    const next = currentIndex + 1;
+    if (next > this.itemCount) { return false; }
+    const nextItem = this.layoutNode.items[next];
+    if (nextItem?.type === '$ref' && !this.showAddTab) { return false; }
+    return true;
   }
 
   setStepTitle(item: any, index: number): string {

--- a/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-stepper.component.ts
@@ -2,11 +2,31 @@ import { AbstractControl } from '@angular/forms';
 import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
 
-// TODO: Add this control
-
 @Component({
     selector: 'material-stepper-widget',
-    template: ``,
+    template: `
+    <mat-stepper
+      [selectedIndex]="selectedItem"
+      [linear]="options?.linear || false"
+      (selectionChange)="select($event.selectedIndex)">
+      <mat-step *ngFor="let item of layoutNode?.items; let i = index">
+        <ng-template matStepLabel>
+          <span *ngIf="showAddTab || item.type !== '$ref'"
+            [innerHTML]="setStepTitle(item, i)"></span>
+        </ng-template>
+        <ng-template matStepContent>
+          <select-framework-widget
+            [class]="(options?.fieldHtmlClass || '') + ' ' + (options?.activeClass || '')"
+            [dataIndex]="layoutNode?.dataType === 'array' ? (dataIndex || []).concat(i) : dataIndex"
+            [layoutIndex]="(layoutIndex || []).concat(i)"
+            [layoutNode]="item"></select-framework-widget>
+          <div style="margin-top: 16px">
+            <button mat-button matStepperPrevious *ngIf="i > 0" type="button">Back</button>
+            <button mat-button matStepperNext *ngIf="i < itemCount" type="button">Next</button>
+          </div>
+        </ng-template>
+      </mat-step>
+    </mat-stepper>`,
     standalone: false
 })
 export class MaterialStepperComponent implements OnInit {
@@ -16,6 +36,9 @@ export class MaterialStepperComponent implements OnInit {
   controlDisabled = false;
   boundControl = false;
   options: any;
+  itemCount: number;
+  selectedItem = 0;
+  showAddTab = true;
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
@@ -26,10 +49,30 @@ export class MaterialStepperComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    this.jsf.initializeControl(this);
+    this.itemCount = this.layoutNode.items.length - 1;
+    this.updateControl();
   }
 
-  updateValue(event) {
-    this.jsf.updateValue(this, event.target.value);
+  select(index) {
+    if (this.layoutNode.items[index].type === '$ref') {
+      this.jsf.addItem({
+        layoutNode: this.layoutNode.items[index],
+        layoutIndex: this.layoutIndex.concat(index),
+        dataIndex: this.dataIndex.concat(index)
+      });
+      this.updateControl();
+    }
+    this.selectedItem = index;
+  }
+
+  updateControl() {
+    this.itemCount = this.layoutNode.items.length - 1;
+    const lastItem = this.layoutNode.items[this.layoutNode.items.length - 1];
+    this.showAddTab = lastItem.type === '$ref' &&
+      this.itemCount < (lastItem.options.maxItems || 1000);
+  }
+
+  setStepTitle(item: any, index: number): string {
+    return this.jsf.setArrayItemTitle(this, item, index);
   }
 }

--- a/testing/corpus/baseline.json
+++ b/testing/corpus/baseline.json
@@ -1190,7 +1190,7 @@
     "valid": true
   },
   "material-design/jsf-fields-autocomplete": {
-    "controls": 3,
+    "controls": 4,
     "error": null,
     "valid": true
   },
@@ -1270,12 +1270,12 @@
     "valid": true
   },
   "material-design/jsf-fields-selectfieldset": {
-    "controls": 0,
+    "controls": 2,
     "error": null,
     "valid": true
   },
   "material-design/jsf-fields-selectfieldset-key": {
-    "controls": 0,
+    "controls": 2,
     "error": null,
     "valid": true
   },


### PR DESCRIPTION
## Summary

Implements the four empty-template Material widget stubs: chip-list, file, stepper and one-of. Each now renders its Angular Material component and participates in the form.

## Changes

Chip-list uses mat-chip-grid with updateArrayCheckboxList for FormArray sync. File uses FileReader to write data URLs. Stepper uses mat-stepper with $ref gating and maxItems enforcement. One-of uses mat-select in three modes (bound, unbound, fieldset) with buildTitleMap and child rendering via select-framework-widget.

Three corpus baseline entries updated for stub-to-real control count increases. Integration tests cover chip remove with form data assertion, FileReader data URL output, stepper $ref filtering at maxItems, and one-of readonly keyed fieldset value preservation.

## Release impact

No release. Ships with the next version bump.

## Validation

104 material specs passed. 2156 core, 76 bootstrap-3, 76 bootstrap-4, 87 bootstrap-5, 45 scripts all green.