### PR TITLE
chore: 20.0.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.2.0",
+    "@ajsf/core": "20.0.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0"
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0"
   }
 }

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.2.0",
+    "@ajsf/core": "20.0.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0"
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0"
   }
 }

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.2.0",
+    "@ajsf/core": "20.0.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0"
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0"
   }
 }

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/core",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -32,10 +32,10 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "@angular/forms": "^19.0.0",
-    "@angular/platform-browser": "^19.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/forms": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
     "rxjs": "^7.0.0"
   }
 }

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/material",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.2.0",
+    "@ajsf/core": "20.0.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/material": "^19.0.0",
-    "@angular/cdk": "^19.0.0"
+    "@angular/material": "^20.0.0",
+    "@angular/cdk": "^20.0.0"
   }
 }

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/primeng",
-  "version": "19.2.0",
+  "version": "20.0.0-rc.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular19",
-    "Angular 19",
-    "ng19",
+    "Angular20",
+    "Angular 20",
+    "ng20",
     "JSON Schema",
     "form",
     "forms",
@@ -28,12 +28,12 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^19.2.0",
+    "@ajsf/core": "20.0.0-rc.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "primeng": "^19.0.0"
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "primeng": "^20.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Publishes all six packages at `20.0.0-rc.0`, the first release candidate on Angular 20. The hyphen sends it to the `next` dist-tag, so `latest` stays on 19.2.0 until the series is promoted.

## Changes

Only what `npm run version:set -- 20.0.0-rc.0 20` writes: the version on all six packages, the internal `@ajsf/core` range pinned exactly as a prerelease requires, the Angular peer ranges bounded to `^20.0.0`, the `primeng` peer to `^20.0.0`, and the workspace keywords retargeted to Angular 20.

## Compatibility

The peer ranges move to `^20.0.0`, so Angular 19 no longer satisfies them, and Angular 20's Node floor of `^20.19.0 || ^22.12.0 || >=24.0.0` applies. `@ajsf/primeng` declares `primeng: ^20.0.0`, which is the first release where that peer describes what the package was built against. No export was added, removed or renamed on any package. `docs/release-notes/20.md` carries the consumer-facing detail and reaches the release page when `20.0.0` is promoted.

## Validation

Verified on main before the bump. All six suites pass on the Vitest runner: core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104, primeng 206, with the 444 entry corpus baseline byte-identical throughout the series and never re-recorded. All six libraries build and the demo builds. The exported surface of every built package matches its published 19.2.0 counterpart, at 118 symbols on core, 24 on material and primeng and 3 on each Bootstrap package. `npm run test:scripts` reported 46 specs, 0 failures, and `@ajsf/core@20.0.0-rc.0` is confirmed absent from the registry.