### PR TITLE
ci: restore the library suites to the release verify job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ name: Release
 # needs a PAT or a GitHub App, which reintroduces the long-lived credential
 # OIDC exists to remove. So the tag is an output here, not an input.
 #
-# CI owns testing. This workflow fires after CI succeeds on main via
-# workflow_run, so library tests are not repeated here. The verify job's
-# responsibility is reproducible package construction: build the dist
-# tarballs, confirm every package carries the release version, and upload the
-# exact artifact that the gated publish job will ship.
+# This workflow fires after CI succeeds on main via workflow_run, so on that
+# path the suites have already run on this exact commit. `verify` runs them
+# again anyway, because `workflow_dispatch` reaches it with no CI run behind
+# it: dropping the step made the manual trigger a way to publish untested.
+# The duplicate run on the automatic path buys the manual path its safety.
 #
 # Three jobs, in this order for a reason. An environment protection rule blocks
 # a job before ANY of its steps run, so building inside the gated job would
@@ -122,6 +122,20 @@ jobs:
 
       - name: Build libraries
         run: npm run build:libs
+
+      # Kept here even though CI runs the same suites on the same commit,
+      # because `workflow_dispatch` reaches this job with no CI run behind it
+      # at all. Removing this step left that path publishing on the strength
+      # of `test:scripts` alone. The duplicate run on the workflow_run path is
+      # the price of the manual trigger staying safe.
+      - name: Test libraries
+        run: |
+          npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs3 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs4 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:bs5 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:material -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          npm run test:primeng -- --no-watch --no-progress --browsers=ChromeHeadlessCI
 
       - name: Confirm every package carries the release version
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Publishing is automated through `.github/workflows/release.yml` and npm OIDC Tru
 
 1. Open a PR containing only the `npm run version:set` bump.
 2. Merge it. The trigger is the version **changing** in that push, so any merge that leaves it alone is a no-op. A version sitting in the repository ahead of what is on npm is fine and does not start a release.
-3. The `verify` job builds and runs all five suites, ungated, and uploads `dist` as an artifact.
+3. The `verify` job builds, runs all six suites, ungated, and uploads `dist` as an artifact. CI has already run those suites on the same commit, but `verify` keeps them because `workflow_dispatch` reaches it with no CI run behind it.
 4. Approve the `npm-publish` deployment. Nothing reaches npm before this, and by now the build is green.
 5. `release` publishes the artifact `verify` built, `core` first, then the three framework packages, and tags the commit.
 


### PR DESCRIPTION
## Summary

#458 moved testing to CI and dropped the library suites from `verify`, on the reasoning that CI already runs them on the same commit. That holds for the `workflow_run` path but not for `workflow_dispatch`, which reaches `verify` with no CI run behind it, leaving the manual trigger able to publish on `test:scripts` alone.

## Changes

Restores the `Test libraries` step, with all six suites rather than the four it carried before #458: `bootstrap5` and `primeng` were missing from the original list. The header comment is corrected, since it claimed library tests are not repeated here. AGENTS.md said `verify` runs five suites and now describes what it actually does and why the duplication is deliberate.

The duplicate run on the automatic path is the cost of the manual trigger staying safe. Nothing else about the pipeline changes.

## Release impact

No release. Workflow and contributor docs only, so the version is untouched and the release workflow correctly does nothing.

## Validation

`npm run test:scripts` reported 45 specs, 0 failures. The workflow YAML was parsed to confirm both triggers are intact and the restored step names all six suites.