### PR TITLE
ci: run the release verify suites through the shared runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,19 +123,17 @@ jobs:
       - name: Build libraries
         run: npm run build:libs
 
-      # Kept here even though CI runs the same suites on the same commit,
-      # because `workflow_dispatch` reaches this job with no CI run behind it
-      # at all. Removing this step left that path publishing on the strength
-      # of `test:scripts` alone. The duplicate run on the workflow_run path is
-      # the price of the manual trigger staying safe.
+      # Kept even though CI runs the same suites on the same commit, because
+      # `workflow_dispatch` reaches this job with no CI run behind it, and
+      # dropping it made the manual trigger a way to publish untested.
+      #
+      # It calls the script CI calls rather than restating the suites and their
+      # flags, because that restatement drifted: it still carried the Karma
+      # flags after the suites moved to Vitest, where --no-progress and
+      # --browsers fail schema validation, so this job could not release
+      # anything. The script reads each suite's builder from angular.json.
       - name: Test libraries
-        run: |
-          npm run test:core -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs3 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs4 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:bs5 -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:material -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-          npm run test:primeng -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+        run: node scripts/run-coverage.js
 
       - name: Confirm every package carries the release version
         run: |


### PR DESCRIPTION
## Summary

The release workflow's `verify` job could not have released anything since the suites moved to Vitest. `20.0.0-rc.0` failed there rather than reaching the approval gate.

## Changes

`verify` restated the six suites with the Karma flags, and `--no-progress` and `--browsers` now fail schema validation on the unit-test builder. `ci.yml` was updated with each migration and this second list was not, which is the argument for not having a second list: it calls `scripts/run-coverage.js` now, so one place knows how to run a suite and it reads each builder from `angular.json` rather than restating it.

The job keeps running the suites at all for the reason it always did, which the comment now states in one place instead of two: `workflow_dispatch` reaches it with no CI run behind it, so dropping the step would make the manual trigger a way to publish untested.

## Release impact

No release from this pull request: the version is already `20.0.0-rc.0` on main and unchanged, so the workflow correctly does nothing on merge. The candidate then needs a manual dispatch of the release workflow, which is the recovery path for a run that failed after the version had already landed.

## Validation

The workflow YAML was parsed to confirm `verify` still checks out, installs, runs `test:scripts`, builds the libraries, runs the suites and then confirms all six packages carry the release version before uploading. The script it now calls was verified on main across all six suites: core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104, primeng 206, producing seven lcov reports.