### PR TITLE
build: raise @types/node from 12 to 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@angular/language-service": "^20.3.30",
         "@primeng/themes": "^20.4.0",
         "@types/jasmine": "~4.0.0",
-        "@types/node": "^12.11.1",
+        "@types/node": "^20.19.43",
         "codelyzer": "^6.0.0",
         "jasmine": "^4.6.0",
         "jasmine-core": "~4.3.0",
@@ -5065,10 +5065,21 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-      "integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ==",
-      "dev": true
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -14886,10 +14897,21 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-      "integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ==",
-      "dev": true
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      },
+      "dependencies": {
+        "undici-types": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+          "dev": true
+        }
+      }
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@angular/language-service": "^20.3.30",
     "@primeng/themes": "^20.4.0",
     "@types/jasmine": "~4.0.0",
-    "@types/node": "^12.11.1",
+    "@types/node": "^20.19.43",
     "codelyzer": "^6.0.0",
     "jasmine": "^4.6.0",
     "jasmine-core": "~4.3.0",


### PR DESCRIPTION
## Summary

`@types/node` was pinned at `^12.11.1`, Node 12 typings, on a workspace whose `engines` floor is now `^20.19.0 || ^22.12.0 || >=24.0.0` and whose `.nvmrc` is 20.19.0. Landed on its own rather than inside the Vitest work, since it is independently correct and independently useful.

## Changes

Raises the pin to `^20`, resolving to 20.19.43, tracking `.nvmrc` rather than jumping to a newer major.

Nothing was reading Node globals from the wrong major by accident: every `tsconfig.lib.json` sets `types` to an empty array and only the spec configs opt in. The declared typings simply did not describe any runtime the project supports.

It is also a hard prerequisite for the runner migration rather than a tidy-up. Vitest 3 declares `peerOptional @types/node "^18.0.0 || ^20.0.0 || >=22.0.0"`, so installing Vitest against the old pin fails with `ERESOLVE` before any configuration is attempted. The resolved 20.19.43 satisfies that range.

## Release impact

No release. Development typings only, so the version is untouched and the release workflow correctly does nothing.

## Validation

`npm run test:scripts` reported 45 specs, 0 failures. All six libraries build, the demo builds, and all six suites pass unchanged: core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104, primeng 206, so 2705 specs and no failures. Only `package.json` and `package-lock.json` change.