### PR TITLE
feat(demo): follow the system theme, with light and dark overrides

### DIFF
--- a/demo/app/demo.component.html
+++ b/demo/app/demo.component.html
@@ -10,10 +10,10 @@
     <button mat-icon-button
       class="theme-toggle"
       type="button"
-      [attr.aria-label]="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
-      [title]="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
-      (click)="toggleDarkMode()">
-      <mat-icon>{{darkMode ? 'light_mode' : 'dark_mode'}}</mat-icon>
+      [attr.aria-label]="themeLabel"
+      [title]="themeLabel"
+      (click)="cycleTheme()">
+      <mat-icon>{{themeIcon}}</mat-icon>
     </button>
   </mat-toolbar>
   <div class="header-content">

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -7,7 +7,15 @@ import { HttpClient } from '@angular/common/http';
 import { Examples } from './example-schemas.model';
 import { JsonPointer } from '@ajsf/core';
 
-const DARK_MODE_KEY = 'ajsf-demo-dark-mode';
+type ThemePreference = 'system' | 'light' | 'dark';
+
+const THEME_KEY = 'ajsf-demo-theme';
+
+// Superseded by THEME_KEY, which also carries 'system'. Still read once so a
+// visitor who picked a theme before this existed keeps it.
+const LEGACY_DARK_MODE_KEY = 'ajsf-demo-dark-mode';
+
+const THEME_CYCLE: ThemePreference[] = ['system', 'light', 'dark'];
 
 @Component({
     selector: 'demo',
@@ -26,7 +34,7 @@ const DARK_MODE_KEY = 'ajsf-demo-dark-mode';
     ],
     standalone: false
 })
-export class DemoComponent implements OnInit {
+export class DemoComponent implements OnInit, OnDestroy {
   examples: any = Examples;
   languageList: any = ['de', 'en', 'es', 'fr', 'it', 'pt', 'zh'];
   languages: any = {
@@ -83,7 +91,12 @@ export class DemoComponent implements OnInit {
     printMargin: false,
     autoScrollEditorIntoView: true,
   };
+  themePreference: ThemePreference = 'system';
   darkMode = false;
+  private readonly prefersDark = matchMedia('(prefers-color-scheme: dark)');
+  private readonly onSystemThemeChange = () => {
+    if (this.themePreference === 'system') { this.applyTheme(); }
+  };
   @ViewChild(MatMenuTrigger, { static: true }) menuTrigger: MatMenuTrigger;
 
   // Bootstrap 5 opts a subtree into its dark palette with this attribute.
@@ -103,14 +116,39 @@ export class DemoComponent implements OnInit {
     return this.darkMode ? 'tomorrow_night' : 'sqlserver';
   }
 
-  toggleDarkMode() {
-    this.setDarkMode(!this.darkMode);
-    localStorage.setItem(DARK_MODE_KEY, String(this.darkMode));
+  get themeIcon(): string {
+    return ({ system: 'brightness_auto', light: 'light_mode', dark: 'dark_mode' })[this.themePreference];
   }
 
-  private setDarkMode(on: boolean) {
-    this.darkMode = on;
-    document.documentElement.classList.toggle('dark-theme', on);
+  // Names the state it is in as well as the one it moves to, because a single
+  // button cycling three states cannot show the third any other way.
+  get themeLabel(): string {
+    return `Theme: ${this.themePreference}. Switch to ${this.nextThemePreference()}.`;
+  }
+
+  cycleTheme() {
+    this.themePreference = this.nextThemePreference();
+    localStorage.setItem(THEME_KEY, this.themePreference);
+    this.applyTheme();
+  }
+
+  private nextThemePreference(): ThemePreference {
+    return THEME_CYCLE[(THEME_CYCLE.indexOf(this.themePreference) + 1) % THEME_CYCLE.length];
+  }
+
+  private applyTheme() {
+    this.darkMode = this.themePreference === 'system' ?
+      this.prefersDark.matches : this.themePreference === 'dark';
+    document.documentElement.classList.toggle('dark-theme', this.darkMode);
+  }
+
+  private storedThemePreference(): ThemePreference {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === 'system' || stored === 'light' || stored === 'dark') { return stored; }
+    const legacy = localStorage.getItem(LEGACY_DARK_MODE_KEY);
+    if (legacy === 'true') { return 'dark'; }
+    if (legacy === 'false') { return 'light'; }
+    return 'system';
   }
 
   constructor(
@@ -119,10 +157,14 @@ export class DemoComponent implements OnInit {
     private router: Router
   ) { }
 
+  ngOnDestroy() {
+    this.prefersDark.removeEventListener('change', this.onSystemThemeChange);
+  }
+
   ngOnInit() {
-    const stored = localStorage.getItem(DARK_MODE_KEY);
-    this.setDarkMode(stored === null ?
-      matchMedia('(prefers-color-scheme: dark)').matches : stored === 'true');
+    this.themePreference = this.storedThemePreference();
+    this.applyTheme();
+    this.prefersDark.addEventListener('change', this.onSystemThemeChange);
 
     // Subscribe to query string to detect schema to load
     this.route.queryParams.subscribe(

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,25 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
     <link rel="icon" type="image/svg+xml" href="assets/logo/ajsf-mark.svg">
     <link rel="icon" type="image/x-icon" href="favicon.ico" sizes="any">
+    <!-- Sets the theme before the bundle loads, so a visitor whose system is
+         dark does not get a light first paint. It has to duplicate the key
+         names and the preference rules from DemoComponent, which reapplies
+         them and owns them from then on. -->
+    <script>
+      (function () {
+        try {
+          var p = localStorage.getItem('ajsf-demo-theme');
+          if (p !== 'system' && p !== 'light' && p !== 'dark') {
+            var legacy = localStorage.getItem('ajsf-demo-dark-mode');
+            p = legacy === 'true' ? 'dark' : legacy === 'false' ? 'light' : 'system';
+          }
+          var dark = p === 'system'
+            ? matchMedia('(prefers-color-scheme: dark)').matches
+            : p === 'dark';
+          document.documentElement.classList.toggle('dark-theme', dark);
+        } catch (e) { /* private mode blocks localStorage; light is the default */ }
+      })();
+    </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TH8GG8HPH6"></script>
     <script>
       window.dataLayer=window.dataLayer||[];


### PR DESCRIPTION
## Summary

The demo read the system color scheme once at startup, and the first click on the toggle pinned a choice for good. The theme now follows the system by default, with the manual override kept.

## Changes

The stored preference becomes system, light or dark, and darkMode is derived from it. A matchMedia listener reapplies the theme while the preference is system and leaves an explicit choice alone; the toggle cycles the three states. Everything downstream still reads darkMode, so the per-framework dark handling and the Ace theme are untouched. An inline head script applies the theme before the bundle loads.

## Release impact

None. The demo is not published, so the version stays at 20.0.0.

## Validation

The demo has no test target, so verification was the production build plus a browser: the three-state cycle, a live system flip with no reload, an explicit choice surviving a flip, the legacy storage key, and change detection reaching the framework bindings. All six frameworks were checked in dark.