### PR TITLE
chore: 20.0.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "20.0.0-rc.0",
+    "@ajsf/core": "^20.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "20.0.0-rc.0",
+    "@ajsf/core": "^20.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "20.0.0-rc.0",
+    "@ajsf/core": "^20.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "20.0.0-rc.0",
+    "@ajsf/core": "^20.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/primeng",
-  "version": "20.0.0-rc.0",
+  "version": "20.0.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "20.0.0-rc.0",
+    "@ajsf/core": "^20.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Promotes the Angular 20 series to `latest`, publishing all six packages at `20.0.0`.

## Changes

Only what `npm run version:set -- 20.0.0 20` writes: the version on all six packages and the internal `@ajsf/core` range back to a caret, since the exact pin applies to prereleases. The Angular and PrimeNG peer ranges were already bounded to `^20.0.0` by the candidate.

## Compatibility

Peers require Angular 20, and Angular 20's Node floor of `^20.19.0 || ^22.12.0 || >=24.0.0` applies. No export was added, removed or renamed anywhere in the series. `docs/release-notes/20.md` is appended to this release page and carries the upgrade detail, including the `@angular/animations` install requirement when using `@ajsf/primeng`.

## Validation

Verified on main and as the published candidate. All six suites pass on the Vitest runner at core 2156, bootstrap3 76, bootstrap4 76, bootstrap5 87, material 104 and primeng 206, with the 444 entry corpus baseline byte-identical across the whole series and never re-recorded. The six `20.0.0-rc.0` packages were installed from npm into a fresh Angular 20.3.31 project, and a production build importing every framework module and both public services exited 0 with no errors. The exported surface of each built package matches its published 19.2.0 counterpart. `npm run test:scripts` reported 46 specs, 0 failures, and `@ajsf/core@20.0.0` is confirmed absent from the registry.