### PR TITLE
docs: add the Angular 20 upgrade note

### DIFF
--- a/docs/release-notes/20.md
+++ b/docs/release-notes/20.md
@@ -1,0 +1,43 @@
+## Upgrading from 19.x
+
+`@ajsf/*` 20 targets Angular 20. Update the Angular packages first, then all six
+`@ajsf/*` packages together: they version in lockstep, and each framework
+package depends on its exact matching `@ajsf/core`.
+
+There is no public API change in this series. Nothing was added, removed or
+renamed on any package's exported surface, and no widget behaviour changed.
+Everything below is about what your project has to satisfy to install it.
+
+### Angular and Node
+
+The peer ranges move to `^20.0.0`, so Angular 19 no longer satisfies them.
+Angular 20 raises its own Node floor to `^20.19.0 || ^22.12.0 || >=24.0.0`, and
+the workspace follows it, so a project on Node 18 has to move before upgrading.
+Node 18 reached end of life in April 2025.
+
+### PrimeNG
+
+`@ajsf/primeng` now declares `primeng: ^20.0.0`. PrimeNG's majors have tracked
+Angular's since v18, so this moves with the Angular major rather than
+independently.
+
+`@ajsf/primeng` 19.2.0 declared `primeng: ^19.0.0` and kept declaring it
+whatever Angular version the release targeted, because the versioning script
+retargeted only the `@angular/*` peers. That is fixed, so 20.x is the first
+release where the PrimeNG peer describes what the package was built against.
+
+If you configure PrimeNG's theme, the preset packages moved: PrimeNG deprecated
+`@primeng/themes` in v20 in favour of `@primeuix/themes`. The old package still
+works, so this is not required to upgrade, but new projects should use
+`@primeuix/themes` and the `@ajsf/primeng` README now says so.
+
+### Nothing else you can observe
+
+The rest of the series is internal. The workspace moved to the Angular
+application build system, the six test suites moved from Karma to Angular 20's
+Vitest runner, and the corpus test harness was restructured so its host
+components compile ahead of time. None of that reaches a consumer: the packages
+are still produced by ng-packagr in Angular Package Format, and the 444 entry
+corpus baseline that pins rendering behaviour was not re-recorded at any point
+in the series, so every schema renders the same control counts and reports the
+same validity as it did in 19.2.0.


### PR DESCRIPTION
## Summary

The release workflow appends `docs/release-notes/<major>.md` on a major's first stable release, so `20.0.0` needs this before it is promoted. Written now rather than then, because reconstructing which of a dozen merged pull requests a consumer can actually observe is much harder after the fact.

## Changes

Adds `docs/release-notes/20.md`, covering what a project has to satisfy to install `@ajsf/*` 20 rather than what it has to change, because the series contains no public API change.

Three things reach a consumer. The peer ranges move to `^20.0.0`, so Angular 19 no longer satisfies them. Angular 20 raises the Node floor to `^20.19.0 || ^22.12.0 || >=24.0.0`, so a project on Node 18 has to move first. And `@ajsf/primeng` declares `primeng: ^20.0.0`, which is the first release where that peer describes what the package was built against, since 19.2.0 shipped declaring `^19.0.0` regardless of the Angular version it targeted.

The PrimeNG theme preset move from `@primeng/themes` to `@primeuix/themes` is mentioned because a consumer configuring the theme sees it, with the note that the old package still works and it is not required to upgrade.

The note is explicit that the rest of the series is invisible: the application build system, the move from Karma to the Vitest runner and the corpus harness restructure all stop at the repository boundary, and the 444 entry baseline was never re-recorded, so rendering behaviour is unchanged.

## Release impact

No release. Contributor and release documentation only, so the version is untouched. The file reaches consumers on the release page when `20.0.0` is promoted, not from this merge and not from a release candidate.

## Validation

Documentation only. The claim that no export changed was verified rather than assumed, by enumerating the exported symbols of all six built packages through the TypeScript compiler API and comparing them against the published 19.2.0 tarballs: 118 on core, 24 on material and primeng, 3 on each Bootstrap package, with none added or removed. The rc dry run of `version:set` over copies of the six real manifests produced `20.0.0-rc.0` on every package, `@ajsf/core` pinned exactly as a prerelease requires, and `primeng: ^20.0.0`.