### PR TITLE
test(bootstrap): move bootstrap4 and bootstrap5 to Vitest, and fix the coverage regression from #475

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,25 @@ jobs:
         # coverage under @angular/build 20.3.36, since browser mode attributes
         # nothing and writes an empty lcov. The rest keep ChromeHeadlessCI
         # until they migrate.
-        npm run test:core -- --code-coverage --no-watch
-        npm run test:bs3 -- --code-coverage --no-watch
-        npm run test:bs4 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
-        npm run test:bs5 -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
+        # Every Vitest suite writes coverage/lcov.info and wipes the coverage
+        # directory before doing so, so each report is staged outside it and
+        # restored at the end. Karma wrote per-project subdirectories and needed
+        # none of this; the unit-test builder exposes no output directory
+        # option, and the istanbul `subdir` reporter option is not honoured.
+        mkdir -p /tmp/vitest-cov
+        for suite in core bs3 bs4 bs5; do
+          npm run test:$suite -- --code-coverage --no-watch
+          cp coverage/lcov.info "/tmp/vitest-cov/$suite.info"
+        done
         npm run test:material -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
         npm run test:primeng -- --code-coverage --no-watch --no-progress --browsers=ChromeHeadlessCI
+        # Karma writes into per-project subdirectories and does not wipe the
+        # directory, so the staged Vitest reports can be put back now.
+        for suite in core bs3 bs4 bs5; do
+          mkdir -p "coverage/vitest-$suite"
+          cp "/tmp/vitest-cov/$suite.info" "coverage/vitest-$suite/lcov.info"
+        done
+        find coverage -name lcov.info | sort
     # The codecov npm package is deprecated and its uploader now fails against
     # the current API with "result.split is not a function". This action is the
     # supported path.

--- a/angular.json
+++ b/angular.json
@@ -129,11 +129,7 @@
             ],
             "codeCoverageReporters": [
               "text-summary",
-              "html",
               "lcov"
-            ],
-            "codeCoverageExclude": [
-              "**/chunk-*.js"
             ]
           }
         }
@@ -158,11 +154,18 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "main": "projects/ajsf-bootstrap4/src/test.ts",
+            "buildTarget": "@ajsf/bootstrap4:build",
             "tsConfig": "projects/ajsf-bootstrap4/tsconfig.spec.json",
-            "karmaConfig": "projects/ajsf-bootstrap4/karma.conf.js"
+            "runner": "vitest",
+            "setupFiles": [
+              "projects/ajsf-bootstrap4/src/test-setup.ts"
+            ],
+            "codeCoverageReporters": [
+              "text-summary",
+              "lcov"
+            ]
           }
         }
       }
@@ -196,11 +199,7 @@
             ],
             "codeCoverageReporters": [
               "text-summary",
-              "html",
               "lcov"
-            ],
-            "codeCoverageExclude": [
-              "**/chunk-*.js"
             ]
           }
         }
@@ -253,11 +252,18 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "main": "projects/ajsf-bootstrap5/src/test.ts",
+            "buildTarget": "@ajsf/bootstrap5:build",
             "tsConfig": "projects/ajsf-bootstrap5/tsconfig.spec.json",
-            "karmaConfig": "projects/ajsf-bootstrap5/karma.conf.js"
+            "runner": "vitest",
+            "setupFiles": [
+              "projects/ajsf-bootstrap5/src/test-setup.ts"
+            ],
+            "codeCoverageReporters": [
+              "text-summary",
+              "lcov"
+            ]
           }
         }
       }

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import {
   JsonSchemaFormModule,
@@ -11,8 +11,8 @@ describe('FwBootstrap4Component', () => {
   let component: Bootstrap4FrameworkComponent;
   let fixture: ComponentFixture<Bootstrap4FrameworkComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         JsonSchemaFormModule,
         CommonModule,
@@ -22,7 +22,7 @@ describe('FwBootstrap4Component', () => {
       providers: [JsonSchemaFormService]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(Bootstrap4FrameworkComponent);

--- a/projects/ajsf-bootstrap4/src/test-setup.ts
+++ b/projects/ajsf-bootstrap4/src/test-setup.ts
@@ -1,0 +1,6 @@
+// Same reason as @ajsf/core: the unit-test builder takes polyfills from the
+// buildTarget, and an ng-packagr target has none to take, so Zone is loaded
+// here. Without it Angular's Zone-based change detection fails with NG0908.
+// See angular/angular-cli#33477. `zone.js/testing` is not needed: there is no
+// fakeAsync here and no ProxyZone-dependent waitForAsync.
+import 'zone.js';

--- a/projects/ajsf-bootstrap4/tsconfig.spec.json
+++ b/projects/ajsf-bootstrap4/tsconfig.spec.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine",
+      "vitest/globals",
       "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules",
+      "../../manual_typings"
     ]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/test-setup.ts"
   ],
   "include": [
     "**/*.spec.ts",

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import {
   JsonSchemaFormModule,
@@ -11,8 +11,8 @@ describe('FwBootstrap5Component', () => {
   let component: Bootstrap5FrameworkComponent;
   let fixture: ComponentFixture<Bootstrap5FrameworkComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         JsonSchemaFormModule,
         CommonModule,
@@ -22,7 +22,7 @@ describe('FwBootstrap5Component', () => {
       providers: [JsonSchemaFormService]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(Bootstrap5FrameworkComponent);

--- a/projects/ajsf-bootstrap5/src/test-setup.ts
+++ b/projects/ajsf-bootstrap5/src/test-setup.ts
@@ -1,0 +1,6 @@
+// Same reason as @ajsf/core: the unit-test builder takes polyfills from the
+// buildTarget, and an ng-packagr target has none to take, so Zone is loaded
+// here. Without it Angular's Zone-based change detection fails with NG0908.
+// See angular/angular-cli#33477. `zone.js/testing` is not needed: there is no
+// fakeAsync here and no ProxyZone-dependent waitForAsync.
+import 'zone.js';

--- a/projects/ajsf-bootstrap5/tsconfig.spec.json
+++ b/projects/ajsf-bootstrap5/tsconfig.spec.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine",
+      "vitest/globals",
       "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules",
+      "../../manual_typings"
     ]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/test-setup.ts"
   ],
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## Summary

Third and fourth suites onto Vitest, plus a revert of the `codeCoverageExclude` added in #475, which broke coverage on core and bootstrap3 rather than tidying it. `material` and `primeng` remain on Karma.

## The coverage regression

#475 added `codeCoverageExclude: ["**/chunk-*.js"]` to the migrated targets, on the reasoning that the `chunk-*.js` entry in the lcov was bundling noise that mapped to nothing.

That reasoning was wrong. The builder collects V8 coverage over its own bundled output under `dist/test-out`, and the source entries in the report are remapped from that chunk. Excluding it discards the data they are derived from. Measured on a clean `dist/test-out`, core reports 57 source files without the exclude and 1 with it.

`codecov/project` failing on this pull request is what surfaced it. It was invisible locally at first because `dist/test-out` is never cleaned and 23 stale run directories were being picked up, so the report looked healthy while a clean tree produced almost nothing. The exclude is removed from all migrated targets.

## Changes

`bootstrap4` and `bootstrap5` each had a single `beforeEach(waitForAsync(...))` block and no jasmine globals, so each needed only that conversion to `async`/`await`, a `test-setup.ts` loading `zone.js`, and the target and spec tsconfig shape `@ajsf/core` established in #473.

Material and PrimeNG are held back deliberately. Their corpus renders `mat-select` and `p-select` overlays rather than plain classes, and `countControls` selects those element names, so whether jsdom reproduces what ChromeHeadless recorded is a real question there rather than the formality it was for the four class-based frameworks.

## Compatibility

Test infrastructure only. No public API change, no `public_api.ts` touched, packaging unchanged. `testing/corpus/baseline.json` is untouched.

## Validation

Each suite run against a cleaned `dist/test-out`, so the numbers are not inflated by stale output. All four migrated suites pass and produce real coverage: core 2156 of 2156 with 57 source files in the lcov, bootstrap3 76 of 76 with 59, bootstrap4 76 of 76 with 59, bootstrap5 87 of 87 with 59. The two remaining Karma suites pass unchanged: material 104, primeng 206. All six libraries build and `baseline.json` is byte-identical.

`codecov/project` is the check to watch on this run, since it is the one that caught the regression.