### PR TITLE
docs(primeng): record the @angular/animations install requirement

### DIFF
--- a/docs/release-notes/20.md
+++ b/docs/release-notes/20.md
@@ -31,6 +31,24 @@ If you configure PrimeNG's theme, the preset packages moved: PrimeNG deprecated
 works, so this is not required to upgrade, but new projects should use
 `@primeuix/themes` and the `@ajsf/primeng` README now says so.
 
+One installation note, found by installing this release into a new Angular 20
+project rather than by reading anything. Install `@angular/animations` at the
+same patch version as the rest of your Angular packages:
+
+```shell
+# if your @angular/* packages are 20.3.31
+npm install @angular/animations@20.3.31
+```
+
+PrimeNG 20 declares `@angular/animations` as a peer dependency and Angular 20 no
+longer adds it to a new project, so npm resolves it unaided. The Angular
+framework packages peer on each other by exact patch, so a patch npm chooses
+freely can leave the install unresolvable with `ERESOLVE`, naming
+`@angular/animations` and `@angular/common`. It is a PrimeNG requirement rather
+than an `@ajsf/primeng` one, so it is not declared as a peer here: a range like
+`^20.0.0` would not fix it, since npm could still pick a patch that disagrees
+with yours.
+
 ### Nothing else you can observe
 
 The rest of the series is internal. The workspace moved to the Angular

--- a/projects/ajsf-primeng/README.md
+++ b/projects/ajsf-primeng/README.md
@@ -12,6 +12,27 @@ With YARN, run the following:
 yarn add @ajsf/primeng@latest
 ```
 
+### PrimeNG needs @angular/animations at your Angular patch version
+
+Install `@angular/animations` at the same patch version as the rest of your
+Angular framework packages. PrimeNG 20 declares it as a peer dependency, and
+Angular 20 no longer adds it to a new project, so npm resolves it on its own.
+The Angular framework packages peer on each other by exact patch, so a version
+npm picks freely can leave the install unresolvable:
+
+```shell
+# if your @angular/* packages are 20.3.31
+npm install @angular/animations@20.3.31
+```
+
+Without it, installing `@ajsf/primeng` alongside `primeng` can fail with
+`ERESOLVE`, reporting that `@angular/animations` peers `@angular/common` at a
+version other than the one you have.
+
+This is a PrimeNG installation requirement rather than an `@ajsf/primeng` one,
+which is why it is not declared as a peer here: a range such as `^20.0.0` would
+not fix it, because npm could still choose a patch that disagrees with yours.
+
 Then import `PrimengFrameworkModule` in your main application module if you want to use `primeng` UI, like this:
 
 ```javascript


### PR DESCRIPTION
## Summary

Installing the published `20.0.0-rc.0` into a new Angular 20 project failed with `ERESOLVE` before anything compiled. This documents the requirement that resolves it, in the `@ajsf/primeng` README and the Angular 20 upgrade note.

## Changes

`primeng` 20.4.0 declares `@angular/animations` as a peer dependency, Angular 20 no longer adds it to a new project, so npm resolved it unaided and chose 20.1.8, which peers `@angular/common` at exactly 20.1.8 against the consumer's 20.3.31. Installing `@angular/animations` at the consumer's own Angular patch resolves it, after which all six packages install and the application builds.

It is recorded as a PrimeNG installation requirement rather than an `@ajsf/primeng` dependency, and deliberately not added as a peer. AJSF does not own the requirement, and a range such as `^20.0.0` would not fix it, because npm could still choose a patch that disagrees with the consumer's Angular.

The workspace never saw this because it declares `@angular/animations` explicitly. It is the class of failure a monorepo cannot expose and an external install can.

## Release impact

No release from this pull request. `projects/ajsf-primeng/README.md` is the npm page for `@ajsf/primeng`, so the correction reaches consumers when `20.0.0` publishes, and `docs/release-notes/20.md` reaches the release page at the same point. No `rc.1` is warranted: the code and dependency graph that `rc.0` qualified are unchanged, and this adds installation knowledge that the candidate uncovered.

## Validation

Both the failure and the fix were reproduced rather than inferred. A fresh Angular 20.3.31 project installing the six published packages plus `primeng` failed with `ERESOLVE` naming `@angular/animations@20.1.8` and `@angular/common`. Adding `@angular/animations@20.3.31` made the install clean, and a production build of an application importing `JsonSchemaFormModule`, all five framework modules and both public services exited 0 with no errors. `npm run test:scripts` reported 46 specs, 0 failures, and no peer dependency was added to any package.