### PR TITLE
fix(scripts): move the primeng peer with the Angular major

### DIFF
--- a/scripts/set-version.js
+++ b/scripts/set-version.js
@@ -2,9 +2,19 @@ const fs = require('fs');
 const path = require('path');
 
 const PACKAGES = ['ajsf-core', 'ajsf-material', 'ajsf-bootstrap3', 'ajsf-bootstrap4', 'ajsf-bootstrap5', 'ajsf-primeng'];
-const ANGULAR_PEERS = [
-  '@angular/core', '@angular/common', '@angular/forms',
-  '@angular/platform-browser', '@angular/material', '@angular/cdk',
+// Peers whose major is pinned to the Angular major this release targets.
+// Not only @angular/* : PrimeNG's majors have tracked Angular's since v18,
+// which is why @ajsf/primeng's major equals both. Leaving it out published
+// @ajsf/primeng 19.2.0 telling consumers to install PrimeNG 19 alongside
+// whatever Angular the release targeted.
+const MAJOR_PEERS = [
+  '@angular/core',
+  '@angular/common',
+  '@angular/forms',
+  '@angular/platform-browser',
+  '@angular/material',
+  '@angular/cdk',
+  'primeng',
 ];
 
 const VERSION = /^(\d+)\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
@@ -120,7 +130,7 @@ function setVersion(nextVersion, angularMajor, packagesDir) {
     }
 
     if (angularMajor !== null && manifest.peerDependencies) {
-      for (const peer of ANGULAR_PEERS) {
+      for (const peer of MAJOR_PEERS) {
         if (manifest.peerDependencies[peer]) {
           manifest.peerDependencies[peer] = `^${angularMajor}.0.0`;
         }

--- a/scripts/set-version.spec.js
+++ b/scripts/set-version.spec.js
@@ -79,12 +79,20 @@ describe('setVersion', () => {
     expect(read(dir, 'ajsf-material').peerDependencies['@angular/cdk']).toEqual('^18.0.0');
   });
 
-  it('leaves non-Angular dependencies alone', () => {
+  it('leaves genuinely unrelated dependencies alone', () => {
     const dir = fixture();
     setVersion('18.0.0', 18, dir);
     expect(read(dir, 'ajsf-core').peerDependencies.rxjs).toEqual('^7.0.0');
     expect(read(dir, 'ajsf-core').dependencies.ajv).toEqual('^6.10.0');
-    expect(read(dir, 'ajsf-primeng').peerDependencies.primeng).toEqual('^19.0.0');
+  });
+
+  // The peer that shipped wrong in 19.2.0. PrimeNG's majors track Angular's,
+  // so it has to move with the release rather than being left behind as an
+  // unrelated dependency.
+  it('moves the primeng peer with the Angular major', () => {
+    const dir = fixture();
+    setVersion('20.0.0-rc.0', 20, dir);
+    expect(read(dir, 'ajsf-primeng').peerDependencies.primeng).toEqual('^20.0.0');
   });
 
   it('leaves Angular peers alone when angularMajor is null', () => {


### PR DESCRIPTION
## Summary

`@ajsf/primeng` 19.2.0 published telling consumers to install PrimeNG 19 alongside whatever Angular the release targeted. This fixes the versioning script so it cannot happen again, ahead of `20.0.0-rc.0`.

## Changes

`setVersion` only rewrites peers listed in what was `ANGULAR_PEERS`, and `primeng` was not among them. Nothing caught it: the corpus records rendered controls and cannot see package metadata, and `set-version.spec.js` asserted the wrong invariant outright, expecting the peer to stay at `^19.0.0` as though it were an unrelated dependency.

PrimeNG's majors have tracked Angular's since v18, which is the same reason `@ajsf/primeng`'s major equals the Angular major. So the list is renamed `MAJOR_PEERS`: peers whose major is pinned to the release, rather than peers under the `@angular` scope. `primeng` joins it.

The spec now covers the path that would have shipped wrong, asserting that a 20 bump writes `^20.0.0` rather than that it leaves 19 alone.

`projects/ajsf-primeng/package.json` still reads `^19.0.0` here on purpose. Those ranges belong to `version:set`, which runs in the release pull request rather than by hand.

## Release impact

No release. Build tooling and its tests only, so the version is untouched and the release workflow correctly does nothing. It changes what the next `version:set` writes, which is the point.

## Validation

`npm run test:scripts` reported 46 specs, 0 failures, the extra one being the new guard. A dry run of `setVersion('20.0.0-rc.0', 20, …)` over copies of the six real manifests produced coherent output: every package on `20.0.0-rc.0`, the five framework packages pinning `@ajsf/core` exactly as a prerelease should, `primeng` reading `^20.0.0`, and `rxjs` left at `^7.0.0` as a genuinely unrelated peer.