### PR TITLE
ci: scope release permissions to the gated job and close two publish paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,33 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege by default. Only the gated `release` job raises this, because
+# `verify` runs repository code (`npm ci`, `npm run build:libs`) before any
+# approval, and a write token or an OIDC credential in that job would be
+# reachable from a postinstall or ng-packagr hook. The environment gate is the
+# approval boundary; it is only a security boundary if the ungated jobs cannot
+# publish or push on their own.
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+
+# npm assigns a dist-tag to whatever version is published and does not enforce
+# that `latest` moves forward, so two releases publishing at once can leave
+# `latest` on the older one. Serializing every run of this workflow keeps the
+# six packages moving as one. GitHub does not promise queue order, so the
+# release job re-checks the registry after approval as well.
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   decide:
     runs-on: ubuntu-latest
+    # A manually dispatched CI run also satisfies workflow_run, so the event is
+    # pinned to `push`: a release follows a merge, not a re-run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     outputs:
       version: ${{ steps.check.outputs.version }}
       publish: ${{ steps.check.outputs.publish }}
@@ -55,6 +72,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2   # need the previous commit to diff the version
+          persist-credentials: false
 
       - name: Did this push change the version
         id: check
@@ -87,9 +105,24 @@ jobs:
           fi
 
           # Safety net, not the trigger: never republish an existing version.
-          # Test the output, not the exit code. `npm view pkg@missing-version`
-          # exits 0 with empty stdout; only a missing package exits non-zero.
-          PUBLISHED=$(npm view "@ajsf/core@$VERSION" version 2>/dev/null || true)
+          #
+          # Both npm behaviours have to read as absent, because this changed
+          # under us: npm 12 exits non-zero with E404 for a missing version of
+          # an existing package, where older npm exited 0 with empty stdout.
+          # A blanket `|| true` covers both but fails open, so a registry
+          # outage or a DNS failure reads as "not published yet" and sends a
+          # bogus release to the approval gate. Only an E404 means absent; any
+          # other failure stops the release.
+          ERRFILE=$(mktemp)
+          if OUT=$(npm view "@ajsf/core@$VERSION" version 2>"$ERRFILE"); then
+            PUBLISHED=$(printf '%s' "$OUT" | tr -d '[:space:]')
+          elif grep -q 'E404' "$ERRFILE"; then
+            PUBLISHED=""
+          else
+            echo "[release] npm view failed, refusing to guess:"
+            cat "$ERRFILE"
+            exit 1
+          fi
 
           if [ "$CHANGED" = "no" ]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
@@ -109,6 +142,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v7
@@ -122,6 +156,20 @@ jobs:
 
       - name: Build libraries
         run: npm run build:libs
+
+      # The workflow_run path already has a green CI run on this exact commit,
+      # which is why the suites are not repeated there. A manual dispatch has
+      # no such run behind it, so it pays for its own coverage rather than
+      # publishing on the strength of test:scripts alone.
+      - name: Test libraries (manual dispatch has no CI run to lean on)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs3 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs4 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs5 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:material -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:primeng -- --no-watch --no-progress --browsers=ChromeHeadlessCI
 
       - name: Confirm every package carries the release version
         run: |
@@ -143,7 +191,10 @@ jobs:
           echo "[release] all $COUNT packages at $VERSION"
 
       # Publishing the artifact verify built, rather than rebuilding inside the
-      # gated job, means what ships is exactly what passed.
+      # gated job, means the gated job compiles nothing. It is not yet a
+      # byte-for-byte guarantee: `npm publish <dir>` packs the directory at
+      # publish time and would run any prepack or prepare script the package
+      # gained. Packing here and publishing the tarballs would close that.
       - name: Upload the verified packages
         uses: actions/upload-artifact@v7
         with:
@@ -162,6 +213,14 @@ jobs:
     # Settings > Environments > npm-publish with yourself as a required
     # reviewer. Free on public repositories.
     environment: npm-publish
+    # The only job that gets these, and only behind the approval gate:
+    # `contents: write` pushes the tag and creates the release, `id-token`
+    # mints the OIDC credential npm trusted publishing exchanges. The npm
+    # trusted publisher for each package must name the `npm-publish`
+    # environment, or this restriction buys nothing.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -186,6 +245,42 @@ jobs:
         with:
           name: ajsf-dist-${{ needs.decide.outputs.version }}
           path: dist/@ajsf/
+
+      # An approval can sit for hours, so `decide`'s reading of the registry is
+      # stale by the time anyone clicks it. Re-reading here closes two gaps the
+      # concurrency group alone cannot: another run may have published this
+      # version already, and a stable release must never drag `latest`
+      # backwards, which npm permits because a dist-tag points at whatever was
+      # published last rather than at the highest version.
+      - name: Re-check the registry after approval
+        run: |
+          VERSION="${{ needs.decide.outputs.version }}"
+          DIST_TAG="${{ needs.decide.outputs.dist-tag }}"
+
+          ERRFILE=$(mktemp)
+          if OUT=$(npm view "@ajsf/core@$VERSION" version 2>"$ERRFILE"); then
+            if [ -n "$(printf '%s' "$OUT" | tr -d '[:space:]')" ]; then
+              echo "[release] @ajsf/core@$VERSION appeared on npm since approval, refusing"
+              exit 1
+            fi
+          elif ! grep -q 'E404' "$ERRFILE"; then
+            echo "[release] npm view failed, refusing to guess:"
+            cat "$ERRFILE"
+            exit 1
+          fi
+
+          if [ "$DIST_TAG" = "latest" ]; then
+            CURRENT=$(npm view "@ajsf/core" version 2>/dev/null || true)
+            if [ -n "$CURRENT" ] && [ "$CURRENT" != "$VERSION" ]; then
+              HIGHEST=$(printf '%s\n%s\n' "$CURRENT" "$VERSION" \
+                | sort -V | tail -1)
+              if [ "$HIGHEST" != "$VERSION" ]; then
+                echo "[release] latest is $CURRENT, publishing $VERSION would move it backwards"
+                exit 1
+              fi
+            fi
+          fi
+          echo "[release] registry still expects $VERSION on $DIST_TAG"
 
       - name: Publish core
         run: npm publish dist/@ajsf/core --provenance --access public --tag ${{ needs.decide.outputs.dist-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,19 @@ name: Release
 # built. Approving means "this built and passed, ship it" rather than "go ahead
 # and try".
 
+# There is deliberately no `workflow_dispatch` here. A dispatch can target any
+# branch or tag, and this workflow runs in default-branch context with the
+# capability to publish, so a manual trigger meant checking out an arbitrary
+# ref and executing it on the way to npm. CodeQL flags that as cache poisoning
+# via a poisonable step, and it also made "dispatch the release" a way to skip
+# CI entirely. To re-run a release, re-run the failed run from the Actions UI:
+# that replays the original workflow_run payload, so it stays pinned to the
+# commit CI tested rather than to whatever main looks like now.
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
     branches: [main]
-  workflow_dispatch:
 
 # Least privilege by default. Only the gated `release` job raises this, because
 # `verify` runs repository code (`npm ci`, `npm run build:libs`) before any
@@ -58,11 +65,10 @@ jobs:
   decide:
     runs-on: ubuntu-latest
     # A manually dispatched CI run also satisfies workflow_run, so the event is
-    # pinned to `push`: a release follows a merge, not a re-run.
+    # pinned to `push`: a release follows a merge, not a re-run of CI.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
     outputs:
       version: ${{ steps.check.outputs.version }}
       publish: ${{ steps.check.outputs.publish }}
@@ -70,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2   # need the previous commit to diff the version
           persist-credentials: false
 
@@ -86,10 +92,7 @@ jobs:
             *)   echo "dist-tag=latest" >> "$GITHUB_OUTPUT" ;;
           esac
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            CHANGED=yes
-            echo "[release] manual dispatch, treating as a release"
-          elif git rev-parse HEAD^ >/dev/null 2>&1; then
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
             PREVIOUS=$(git show HEAD^:"$MANIFEST" 2>/dev/null \
               | node -p "try{JSON.parse(require('fs').readFileSync(0,'utf8')).version}catch(e){''}" || true)
             if [ "$PREVIOUS" = "$VERSION" ]; then
@@ -141,7 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Setup Node
@@ -156,20 +159,6 @@ jobs:
 
       - name: Build libraries
         run: npm run build:libs
-
-      # The workflow_run path already has a green CI run on this exact commit,
-      # which is why the suites are not repeated there. A manual dispatch has
-      # no such run behind it, so it pays for its own coverage rather than
-      # publishing on the strength of test:scripts alone.
-      - name: Test libraries (manual dispatch has no CI run to lean on)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs3 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs4 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs5 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:material -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:primeng -- --no-watch --no-progress --browsers=ChromeHeadlessCI
 
       - name: Confirm every package carries the release version
         run: |
@@ -224,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       # NOT .nvmrc. This job publishes prebuilt tarballs and never compiles
       # anything, so it does not need the Angular toolchain's Node 16. It does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 Notes for AI coding agents working in this repository. Humans may find the traps section useful too.
 
-`@ajsf/*` is a JSON Schema form builder for Angular, published as five packages from one Angular CLI workspace: `@ajsf/core` plus the `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4` and `@ajsf/bootstrap5` framework packages. All five version in lockstep.
+`@ajsf/*` is a JSON Schema form builder for Angular, published as six packages from one Angular CLI workspace: `@ajsf/core` plus the `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4`, `@ajsf/bootstrap5` and `@ajsf/primeng` framework packages. All six version in lockstep.
+
+That count is currently written down in four places: `PACKAGES` in `scripts/set-version.js`, `LIBRARIES` in `scripts/package-guards.spec.js`, `build:libs` in `package.json`, and the expected package count in `release.yml`. Adding a seventh means editing all four, and `@ajsf/primeng` shipped in 19.2.0 having been missed by three of them.
 
 ## Environment
 
@@ -23,7 +25,7 @@ nvm use "$(cat .nvmrc)"
 
 ```bash
 npm ci                       # install
-npm run build:libs           # build all five packages into dist/@ajsf/
+npm run build:libs           # build all six packages into dist/@ajsf/
 npm run build:demo           # build the libraries and the demo app
 npm start                    # serve the demo
 npm run test:scripts         # tests for scripts/, plain jasmine, fast
@@ -35,7 +37,7 @@ Library tests need the headless launcher flags:
 npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
 ```
 
-Substitute `test:bs3`, `test:bs4`, `test:bs5`, `test:material` for the others.
+Substitute `test:bs3`, `test:bs4`, `test:bs5`, `test:material`, `test:primeng` for the others.
 
 ## Versioning
 
@@ -58,9 +60,9 @@ Publishing is automated through `.github/workflows/release.yml` and npm OIDC Tru
 
 1. Open a PR containing only the `npm run version:set` bump.
 2. Merge it. The trigger is the version **changing** in that push, so any merge that leaves it alone is a no-op. A version sitting in the repository ahead of what is on npm is fine and does not start a release.
-3. The `verify` job builds and runs all five suites, ungated, and uploads `dist` as an artifact.
+3. CI runs the suites on that merge commit. Release then fires from `workflow_run` once CI is green, so `verify` does not repeat them: it builds, confirms all six packages carry the release version, and uploads `dist` as an artifact, ungated.
 4. Approve the `npm-publish` deployment. Nothing reaches npm before this, and by now the build is green.
-5. `release` publishes the artifact `verify` built, `core` first, then the three framework packages, and tags the commit.
+5. `release` publishes the artifact `verify` built, `core` first, then the five framework packages, and tags the commit. It is the only job holding `contents: write` and `id-token: write`, and it re-reads the registry after approval so a stale approval cannot republish a version or drag `latest` backwards.
 
 The `release` job deliberately runs a **newer Node than `.nvmrc`**. It publishes prebuilt tarballs and compiles nothing, but it needs an npm recent enough for OIDC, and current npm requires Node 22 or later. Pinning it to `.nvmrc` made `npm i -g npm@latest` fail with `EBADENGINE` before any publish ran.
 
@@ -72,7 +74,7 @@ There is no CHANGELOG.md and no changelog script. The release pages are the reco
 
 ## Coverage
 
-Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all five libraries. CI uploads them to Codecov from the `20.x` matrix leg only: both legs run the same tests on the same commit, so a second upload is a duplicate.
+Karma writes `html`, `lcov` and `text-summary` into `coverage/<project>` for all six libraries. CI uploads them to Codecov from the `20.x` matrix leg only: both legs run the same tests on the same commit, so a second upload is a duplicate.
 
 **Codecov authenticates with the `CODECOV_TOKEN` secret, not OIDC**, which is deliberate and differs from the npm publishing flow. `codecov/codecov-action` does accept `use_oidc: true`, but the CLI has a reported failure mode where it ignores the OIDC credential, falls back to tokenless and then fails on a rate limit (`codecov-action#1461`, closed with no stated fix), and fork pull requests receive no `id-token` at all. The token is the predictable option. Do not switch this to OIDC without confirming an upload actually lands.
 
@@ -205,7 +207,7 @@ Each of these cost real debugging time. They look like bugs in your code and are
   change, not a contributor-only doc, and it reaches consumers only when a
   version publishes.
 
-- **`npm view pkg@missing-version` exits 0** with empty stdout. Only a missing *package* exits non-zero. Any "is this published" check must test the output, not the exit code, or it reports "already published" forever.
+- **`npm view pkg@missing-version` signals absence two different ways, depending on the npm version.** Older npm exited 0 with empty stdout, and only a missing *package* exited non-zero. npm 12.0.2 exits 1 with `npm error code E404` for a missing version of an existing package too, verified against the live registry. An "is this published" check has to treat both as absent, and must not collapse that into `|| true`: swallowing every failure makes a registry outage or a DNS error read as "not published yet" and sends a bogus release to the approval gate. Match E404 explicitly and let any other failure stop the release, which is what `release.yml` does in both the `decide` preflight and the post-approval re-check.
 - **`private: true` cannot be verified locally.** npm authenticates before it checks the flag, so an unauthenticated `npm publish` reports `ENEEDAUTH` whether or not the package is private, and `--dry-run` packs and exits 0 regardless. `scripts/package-guards.spec.js` asserts it instead.
 - **A tag pushed with `GITHUB_TOKEN` does not trigger another workflow**, by design, to prevent recursion. Any "create a tag, let the tag start a release" design silently never runs.
 - **`jasmine@7` installs on Node 16 and then fails at run time** with `ReferenceError: structuredClone is not defined`, which arrived in Node 17. The repository pins jasmine 4.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ The `release` job deliberately runs a **newer Node than `.nvmrc`**. It publishes
 
 A version containing a hyphen goes to the `next` dist-tag, everything else to `latest`. Do not create release tags by hand: the workflow writes them, so a tag always means the version shipped.
 
+⚠️ **The release workflow has no `workflow_dispatch`, on purpose.** A dispatch can target any branch or tag, and this workflow runs in default-branch context holding the ability to publish, so a manual trigger meant checking out an arbitrary ref and executing it on the way to npm. CodeQL reports that as `actions/cache-poisoning/poisonable-step`, high severity, and it also made "dispatch the release" a way to bypass CI. **To retry a release, re-run the failed run from the Actions UI**, which replays the original `workflow_run` payload and so stays pinned to the commit CI tested. Adding `workflow_dispatch` back would reintroduce both problems.
+
 **Write `docs/release-notes/<major>.md` before promoting a major.** GitHub generates a release page from the previous tag, which for a stable release is its own last candidate, so the page would show the version bump and nothing from the series it completes. A stable release generates from the last stable tag instead and appends that file on the major's first stable release, `X.0.0`. Later releases of the same major do not repeat it. Prereleases are unaffected and keep listing what landed since the previous candidate.
 
 There is no CHANGELOG.md and no changelog script. The release pages are the record. `conventional-changelog -p angular` was removed because it emits no BREAKING CHANGES section from a `!` subject without a `BREAKING CHANGE:` footer, and no commit in this repository has ever carried one.


### PR DESCRIPTION
## Summary

An independent review of the pipeline that shipped 19.2.0 found the `npm-publish` gate was treated as a security boundary while the ungated jobs held the capabilities it protects. This scopes those capabilities to the gated job and removes two routes to publishing without a green suite.

## Changes

Workflow permissions drop to `contents: read`; only `release` raises them to `contents: write` and `id-token: write`. That matters because `verify` runs `npm ci` and `build:libs` before any approval, so a postinstall hook there previously held a write token and could mint the OIDC credential trusted publishing exchanges. Read-only checkouts stop persisting credentials.

The `workflow_run` gate now requires `event == 'push'`, and `workflow_dispatch` is gone: a dispatch can target any ref, which CodeQL reports as a high-severity poisonable step and which also let a manual trigger skip CI. Retries re-run the original run instead, staying pinned to the tested commit.

A `concurrency` group serializes runs, and `release` re-reads the registry after approval, since npm points a dist-tag at whatever published last rather than the highest version.

The `npm view` preflight no longer treats every failure as "not published". npm 12.0.2 exits 1 with E404 where older npm exited 0 empty, so both mean absent and anything else stops the release.

## Release impact

No release. Workflows and contributor docs only, so the version is untouched and the release workflow correctly does nothing.

## Validation

CodeQL, all three CI legs and Codecov pass. `npm run test:scripts` reported 45 specs, 0 failures. The YAML was parsed to confirm `decide` and `verify` inherit `contents: read` with no `id-token`, that `release` alone holds the write and OIDC permissions behind `npm-publish`, and that only `release` keeps checkout credentials. The backwards-`latest` guard was exercised over seven version pairs including 19.9.0 to 19.10.0, which a lexical compare misorders. E404 discrimination was checked against the live registry for an existing version, a missing version and a missing package.