### PR TITLE
test(bootstrap3): move @ajsf/bootstrap3 to the Angular Vitest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
       run: npm run build:demo
     - name: Test libs
       run: |
-        # Core is on the Vitest runner and takes neither --no-progress nor
-        # --browsers. The unit-test builder's schema has no progress option, and
+        # The migrated suites run on Vitest and take neither --no-progress nor
+        # --browsers: the unit-test builder's schema has no progress option, and
         # omitting browsers selects jsdom, which is the only mode that produces
-        # coverage under @angular/build 20.3.36: browser mode attributes nothing
-        # and writes an empty lcov. The other five keep ChromeHeadlessCI until
-        # they migrate.
+        # coverage under @angular/build 20.3.36, since browser mode attributes
+        # nothing and writes an empty lcov. The rest keep ChromeHeadlessCI
+        # until they migrate.
         npm run test:core -- --code-coverage --no-watch
-        npm run test:bs3 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
+        npm run test:bs3 -- --code-coverage --no-watch
         npm run test:bs4 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
         npm run test:bs5 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
         npm run test:material -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI

--- a/angular.json
+++ b/angular.json
@@ -131,6 +131,9 @@
               "text-summary",
               "html",
               "lcov"
+            ],
+            "codeCoverageExclude": [
+              "**/chunk-*.js"
             ]
           }
         }
@@ -183,11 +186,22 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "main": "projects/ajsf-bootstrap3/src/test.ts",
+            "buildTarget": "@ajsf/bootstrap3:build",
             "tsConfig": "projects/ajsf-bootstrap3/tsconfig.spec.json",
-            "karmaConfig": "projects/ajsf-bootstrap3/karma.conf.js"
+            "runner": "vitest",
+            "setupFiles": [
+              "projects/ajsf-bootstrap3/src/test-setup.ts"
+            ],
+            "codeCoverageReporters": [
+              "text-summary",
+              "html",
+              "lcov"
+            ],
+            "codeCoverageExclude": [
+              "**/chunk-*.js"
+            ]
           }
         }
       }

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import {
   JsonSchemaFormModule,
@@ -11,8 +11,8 @@ describe('Bootstrap3FrameworkComponent', () => {
   let component: Bootstrap3FrameworkComponent;
   let fixture: ComponentFixture<Bootstrap3FrameworkComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         JsonSchemaFormModule,
         CommonModule,
@@ -22,7 +22,7 @@ describe('Bootstrap3FrameworkComponent', () => {
       providers: [JsonSchemaFormService]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(Bootstrap3FrameworkComponent);

--- a/projects/ajsf-bootstrap3/src/test-setup.ts
+++ b/projects/ajsf-bootstrap3/src/test-setup.ts
@@ -1,0 +1,6 @@
+// Same reason as @ajsf/core: the unit-test builder takes polyfills from the
+// buildTarget, and an ng-packagr target has none to take, so Zone is loaded
+// here. Without it Angular's Zone-based change detection fails with NG0908.
+// See angular/angular-cli#33477. `zone.js/testing` is not needed: there is no
+// fakeAsync here and no ProxyZone-dependent waitForAsync.
+import 'zone.js';

--- a/projects/ajsf-bootstrap3/tsconfig.spec.json
+++ b/projects/ajsf-bootstrap3/tsconfig.spec.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine",
+      "vitest/globals",
       "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules",
+      "../../manual_typings"
     ]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/test-setup.ts"
   ],
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## Summary

Second suite onto the Vitest runner, following the shape `@ajsf/core` established in #473. `bootstrap4`, `bootstrap5`, `material` and `primeng` stay on Karma.

## Changes

`bootstrap3` needed almost nothing: no jasmine globals, no `spyOn`, no `withContext`, and a single `beforeEach(waitForAsync(...))` block that now awaits `compileComponents` directly, for the same reason as core's four. Its test target becomes `@angular/build:unit-test` with `buildTarget: "@ajsf/bootstrap3:build"`, a `test-setup.ts` loading `zone.js` only, and the same `codeCoverageReporters`. Its spec tsconfig drops the jasmine types and gains `node_modules` in `typeRoots` so `vitest/globals` resolves.

It goes first among the framework packages deliberately: its corpus renders plain Bootstrap classes rather than component overlays, so jsdom equivalence carried about as little risk here as it did for core. Material and PrimeNG are last for the opposite reason.

## One thing this also fixes

The unit-test builder collects coverage over its own bundled output under `dist/test-out/<timestamp>-<uuid>/`, so the lcov names a `chunk-*.js` entry beside the real sources, and every path carries that temp prefix.

The prefix turns out to be harmless: Codecov's path fixing discards it and maps the source files, which is why `codecov/project` reported 90.86% and **+3.46%** on the core migration rather than falling. The chunk entry maps to nothing, though, so both migrated targets now carry `codeCoverageExclude: ["**/chunk-*.js"]`. Applying it to core as well as bootstrap3 keeps the two from drifting.

## Compatibility

Test infrastructure only. No public API change, no `public_api.ts` touched, packaging unchanged. `testing/corpus/baseline.json` is untouched.

## Validation

`npm run test:bs3 -- --code-coverage --no-watch` exits 0 with 76 of 76 tests and writes an lcov with no `chunk-*.js` entries. Core re-verified alongside it at 2156 of 2156, also chunk-free. The four remaining Karma suites pass unchanged: bootstrap4 76, bootstrap5 87, material 104, primeng 206, so 2599 specs green across both runners plus core. `npm run test:scripts` reported 46 specs, 0 failures. All six libraries build and `baseline.json` is byte-identical.