### PR TITLE
test: give each corpus suite its own AOT-visible host

### DIFF
--- a/projects/ajsf-bootstrap3/src/lib/corpus.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/corpus.spec.ts
@@ -1,5 +1,22 @@
 import { Bootstrap3FrameworkModule } from './bootstrap3-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
-runCorpus('bootstrap-3', [Bootstrap3FrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [Bootstrap3FrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class Bootstrap3CorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('bootstrap-3', Bootstrap3CorpusHost);

--- a/projects/ajsf-bootstrap4/src/lib/corpus.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/corpus.spec.ts
@@ -1,5 +1,22 @@
 import { Bootstrap4FrameworkModule } from './bootstrap4-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
-runCorpus('bootstrap-4', [Bootstrap4FrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [Bootstrap4FrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class Bootstrap4CorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('bootstrap-4', Bootstrap4CorpusHost);

--- a/projects/ajsf-bootstrap5/src/lib/corpus.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/corpus.spec.ts
@@ -1,5 +1,22 @@
 import { Bootstrap5FrameworkModule } from './bootstrap5-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
-runCorpus('bootstrap-5', [Bootstrap5FrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [Bootstrap5FrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class Bootstrap5CorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('bootstrap-5', Bootstrap5CorpusHost);

--- a/projects/ajsf-core/src/lib/corpus.spec.ts
+++ b/projects/ajsf-core/src/lib/corpus.spec.ts
@@ -1,6 +1,23 @@
 import { JsonSchemaFormModule } from './json-schema-form.module';
 import { NoFrameworkModule } from './framework-library/no-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // Source copies, because this project is @ajsf/core itself.
-runCorpus('no-framework', [JsonSchemaFormModule, NoFrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [JsonSchemaFormModule, NoFrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class CoreCorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('no-framework', CoreCorpusHost);

--- a/projects/ajsf-material/src/lib/corpus.spec.ts
+++ b/projects/ajsf-material/src/lib/corpus.spec.ts
@@ -1,5 +1,22 @@
 import { MaterialDesignFrameworkModule } from './material-design-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
-runCorpus('material-design', [MaterialDesignFrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [MaterialDesignFrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class MaterialCorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('material-design', MaterialCorpusHost);

--- a/projects/ajsf-primeng/src/lib/corpus.spec.ts
+++ b/projects/ajsf-primeng/src/lib/corpus.spec.ts
@@ -1,5 +1,22 @@
 import { PrimengFrameworkModule } from './primeng-framework.module';
-import { runCorpus } from '../../../../testing/corpus/harness';
+import { Component } from '@angular/core';
+import { CorpusHost, runCorpus } from '../../../../testing/corpus/harness';
 
 // The framework module re-exports JsonSchemaFormModule from '@ajsf/core'.
-runCorpus('primeng', [PrimengFrameworkModule]);
+@Component({
+  standalone: true,
+  imports: [PrimengFrameworkModule],
+  template: `
+    <json-schema-form
+      [form]="form"
+      [framework]="framework"
+      (isValid)="valid = $event"
+    ></json-schema-form>`,
+})
+class PrimengCorpusHost implements CorpusHost {
+  form: any;
+  framework: string;
+  valid: boolean | null = null;
+}
+
+runCorpus('primeng', PrimengCorpusHost);

--- a/testing/corpus/harness.ts
+++ b/testing/corpus/harness.ts
@@ -1,4 +1,4 @@
-import { Component, Type } from '@angular/core';
+import { Type } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CorpusSchema, loadCorpus } from './schemas';
@@ -18,19 +18,18 @@ export interface CorpusResult {
   valid: boolean | null;
 }
 
-@Component({
-    template: `
-    <json-schema-form
-      [form]="form"
-      [framework]="framework"
-      (isValid)="valid = $event"
-    ></json-schema-form>`,
-    standalone: false
-})
-class CorpusHostComponent {
+/**
+ * What every suite's host component must expose. The host owns the template
+ * rather than this file, because the template's dependencies have to be known
+ * at compile time and they differ per suite: ajsf-core renders through its
+ * source JsonSchemaFormModule while the framework packages reach the same
+ * component through dist/@ajsf/core. A single shared host cannot import
+ * either without the two copies colliding as NG0300.
+ */
+export interface CorpusHost {
   form: any;
   framework: string;
-  valid: boolean | null = null;
+  valid: boolean | null;
 }
 
 /**
@@ -39,35 +38,39 @@ class CorpusHostComponent {
  * "this schema stopped rendering" across an Angular upgrade, not to assert
  * any particular widget implementation.
  */
-function countControls(fixture: ComponentFixture<CorpusHostComponent>): number {
+function countControls(fixture: ComponentFixture<CorpusHost>): number {
   return fixture.nativeElement.querySelectorAll(
     'input, select, textarea, mat-select, mat-slider, p-select, p-multiselect, p-slider'
   ).length;
 }
 
 /**
- * `modules` must supply both json-schema-form and the framework under test.
+ * `host` is the suite's own standalone component, which must render
+ * json-schema-form and satisfy CorpusHost.
  *
- * Do not import JsonSchemaFormModule here. The framework packages import it
- * from '@ajsf/core', which tsconfig maps to dist/, while ajsf-core's own specs
- * use the source. Importing it in this file puts both copies in the same
- * TestBed and Angular fails with NG0300, "Multiple components match node with
- * tagname json-schema-form". Each spec passes whichever copy is right for it.
+ * The host is passed in rather than declared here so its template
+ * dependencies are statically known. ajsf-core passes a host importing its
+ * source JsonSchemaFormModule; each framework package passes one importing
+ * its own framework module, which reaches JsonSchemaFormModule through
+ * dist/@ajsf/core. Declaring one shared host here and importing
+ * JsonSchemaFormModule into it would put both copies in the same TestBed and
+ * fail with NG0300, "Multiple components match node with tagname
+ * json-schema-form".
  */
-export function runCorpus(frameworkName: string, modules: Type<any>[]) {
+export function runCorpus(frameworkName: string, host: Type<CorpusHost>) {
   describe(`corpus: ${frameworkName}`, () => {
     const corpus: CorpusSchema[] = loadCorpus();
     const recorded: Record<string, CorpusResult> = {};
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        // Whatever declares json-schema-form must be in here. Without it the
-        // element matches nothing and every schema renders zero controls while
-        // the suite still reports success.
-        imports: [...modules, NoopAnimationsModule],
-        declarations: [CorpusHostComponent],
-        // Turn an unmatched element or binding into a failure rather than a
-        // console warning, so this cannot silently regress again.
+        // The host is standalone, so it carries json-schema-form and the
+        // framework under test in its own imports. Without them the element
+        // matches nothing and every schema renders zero controls while the
+        // suite still reports success.
+        imports: [host, NoopAnimationsModule],
+        // Kept for clarity. Compiling the host ahead of time is now what
+        // actually rejects an unmatched element or binding.
         schemas: [],
       }).compileComponents();
     }));
@@ -86,7 +89,7 @@ export function runCorpus(frameworkName: string, modules: Type<any>[]) {
     corpus.forEach((entry) => {
       it(`renders ${entry.name}`, () => {
         const key = `${frameworkName}/${entry.name}`;
-        const fixture = TestBed.createComponent(CorpusHostComponent);
+        const fixture = TestBed.createComponent(host);
         fixture.componentInstance.form = entry.form;
         fixture.componentInstance.framework = frameworkName;
 


### PR DESCRIPTION
## Summary

Makes the corpus harness compilable ahead of time, which is the prerequisite for any runner that builds specs rather than compiling them in the browser. Behaviour-only: Karma stays, the six test targets are untouched, and the 444-entry baseline is not re-recorded.

## Changes

The harness declared one `CorpusHostComponent` with an inline `json-schema-form` template and took the modules satisfying it as a runtime argument. That works under JIT, where TestBed is already configured by the time the template compiles, and cannot work ahead of time: the compiler needs the template's dependencies and they differ per suite. `ajsf-core` renders through its source `JsonSchemaFormModule` while the five framework packages reach the same component through `dist/@ajsf/core`, which is why the harness could not simply import it. Both copies in one TestBed fail with NG0300.

Template ownership therefore moves to the suites. `runCorpus` now takes a standalone host satisfying the exported `CorpusHost` interface, and each suite declares a small one importing exactly the modules it wants. Execution, control counting, error capture, validity and baseline comparison all stay in the harness.

No `CUSTOM_ELEMENTS_SCHEMA` or `NO_ERRORS_SCHEMA`. Compiling the host is now what rejects an unmatched element or binding, which is stricter than the runtime check it replaces. The empty `schemas: []` stays for clarity.

Six explicit hosts rather than one host patched per suite through `TestBed.overrideComponent`, since override behaviour under the unit-test builder is a known open issue and this is less clever.

## Compatibility

Test code only. No public API change, no `public_api.ts` touched, nothing shipped to consumers.

## Validation

Seven files changed and nothing else. All six suites pass under the unchanged `@angular/build:karma`: core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104, primeng 206, so 2705 specs and no failures, identical to the counts before the change. `testing/corpus/baseline.json` is untouched and still holds 444 entries, 74 per framework across six frameworks, so every slice asserted against the existing baseline rather than being re-recorded.