### PR TITLE
test(primeng): move @ajsf/primeng to the Angular Vitest runner

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -294,11 +294,18 @@
           }
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "main": "projects/ajsf-primeng/src/test.ts",
+            "buildTarget": "@ajsf/primeng:build",
             "tsConfig": "projects/ajsf-primeng/tsconfig.spec.json",
-            "karmaConfig": "projects/ajsf-primeng/karma.conf.js"
+            "runner": "vitest",
+            "setupFiles": [
+              "projects/ajsf-primeng/src/test-setup.ts"
+            ],
+            "codeCoverageReporters": [
+              "text-summary",
+              "lcov"
+            ]
           }
         }
       }

--- a/projects/ajsf-primeng/src/lib/primeng-framework.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/primeng-framework.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import {
   JsonSchemaFormModule,
@@ -11,8 +11,8 @@ describe('PrimengFrameworkComponent', () => {
   let component: PrimengFrameworkComponent;
   let fixture: ComponentFixture<PrimengFrameworkComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         JsonSchemaFormModule,
         CommonModule,
@@ -22,7 +22,7 @@ describe('PrimengFrameworkComponent', () => {
       providers: [JsonSchemaFormService]
     })
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PrimengFrameworkComponent);

--- a/projects/ajsf-primeng/src/lib/widgets/flex-layout-options.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/flex-layout-options.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PrimengFrameworkModule } from '../primeng-framework.module';
 import { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.component';
@@ -6,11 +6,11 @@ import { PrimengFlexLayoutRootComponent } from './primeng-flex-layout-root.compo
 describe('flex layout options (primeng)', () => {
   let fixture: ComponentFixture<PrimengFlexLayoutRootComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [PrimengFrameworkModule, NoopAnimationsModule],
     }).compileComponents();
-  }));
+  });
 
   function itemFor(options: any): HTMLElement {
     fixture = TestBed.createComponent(PrimengFlexLayoutRootComponent);

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-button-group.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-button-group.component.spec.ts
@@ -1,10 +1,11 @@
+import { vi } from 'vitest';
 import { PrimengButtonGroupComponent } from './primeng-button-group.component';
 
 describe('PrimengButtonGroupComponent', () => {
   const make = (opts: any) => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
     };
     const c = new PrimengButtonGroupComponent(jsf as any);
     c.layoutNode = { type: 'button-group', options: opts };

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-button.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-button.component.spec.ts
@@ -1,13 +1,14 @@
+import { vi } from 'vitest';
 import { PrimengButtonComponent } from './primeng-button.component';
 
 describe('PrimengButtonComponent', () => {
   const make = (opts: any) => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
       formOptions: {},
       isValid: true,
-      isValidChanges: { subscribe: jasmine.createSpy('subscribe') },
+      isValidChanges: { subscribe: vi.fn() },
     };
     const c = new PrimengButtonComponent(jsf as any);
     c.layoutNode = { type: 'submit', options: opts };
@@ -22,11 +23,11 @@ describe('PrimengButtonComponent', () => {
 
   it('subscribes to isValidChanges when disableInvalidSubmit is set', () => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
       formOptions: { disableInvalidSubmit: true },
       isValid: false,
-      isValidChanges: { subscribe: jasmine.createSpy('subscribe') },
+      isValidChanges: { subscribe: vi.fn() },
     };
     const c = new PrimengButtonComponent(jsf as any);
     c.layoutNode = { type: 'submit', options: {} };
@@ -36,7 +37,7 @@ describe('PrimengButtonComponent', () => {
   });
 
   it('calls onClick function when provided', () => {
-    const onClick = jasmine.createSpy('onClick');
+    const onClick = vi.fn();
     const { component, jsf } = make({ onClick });
     const event = { target: { value: 'test' } };
     component.updateValue(event);

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-checkbox.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-checkbox.component.spec.ts
@@ -1,11 +1,12 @@
+import { vi } from 'vitest';
 import { PrimengCheckboxComponent } from './primeng-checkbox.component';
 
 describe('PrimengCheckboxComponent', () => {
   const make = (opts: any, layoutType = 'checkbox') => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
-      getFormControlValue: jasmine.createSpy('getFormControlValue').and.returnValue(false),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
+      getFormControlValue: vi.fn().mockReturnValue(false),
     };
     const c = new PrimengCheckboxComponent(jsf as any);
     c.layoutNode = { type: layoutType, options: opts };
@@ -26,9 +27,9 @@ describe('PrimengCheckboxComponent', () => {
 
   it('detects slide-toggle from layoutNode.format', () => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
-      getFormControlValue: jasmine.createSpy('getFormControlValue').and.returnValue(false),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
+      getFormControlValue: vi.fn().mockReturnValue(false),
     };
     const c = new PrimengCheckboxComponent(jsf as any);
     c.layoutNode = { type: 'checkbox', format: 'slide-toggle', options: {} };
@@ -43,26 +44,26 @@ describe('PrimengCheckboxComponent', () => {
 
   it('updates with trueValue on checked', () => {
     const { component, jsf } = make({});
-    jsf.updateValue.calls.reset();
+    jsf.updateValue.mockClear();
     component.updateValue({ checked: true });
     expect(jsf.updateValue).toHaveBeenCalledWith(component, true);
   });
 
   it('updates with falseValue on unchecked', () => {
     const { component, jsf } = make({});
-    jsf.updateValue.calls.reset();
+    jsf.updateValue.mockClear();
     component.updateValue({ checked: false });
     expect(jsf.updateValue).toHaveBeenCalledWith(component, false);
   });
 
   it('isChecked returns true when controlValue equals trueValue', () => {
     const { component, jsf } = make({});
-    jsf.getFormControlValue.and.returnValue(true);
+    jsf.getFormControlValue.mockReturnValue(true);
     expect(component.isChecked).toBe(true);
   });
 
   it('passes !readonly to initializeControl', () => {
     const { jsf } = make({ readonly: true });
-    expect(jsf.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(jsf.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-checkboxes.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-checkboxes.component.spec.ts
@@ -1,11 +1,12 @@
+import { vi } from 'vitest';
 import { PrimengCheckboxesComponent } from './primeng-checkboxes.component';
 
 describe('PrimengCheckboxesComponent', () => {
   const make = (opts: any, layoutType = 'checkboxes') => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateArrayCheckboxList: jasmine.createSpy('updateArrayCheckboxList'),
-      getFormControl: jasmine.createSpy('getFormControl'),
+      initializeControl: vi.fn(),
+      updateArrayCheckboxList: vi.fn(),
+      getFormControl: vi.fn(),
     };
     const c = new PrimengCheckboxesComponent(jsf as any);
     c.layoutNode = { type: layoutType, options: opts };

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-chip-list.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengChipListComponent } from './primeng-chip-list.component';
 
 describe('PrimengChipListComponent', () => {
   const jsf = () => ({
-    initializeControl: jasmine.createSpy('initializeControl'),
-    updateArrayCheckboxList: jasmine.createSpy('updateArrayCheckboxList'),
+    initializeControl: vi.fn(),
+    updateArrayCheckboxList: vi.fn(),
   });
 
   const make = (node: any) => {
@@ -27,7 +28,7 @@ describe('PrimengChipListComponent', () => {
       type: 'chip-list',
       options: {},
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 
   it('filters suggestions from typeahead source', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-datepicker.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengDatepickerComponent } from './primeng-datepicker.component';
 
 describe('PrimengDatepickerComponent', () => {
   const jsf = () => ({
-    initializeControl: jasmine.createSpy('initializeControl'),
-    updateValue: jasmine.createSpy('updateValue'),
+    initializeControl: vi.fn(),
+    updateValue: vi.fn(),
   });
 
   const make = (node: any) => {
@@ -27,7 +28,7 @@ describe('PrimengDatepickerComponent', () => {
       type: 'date',
       options: {},
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), true);
   });
 
   it('respects readonly option', () => {
@@ -35,7 +36,7 @@ describe('PrimengDatepickerComponent', () => {
       type: 'date',
       options: { readonly: true },
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 
   it('parses minimum as a local date', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-file.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengFileComponent } from './primeng-file.component';
 
 describe('PrimengFileComponent', () => {
   const jsf = () => ({
-    initializeControl: jasmine.createSpy('initializeControl'),
-    updateValue: jasmine.createSpy('updateValue'),
+    initializeControl: vi.fn(),
+    updateValue: vi.fn(),
   });
 
   const make = (node: any) => {
@@ -27,7 +28,7 @@ describe('PrimengFileComponent', () => {
       type: 'file',
       options: {},
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), true);
   });
 
   it('respects readonly option', () => {
@@ -35,10 +36,10 @@ describe('PrimengFileComponent', () => {
       type: 'file',
       options: { readonly: true },
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 
-  it('reads a file as data URL and updates value', (done) => {
+  it('reads a file as data URL and updates value', async () => {
     const { component, jsf: j } = make({
       type: 'file',
       options: {},
@@ -58,13 +59,13 @@ describe('PrimengFileComponent', () => {
 
     component.onSelect({ files: [file] });
 
-    setTimeout(() => {
-      expect(component.fileName).toBe('test.txt');
-      expect(j.updateValue).toHaveBeenCalledWith(component, 'data:text/plain;base64,aGVsbG8=');
-      expect(component.options.showErrors).toBe(true);
-      (window as any).FileReader = originalFileReader;
-      done();
-    }, 50);
+    // The stubbed FileReader fires onload on a macrotask, so this waits rather
+    // than asserting synchronously.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(component.fileName).toBe('test.txt');
+    expect(j.updateValue).toHaveBeenCalledWith(component, 'data:text/plain;base64,aGVsbG8=');
+    expect(component.options.showErrors).toBe(true);
+    (window as any).FileReader = originalFileReader;
   });
 
   it('does nothing when no file is selected', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-input.component.spec.ts
@@ -1,4 +1,5 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { InputTextModule } from 'primeng/inputtext';
@@ -7,7 +8,7 @@ import { JsonSchemaFormService } from '@ajsf/core';
 
 describe('PrimengInputComponent', () => {
   const make = (opts: any, layoutType = 'text') => {
-    const jsf = { initializeControl: jasmine.createSpy('initializeControl'), updateValue: jasmine.createSpy('updateValue') };
+    const jsf = { initializeControl: vi.fn(), updateValue: vi.fn() };
     const c = new PrimengInputComponent(jsf as any);
     c.layoutNode = { type: layoutType, options: opts };
     c.ngOnInit();
@@ -38,15 +39,15 @@ describe('PrimengInputComponent', () => {
   describe('typeahead datalist', () => {
     let fixture: ComponentFixture<PrimengInputComponent>;
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
         imports: [CommonModule, ReactiveFormsModule, InputTextModule],
         declarations: [PrimengInputComponent],
         providers: [
           { provide: JsonSchemaFormService, useValue: { initializeControl: () => {} } },
         ],
       }).compileComponents();
-    }));
+    });
 
     it('renders a datalist with the configured suggestions', () => {
       fixture = TestBed.createComponent(PrimengInputComponent);

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-integration.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PrimengFrameworkModule } from '../primeng-framework.module';
@@ -14,7 +14,8 @@ import { PrimengFrameworkModule } from '../primeng-framework.module';
       (onChanges)="value = $event"
       (isValid)="valid = $event"
     ></json-schema-form>`,
-    standalone: false
+    standalone: true,
+    imports: [PrimengFrameworkModule]
 })
 class IntegrationHostComponent {
   schema: any = {};
@@ -28,13 +29,12 @@ describe('PrimeNG integration', () => {
   let fixture: ComponentFixture<IntegrationHostComponent>;
   let host: IntegrationHostComponent;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [PrimengFrameworkModule, NoopAnimationsModule],
-      declarations: [IntegrationHostComponent],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IntegrationHostComponent, NoopAnimationsModule],
       schemas: [],
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IntegrationHostComponent);

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-number.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-number.component.spec.ts
@@ -1,8 +1,9 @@
+import { vi } from 'vitest';
 import { PrimengNumberComponent } from './primeng-number.component';
 
 describe('PrimengNumberComponent', () => {
   const make = (opts: any, dataType = 'number') => {
-    const jsf = { initializeControl: jasmine.createSpy('initializeControl'), updateValue: jasmine.createSpy('updateValue') };
+    const jsf = { initializeControl: vi.fn(), updateValue: vi.fn() };
     const c = new PrimengNumberComponent(jsf as any);
     c.layoutNode = { type: 'number', dataType, options: opts };
     c.ngOnInit();

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-one-of.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-one-of.component.spec.ts
@@ -1,5 +1,6 @@
+import { vi } from 'vitest';
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { PrimengFrameworkModule } from '../primeng-framework.module';
@@ -7,8 +8,8 @@ import { PrimengOneOfComponent } from './primeng-one-of.component';
 
 describe('PrimengOneOfComponent', () => {
   const jsf = () => ({
-    initializeControl: jasmine.createSpy('initializeControl'),
-    updateValue: jasmine.createSpy('updateValue'),
+    initializeControl: vi.fn(),
+    updateValue: vi.fn(),
   });
 
   const make = (node: any) => {
@@ -46,7 +47,7 @@ describe('PrimengOneOfComponent', () => {
         type: 'one-of',
         options: { enum: ['a'], readonly: true },
       });
-      expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+      expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
     });
 
     it('forwards value updates through jsf using event.value', () => {
@@ -226,7 +227,8 @@ describe('PrimengOneOfComponent', () => {
       [framework]="'primeng'"
       (isValid)="valid = $event"
     ></json-schema-form>`,
-    standalone: false
+    standalone: true,
+    imports: [PrimengFrameworkModule]
 })
 class OneOfHostComponent {
   form: any;
@@ -236,13 +238,12 @@ class OneOfHostComponent {
 describe('PrimengOneOfComponent (TestBed)', () => {
   let fixture: ComponentFixture<OneOfHostComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [PrimengFrameworkModule, NoopAnimationsModule],
-      declarations: [OneOfHostComponent],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OneOfHostComponent, NoopAnimationsModule],
       schemas: [],
     }).compileComponents();
-  }));
+  });
 
   describe('unkeyed selectfieldset child rendering', () => {
     beforeEach(() => {
@@ -278,7 +279,7 @@ describe('PrimengOneOfComponent (TestBed)', () => {
       expect(fwWidgets.length).toBe(1);
     });
 
-    it('switches rendered child after selectChild', waitForAsync(() => {
+    it('switches rendered child after selectChild', async () => {
       const oneOf = fixture.debugElement.query(By.directive(PrimengOneOfComponent));
       const comp = oneOf.componentInstance as PrimengOneOfComponent;
       const el = oneOf.nativeElement as HTMLElement;
@@ -286,13 +287,12 @@ describe('PrimengOneOfComponent (TestBed)', () => {
       const selectsBefore = el.querySelectorAll('p-select').length;
       comp.selectChild({ value: 1 });
       fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        expect(comp.selectedItem).toBe(1);
-        const selectsAfter = el.querySelectorAll('p-select').length;
-        expect(selectsAfter).toBeGreaterThan(selectsBefore);
-      });
-    }));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(comp.selectedItem).toBe(1);
+      const selectsAfter = el.querySelectorAll('p-select').length;
+      expect(selectsAfter).toBeGreaterThan(selectsBefore);
+    });
   });
 
   describe('keyed selectfieldset child rendering', () => {
@@ -327,7 +327,7 @@ describe('PrimengOneOfComponent (TestBed)', () => {
       expect(comp.selectList.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('renders a child and switches on formControl change', waitForAsync(() => {
+    it('renders a child and switches on formControl change', async () => {
       const oneOf = fixture.debugElement.query(By.directive(PrimengOneOfComponent));
       const comp = oneOf.componentInstance as PrimengOneOfComponent;
       const el = oneOf.nativeElement as HTMLElement;
@@ -336,12 +336,11 @@ describe('PrimengOneOfComponent (TestBed)', () => {
       const selectsBefore = el.querySelectorAll('p-select').length;
       comp.formControl.setValue('cat');
       fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        expect(comp.selectedItem).toBe(1);
-        const selectsAfter = el.querySelectorAll('p-select').length;
-        expect(selectsAfter).toBeGreaterThan(selectsBefore);
-      });
-    }));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(comp.selectedItem).toBe(1);
+      const selectsAfter = el.querySelectorAll('p-select').length;
+      expect(selectsAfter).toBeGreaterThan(selectsBefore);
+    });
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-radios.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-radios.component.spec.ts
@@ -1,10 +1,11 @@
+import { vi } from 'vitest';
 import { PrimengRadiosComponent } from './primeng-radios.component';
 
 describe('PrimengRadiosComponent', () => {
   const make = (opts: any, layoutType = 'radios') => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
     };
     const c = new PrimengRadiosComponent(jsf as any);
     c.layoutNode = { type: layoutType, options: opts };
@@ -36,6 +37,6 @@ describe('PrimengRadiosComponent', () => {
 
   it('passes !readonly to initializeControl', () => {
     const { jsf } = make({ enum: ['a'], readonly: true });
-    expect(jsf.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(jsf.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-select.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-select.component.spec.ts
@@ -1,10 +1,11 @@
+import { vi } from 'vitest';
 import { PrimengSelectComponent } from './primeng-select.component';
 
 describe('PrimengSelectComponent', () => {
   const make = (opts: any) => {
     const jsf = {
-      initializeControl: jasmine.createSpy('initializeControl'),
-      updateValue: jasmine.createSpy('updateValue'),
+      initializeControl: vi.fn(),
+      updateValue: vi.fn(),
     };
     const c = new PrimengSelectComponent(jsf as any);
     c.layoutNode = { type: 'select', options: opts };
@@ -38,7 +39,7 @@ describe('PrimengSelectComponent', () => {
 
   it('passes !readonly to initializeControl', () => {
     const { jsf } = make({ enum: ['a'], readonly: true });
-    expect(jsf.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(jsf.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 
   it('exposes options.multiple for template branching', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-slider.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengSliderComponent } from './primeng-slider.component';
 
 describe('PrimengSliderComponent', () => {
   const jsf = () => ({
-    initializeControl: jasmine.createSpy('initializeControl'),
-    updateValue: jasmine.createSpy('updateValue'),
+    initializeControl: vi.fn(),
+    updateValue: vi.fn(),
   });
 
   const make = (node: any) => {
@@ -28,7 +29,7 @@ describe('PrimengSliderComponent', () => {
       type: 'slider',
       options: {},
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), true);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), true);
   });
 
   it('respects readonly option', () => {
@@ -36,7 +37,7 @@ describe('PrimengSliderComponent', () => {
       type: 'slider',
       options: { readonly: true },
     });
-    expect(j.initializeControl).toHaveBeenCalledWith(jasmine.anything(), false);
+    expect(j.initializeControl).toHaveBeenCalledWith(expect.anything(), false);
   });
 
   it('computes minValue from options.minimum', () => {

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-stepper.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengStepperComponent } from './primeng-stepper.component';
 
 describe('PrimengStepperComponent', () => {
   const jsf = () => ({
-    addItem: jasmine.createSpy('addItem'),
-    setArrayItemTitle: jasmine.createSpy('setArrayItemTitle').and.callFake(
+    addItem: vi.fn(),
+    setArrayItemTitle: vi.fn(
       (_self, item, index) => item.options?.title || `Step ${index + 1}`
     ),
   });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-tabs.component.spec.ts
@@ -1,9 +1,10 @@
+import { vi } from 'vitest';
 import { PrimengTabsComponent } from './primeng-tabs.component';
 
 describe('PrimengTabsComponent', () => {
   const jsf = () => ({
-    addItem: jasmine.createSpy('addItem'),
-    setArrayItemTitle: jasmine.createSpy('setArrayItemTitle').and.callFake(
+    addItem: vi.fn(),
+    setArrayItemTitle: vi.fn(
       (_self, item, index) => item.options?.title || `Item ${index + 1}`
     ),
   });

--- a/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.spec.ts
+++ b/projects/ajsf-primeng/src/lib/widgets/primeng-textarea.component.spec.ts
@@ -1,8 +1,9 @@
+import { vi } from 'vitest';
 import { PrimengTextareaComponent } from './primeng-textarea.component';
 
 describe('PrimengTextareaComponent', () => {
   const make = (opts: any) => {
-    const jsf = { initializeControl: jasmine.createSpy('initializeControl'), updateValue: jasmine.createSpy('updateValue') };
+    const jsf = { initializeControl: vi.fn(), updateValue: vi.fn() };
     const c = new PrimengTextareaComponent(jsf as any);
     c.layoutNode = { type: 'textarea', options: opts };
     c.ngOnInit();

--- a/projects/ajsf-primeng/src/test-setup.ts
+++ b/projects/ajsf-primeng/src/test-setup.ts
@@ -1,0 +1,22 @@
+// Same reason as @ajsf/core: the unit-test builder takes polyfills from the
+// buildTarget, and an ng-packagr target has none to take, so Zone is loaded
+// here. Without it Angular's Zone-based change detection fails with NG0908.
+// See angular/angular-cli#33477.
+import 'zone.js';
+
+// jsdom 29 does not implement ResizeObserver, and PrimeNG's tab components
+// construct one, so seven corpus schemas that render fine in a browser threw
+// "ResizeObserver is not defined" instead. The baseline records a real control
+// count and no error for all seven, so this closes an environment gap rather
+// than papering over a regression: re-recording would have pinned the throw as
+// expected and hidden any later real breakage in those schemas.
+//
+// A no-op is enough. Nothing under test reads a measurement back; the
+// components only need the constructor and its methods to exist.
+if (!('ResizeObserver' in globalThis)) {
+  (globalThis as any).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}

--- a/projects/ajsf-primeng/tsconfig.spec.json
+++ b/projects/ajsf-primeng/tsconfig.spec.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine",
+      "vitest/globals",
       "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules",
+      "../../manual_typings"
     ]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/test-setup.ts"
   ],
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## Summary

Sixth and last suite onto the Vitest runner. Every library now runs on Vitest, which completes the runner move in phase 6.

## Changes

By far the heaviest conversion. Forty `jasmine.createSpy` become `vi.fn`, two of those keeping a return value and two a fake implementation; eleven `jasmine.anything` become `expect.anything`; two `calls.reset` become `mockClear`; and one `and.returnValue` on an existing spy becomes `mockReturnValue`. Seven `beforeEach` and two `it` level `waitForAsync` blocks become `async` and `await`, and the two at `it` level wrapped their assertions in a `whenStable().then()` that Zone was tracking, so they now await it explicitly. One `done` callback becomes an awaited promise. Two host components carrying inline `json-schema-form` templates become standalone and are imported rather than declared.

## The corpus moved here, and why the baseline is still untouched

Seven of the 74 `primeng` entries threw `ResizeObserver is not defined` where the baseline records a real control count and no error. jsdom 29 does not implement `ResizeObserver` and PrimeNG's tab components construct one.

That is an environment gap rather than a regression, so the setup file provides a no-op and the baseline stays as it was. Re-recording would have pinned the throw as expected behaviour for seven schemas that render correctly in a browser, and hidden any later real breakage in them. The other five suites needed nothing equivalent, which is why primeng was left last.

## Compatibility

Test infrastructure only. No public API change, no `public_api.ts` touched, packaging unchanged. `testing/corpus/baseline.json` is untouched.

## Validation

`npm run test:primeng -- --code-coverage --no-watch` exits 0 with 20 of 20 files and 206 of 206 tests. A full `node scripts/run-coverage.js` run from a cleaned tree exits 0 with all six suites on Vitest at their existing counts, core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104 and primeng 206, and produces seven lcov reports carrying 57 to 79 source files each. `npm run test:scripts` reported 46 specs, 0 failures, and `baseline.json` is byte-identical.