### PR TITLE
test(material): move @ajsf/material to the Angular Vitest runner

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -224,11 +224,18 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "main": "projects/ajsf-material/src/test.ts",
+            "buildTarget": "@ajsf/material:build",
             "tsConfig": "projects/ajsf-material/tsconfig.spec.json",
-            "karmaConfig": "projects/ajsf-material/karma.conf.js"
+            "runner": "vitest",
+            "setupFiles": [
+              "projects/ajsf-material/src/test-setup.ts"
+            ],
+            "codeCoverageReporters": [
+              "text-summary",
+              "lcov"
+            ]
           }
         }
       }

--- a/projects/ajsf-material/src/lib/material-design-framework.component.spec.ts
+++ b/projects/ajsf-material/src/lib/material-design-framework.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import {
   JsonSchemaFormModule,
@@ -11,8 +11,8 @@ describe('FwBootstrap4Component', () => {
   let component: MaterialDesignFrameworkComponent;
   let fixture: ComponentFixture<MaterialDesignFrameworkComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         JsonSchemaFormModule,
         CommonModule,
@@ -22,7 +22,7 @@ describe('FwBootstrap4Component', () => {
       providers: [JsonSchemaFormService]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MaterialDesignFrameworkComponent);

--- a/projects/ajsf-material/src/lib/widgets/flex-layout-options.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/flex-layout-options.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
 import { FlexLayoutRootComponent } from './flex-layout-root.component';
@@ -15,11 +15,11 @@ import { FlexLayoutRootComponent } from './flex-layout-root.component';
 describe('flex layout options', () => {
   let fixture: ComponentFixture<FlexLayoutRootComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [MaterialDesignFrameworkModule, NoopAnimationsModule],
     }).compileComponents();
-  }));
+  });
 
   /** Renders one layout node and returns the item wrapper the options land on. */
   function itemFor(options: any): HTMLElement {

--- a/projects/ajsf-material/src/lib/widgets/material-button.component.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-button.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { JsonSchemaFormModule } from '@ajsf/core';
 import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
@@ -13,7 +13,8 @@ describe('MaterialButtonComponent as a layout-declared submit', () => {
         [form]="form"
         framework="material-design"
       ></json-schema-form>`,
-      standalone: false
+      standalone: true,
+      imports: [JsonSchemaFormModule, MaterialDesignFrameworkModule]
   })
   class HostComponent {
     form: any;
@@ -21,12 +22,11 @@ describe('MaterialButtonComponent as a layout-declared submit', () => {
 
   let fixture: ComponentFixture<HostComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [HostComponent],
-      imports: [JsonSchemaFormModule, MaterialDesignFrameworkModule, NoopAnimationsModule],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent, NoopAnimationsModule],
     }).compileComponents();
-  }));
+  });
 
   const render = (layout: any[], data: any = {}) => {
     fixture = TestBed.createComponent(HostComponent);

--- a/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
+++ b/projects/ajsf-material/src/lib/widgets/material-integration.spec.ts
@@ -1,5 +1,6 @@
+import { vi } from 'vitest';
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialDesignFrameworkModule } from '../material-design-framework.module';
@@ -14,7 +15,8 @@ import { MaterialDesignFrameworkModule } from '../material-design-framework.modu
       (onChanges)="value = $event"
       (isValid)="valid = $event"
     ></json-schema-form>`,
-    standalone: false
+    standalone: true,
+    imports: [MaterialDesignFrameworkModule]
 })
 class TestHostComponent {
   schema: any = {};
@@ -28,13 +30,12 @@ describe('Material widget integration', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MaterialDesignFrameworkModule, NoopAnimationsModule],
-      declarations: [TestHostComponent],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, NoopAnimationsModule],
       schemas: [],
     }).compileComponents();
-  }));
+  });
 
   function create(schema: any, data?: any, layout?: any) {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -105,21 +106,21 @@ describe('Material widget integration', () => {
       expect(input.hidden).toBe(true);
     });
 
-    it('writes data URL to control after file selection', (done) => {
+    it('writes data URL to control after file selection', async () => {
       create(fileSchema);
       const de = fixture.debugElement.query(By.css('material-file-widget'));
       const fileComp = de.componentInstance;
-      const updateSpy = spyOn(fileComp.jsf, 'updateValue');
+      const updateSpy = vi.spyOn(fileComp.jsf, 'updateValue');
       const blob = new Blob(['hello'], { type: 'text/plain' });
       const file = new File([blob], 'test.txt', { type: 'text/plain' });
       fileComp.onFileSelect({ target: { files: [file] } });
-      setTimeout(() => {
-        expect(fileComp.fileName).toBe('test.txt');
-        expect(updateSpy).toHaveBeenCalledWith(
-          fileComp, jasmine.stringMatching(/^data:text\/plain;base64,/)
-        );
-        done();
-      }, 50);
+      // FileReader resolves on a macrotask, and there is no fixture-level hook
+      // to await it: whenStable does not cover it.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(fileComp.fileName).toBe('test.txt');
+      expect(updateSpy).toHaveBeenCalledWith(
+        fileComp, expect.stringMatching(/^data:text\/plain;base64,/)
+      );
     });
   });
 

--- a/projects/ajsf-material/src/test-setup.ts
+++ b/projects/ajsf-material/src/test-setup.ts
@@ -1,0 +1,5 @@
+// Same reason as @ajsf/core: the unit-test builder takes polyfills from the
+// buildTarget, and an ng-packagr target has none to take, so Zone is loaded
+// here. Without it Angular's Zone-based change detection fails with NG0908.
+// See angular/angular-cli#33477.
+import 'zone.js';

--- a/projects/ajsf-material/tsconfig.spec.json
+++ b/projects/ajsf-material/tsconfig.spec.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine",
+      "vitest/globals",
       "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules",
+      "../../manual_typings"
     ]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/test-setup.ts"
   ],
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## Summary

Fifth suite onto the Vitest runner. Only `@ajsf/primeng` remains on Karma.

## Changes

Material was held back with primeng because its corpus renders `mat-select` and `mat-slider`, which `countControls` selects by element name, so whether jsdom reproduces what ChromeHeadless recorded was a real question rather than a formality. It does: all 74 `material-design` corpus entries pass against the unchanged baseline.

Four `beforeEach(waitForAsync(...))` blocks become `async` and `await`, for the same reason as the earlier suites: they depend on a ProxyZone that nothing installs under Vitest.

Two host components carrying inline `json-schema-form` templates become standalone with explicit imports, the same AOT accommodation the corpus harness needed in #465. A standalone component is imported rather than declared, so their TestBed configuration moves with them.

The file widget test used a `done` callback, which Vitest does not support. It now awaits a promise around the same `setTimeout`, which is what the callback was doing. Its `spyOn` becomes `vi.spyOn` and its `jasmine.stringMatching` becomes `expect.stringMatching`.

The workflow needs no change, because `scripts/run-coverage.js` reads each suite's builder from `angular.json` and picks the flags from that.

## Compatibility

Test infrastructure only. No public API change, no `public_api.ts` touched, packaging unchanged. `testing/corpus/baseline.json` is untouched.

## Validation

`npm run test:material -- --code-coverage --no-watch` exits 0 with 7 of 7 files and 104 of 104 tests, no build errors, and its corpus slice asserting against the existing baseline. PrimeNG passes unchanged on Karma at 206. `npm run test:scripts` reported 46 specs, 0 failures, and `baseline.json` is byte-identical.