### PR TITLE
build(primeng): move theming to @primeuix/themes

### DIFF
--- a/demo/app/demo.module.ts
+++ b/demo/app/demo.module.ts
@@ -4,7 +4,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { providePrimeNG } from 'primeng/config';
-import Aura from '@primeng/themes/aura';
+import Aura from '@primeuix/themes/aura';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@angular/cli": "^20.3.36",
         "@angular/compiler-cli": "^20.3.30",
         "@angular/language-service": "^20.3.30",
-        "@primeng/themes": "^20.4.0",
+        "@primeuix/themes": "^3.0.0",
         "@types/node": "^20.19.43",
         "@vitest/coverage-v8": "^3.2.7",
         "codelyzer": "^6.0.0",
@@ -4533,17 +4533,12 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@primeng/themes": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@primeng/themes/-/themes-20.4.0.tgz",
-      "integrity": "sha512-bh1yIRbCDAo+OLhQ+bm8sgwlZFRphwlR3/GXOdshJVurm5/Up+CWzoRqsZw/Q2RSrq0x3rDNA2pOTIYpcwgXbA==",
-      "deprecated": "Deprecated. This package is no longer maintained. Please migrate to @primeuix/themes: https://www.npmjs.com/package/@primeuix/themes",
+    "node_modules/@primeui/license-manager": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@primeui/license-manager/-/license-manager-1.1.0.tgz",
+      "integrity": "sha512-irjhOGs6Xjwh1JhMyXtdUsYCsve6kBySZzDUhS/mWxsjwQm/wSN7oulyP/f5huJKdhZSzaN6rVApwpp4nDWE1g==",
       "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/styled": "^0.7.4",
-        "@primeuix/themes": "^1.2.5"
-      }
+      "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@primeuix/styled": {
       "version": "0.7.4",
@@ -4569,13 +4564,37 @@
       }
     },
     "node_modules/@primeuix/themes": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.5.tgz",
-      "integrity": "sha512-n3YkwJrHQaEESc/D/A/iD815sxp8cKnmzscA6a8Tm8YvMtYU32eCahwLLe6h5rywghVwxASWuG36XBgISYOIjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-3.0.0.tgz",
+      "integrity": "sha512-lNMOhorzu4vHRKbTDIU2/raS7/Z6Oyq2WXGfFDVhOwAIVDF4e7hCX75jlgfC7bo4D0Bl5f+oW5HPGZpG52r6lw==",
       "dev": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@primeuix/styled": "^0.7.3"
+        "@primeuix/styled": "^1.0.0"
+      }
+    },
+    "node_modules/@primeuix/themes/node_modules/@primeuix/styled": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
+      "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@primeui/license-manager": "^1.0.0",
+        "@primeuix/utils": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primeuix/themes/node_modules/@primeuix/utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.2.tgz",
+      "integrity": "sha512-4Cz5HY1XHqJwhq1ieml6l5IDkWt41Amdw/t2rAQxNXv7WwAhgb8QrnjJM6scW9h1D0PjQgm9Z3RgNlWCU+WZng==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "engines": {
+        "node": ">=12.11.0"
       }
     },
     "node_modules/@primeuix/utils": {
@@ -16426,15 +16445,11 @@
       "optional": true,
       "peer": true
     },
-    "@primeng/themes": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@primeng/themes/-/themes-20.4.0.tgz",
-      "integrity": "sha512-bh1yIRbCDAo+OLhQ+bm8sgwlZFRphwlR3/GXOdshJVurm5/Up+CWzoRqsZw/Q2RSrq0x3rDNA2pOTIYpcwgXbA==",
-      "dev": true,
-      "requires": {
-        "@primeuix/styled": "^0.7.4",
-        "@primeuix/themes": "^1.2.5"
-      }
+    "@primeui/license-manager": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@primeui/license-manager/-/license-manager-1.1.0.tgz",
+      "integrity": "sha512-irjhOGs6Xjwh1JhMyXtdUsYCsve6kBySZzDUhS/mWxsjwQm/wSN7oulyP/f5huJKdhZSzaN6rVApwpp4nDWE1g==",
+      "dev": true
     },
     "@primeuix/styled": {
       "version": "0.7.4",
@@ -16455,12 +16470,30 @@
       }
     },
     "@primeuix/themes": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.5.tgz",
-      "integrity": "sha512-n3YkwJrHQaEESc/D/A/iD815sxp8cKnmzscA6a8Tm8YvMtYU32eCahwLLe6h5rywghVwxASWuG36XBgISYOIjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-3.0.0.tgz",
+      "integrity": "sha512-lNMOhorzu4vHRKbTDIU2/raS7/Z6Oyq2WXGfFDVhOwAIVDF4e7hCX75jlgfC7bo4D0Bl5f+oW5HPGZpG52r6lw==",
       "dev": true,
       "requires": {
-        "@primeuix/styled": "^0.7.3"
+        "@primeuix/styled": "^1.0.0"
+      },
+      "dependencies": {
+        "@primeuix/styled": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
+          "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
+          "dev": true,
+          "requires": {
+            "@primeui/license-manager": "^1.0.0",
+            "@primeuix/utils": "^0.8.0"
+          }
+        },
+        "@primeuix/utils": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.2.tgz",
+          "integrity": "sha512-4Cz5HY1XHqJwhq1ieml6l5IDkWt41Amdw/t2rAQxNXv7WwAhgb8QrnjJM6scW9h1D0PjQgm9Z3RgNlWCU+WZng==",
+          "dev": true
+        }
       }
     },
     "@primeuix/utils": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@angular/cli": "^20.3.36",
     "@angular/compiler-cli": "^20.3.30",
     "@angular/language-service": "^20.3.30",
-    "@primeng/themes": "^20.4.0",
+    "@primeuix/themes": "^3.0.0",
     "@types/node": "^20.19.43",
     "@vitest/coverage-v8": "^3.2.7",
     "codelyzer": "^6.0.0",

--- a/projects/ajsf-primeng/README.md
+++ b/projects/ajsf-primeng/README.md
@@ -34,7 +34,7 @@ export class AppModule { }
 ```
 
 PrimeNG is configured by the consuming application, not by this package. Set up
-`providePrimeNG` with a theme preset from `@primeng/themes` once, as PrimeNG's own
+`providePrimeNG` with a theme preset from `@primeuix/themes` once, as PrimeNG's own
 installation guide describes. This package uses PrimeNG components and leaves the
 theme to you.
 


### PR DESCRIPTION
## Summary

npm marks `@primeng/themes` deprecated with "no longer maintained, please migrate to `@primeuix/themes`", and the published `@ajsf/primeng` README told consumers to configure `providePrimeNG` with a preset from it.

## Changes

Replaces the `@primeng/themes` devDependency with `@primeuix/themes` at 3.0.0, updates the demo's `Aura` import, and corrects the sentence in `projects/ajsf-primeng/README.md` that names the preset package. The old package still works, so this is a correctness and hygiene change rather than a break.

`docs/primeng-plan.md` keeps its reference. It describes what PrimeNG 19 did at the time, which remains an accurate statement about PrimeNG 19.

## Release impact

No release from this pull request, but it does change published content. `projects/ajsf-primeng/README.md` is the npm page for `@ajsf/primeng`, so the correction reaches consumers with the next publish, which will be `20.0.0-rc.0`.

## Validation

All six libraries build and the demo builds, so the `Aura` import resolves from the new package. `npm run test:primeng -- --code-coverage --no-watch` exits 0 with 206 of 206 tests. `npm run test:scripts` reported 46 specs, 0 failures, and `baseline.json` is byte-identical.