### PR TITLE
build: smoke test a consumer install before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,17 @@ jobs:
           fi
           echo "[release] all $COUNT packages at $VERSION"
 
+      # Gates the publish on the packages being installable, which nothing
+      # else here can see: the suites compile @ajsf/core through a tsconfig
+      # path mapping and the workspace pins every Angular package in one
+      # lockfile, so peer resolution in a consumer's tree is invisible to them.
+      # 20.0.0 shipped needing an @angular/animations install at the exact
+      # Angular patch, found by installing it into a new project after the
+      # fact. This packs dist rather than installing from npm, so it runs
+      # before the publish rather than after it.
+      - name: Smoke test a consumer install
+        run: npm run smoke:consumer
+
       # Publishing the artifact verify built, rather than rebuilding inside the
       # gated job, means what ships is exactly what passed.
       - name: Upload the verified packages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,15 @@ npm run build:libs           # build all six packages into dist/@ajsf/
 npm run build:demo           # build the libraries and the demo app
 npm start                    # serve the demo
 npm run test:scripts         # tests for scripts/, plain jasmine, fast
+npm run smoke:consumer       # install the built packages into a throwaway app
 ```
+
+`smoke:consumer` needs `dist/@ajsf` (run `build:libs` first) and refuses with
+the packages it is missing rather than failing inside npm. It scaffolds a new
+Angular project with the CLI, packs `dist/@ajsf/*`, installs the tarballs
+following the release notes for that major, and runs a production build. Pass
+`--keep` to leave the project behind for inspection. The release workflow runs
+it in `verify`, so a publish is gated on the packages being installable.
 
 All six libraries run on Vitest through `@angular/build:unit-test`:
 
@@ -48,6 +56,20 @@ Use `npm run coverage` rather than running the suites by hand when you want
 coverage. `scripts/run-coverage.js` reads each suite's builder from
 `angular.json`, removes `dist/test-out` before every suite, and stages the
 reports; see Coverage for why each of those matters.
+
+⚠️ **The suites cannot tell you whether a consumer can install the packages.**
+They compile `@ajsf/core` through a tsconfig path mapping, and the workspace
+pins every Angular package in one lockfile, so npm's resolution in someone
+else's tree is invisible to them. 20.0.0 published needing
+`npm install @angular/animations` at the exact Angular patch, which was found by
+installing it into a new project. `smoke:consumer` is that check, and it packs
+`dist` rather than installing from npm so it can run before a publish.
+
+⚠️ **A `ng new` bundle budget failure is not a size regression.** The smoke
+component imports all six framework packages into one bundle, which no real
+consumer does, and that alone is 2.29 MB against the scaffold's 1 MB error
+threshold. The script deletes the budgets for that reason. Do not chase the
+number.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "corpus:index": "node scripts/generate-corpus-index.js",
     "build:primeng": "ng build @ajsf/primeng --configuration production",
     "postbuild:primeng": "cp projects/ajsf-primeng/README.md LICENSE dist/@ajsf/primeng/",
-    "test:primeng": "ng test @ajsf/primeng"
+    "test:primeng": "ng test @ajsf/primeng",
+    "smoke:consumer": "node scripts/smoke-consumer.js"
   },
   "dependencies": {
     "@angular/animations": "^20.3.30",

--- a/scripts/smoke-consumer.js
+++ b/scripts/smoke-consumer.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Installs the built packages into a throwaway Angular project and builds it,
+ * because two things are only observable from outside this workspace.
+ *
+ * Peer resolution is one. The workspace has every Angular package pinned in one
+ * lockfile, so it can never see what npm does with a consumer's tree. 20.0.0
+ * shipped needing `npm install @angular/animations` at the exact Angular patch,
+ * and that was found by installing the release into a new project, not by
+ * reading a manifest: PrimeNG peers on @angular/animations, Angular 20 no
+ * longer scaffolds it, and the Angular packages peer on each other by exact
+ * patch, so a patch npm picks freely leaves the install unresolvable.
+ *
+ * AOT against the published entry points is the other. `test:material` and the
+ * rest compile against dist/@ajsf/core through a tsconfig path mapping, which
+ * is not the same as a consumer resolving the package by name from node_modules
+ * and compiling it into their own production build.
+ *
+ * It packs dist/@ajsf/* rather than installing from npm, so it can run before a
+ * publish. The peer ranges live in the built manifests, so the resolution above
+ * is still exercised.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+/** The six packages, core first: the frameworks depend on it. */
+const PACKAGES = ['core', 'material', 'bootstrap3', 'bootstrap4', 'bootstrap5', 'primeng'];
+
+/** Framework modules the smoke component imports, to make AOT compile each. */
+const FRAMEWORK_MODULES = [
+  ['MaterialDesignFrameworkModule', '@ajsf/material'],
+  ['Bootstrap3FrameworkModule', '@ajsf/bootstrap3'],
+  ['Bootstrap4FrameworkModule', '@ajsf/bootstrap4'],
+  ['Bootstrap5FrameworkModule', '@ajsf/bootstrap5'],
+  ['PrimengFrameworkModule', '@ajsf/primeng'],
+];
+
+/**
+ * The Angular major to scaffold against, read from the workspace rather than
+ * written down, so it moves with the upgrade that changes it.
+ */
+function angularMajor(manifest) {
+  const declared = manifest.dependencies && manifest.dependencies['@angular/core'];
+  if (!declared) { throw new Error('@angular/core is not a dependency of the workspace'); }
+  const major = /(\d+)/.exec(declared);
+  if (!major) { throw new Error(`cannot read a major out of @angular/core ${declared}`); }
+  return major[1];
+}
+
+/** Refuses early when dist is absent or partial, rather than failing in npm. */
+function assertBuilt(distDir, packages = PACKAGES) {
+  const missing = packages.filter((p) => !fs.existsSync(path.join(distDir, p, 'package.json')));
+  if (missing.length) {
+    throw new Error(
+      `dist/@ajsf is missing ${missing.join(', ')}. Run \`npm run build:libs\` first.`
+    );
+  }
+  return packages.map((p) => path.join(distDir, p));
+}
+
+/** The version every built package must agree on, so a mixed dist is caught. */
+function builtVersion(dirs) {
+  const versions = [...new Set(dirs.map((d) => require(path.join(d, 'package.json')).version))];
+  if (versions.length !== 1) {
+    throw new Error(`dist/@ajsf holds more than one version: ${versions.join(', ')}`);
+  }
+  return versions[0];
+}
+
+/**
+ * Removes `ng new`'s default bundle budgets from the scaffolded project.
+ *
+ * They are a scaffold default and say nothing about whether the packages
+ * install and compile, which is all this checks. The smoke component imports
+ * all six framework packages into one bundle, which no real consumer does, and
+ * that alone is 2.29 MB against the scaffold's 1 MB error threshold.
+ */
+function dropBundleBudgets(app) {
+  const file = path.join(app, 'angular.json');
+  const config = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const project = config.projects.smoke;
+  const targets = project.architect || project.targets;
+  const production = targets.build.configurations.production;
+  delete production.budgets;
+  fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n');
+  return production;
+}
+
+const run = (cmd, args, cwd) =>
+  execFileSync(cmd, args, {
+    cwd,
+    stdio: 'inherit',
+    env: { ...process.env, NG_CLI_ANALYTICS: 'false' },
+  });
+
+const capture = (cmd, args, cwd) =>
+  execFileSync(cmd, args, { cwd, encoding: 'utf8', env: { ...process.env, NG_CLI_ANALYTICS: 'false' } }).trim();
+
+/** A standalone component importing every framework, so AOT has to compile them. */
+function smokeMain() {
+  const imports = FRAMEWORK_MODULES.map(([m, p]) => `import { ${m} } from '${p}';`).join('\n');
+  const moduleNames = FRAMEWORK_MODULES.map(([m]) => m).join(', ');
+  return `import { Component } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { JsonSchemaFormModule } from '@ajsf/core';
+${imports}
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [JsonSchemaFormModule, ${moduleNames}],
+  template: \`<json-schema-form
+    [schema]="schema"
+    [framework]="framework"
+    (onSubmit)="submitted = $event"></json-schema-form>\`,
+})
+export class AppComponent {
+  framework = 'material-design';
+  submitted: any = null;
+  schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string', title: 'Name' },
+      accept: { type: 'boolean', title: 'Accept' },
+    },
+    required: ['name'],
+  };
+}
+
+bootstrapApplication(AppComponent, { providers: [provideAnimations()] });
+`;
+}
+
+function main(argv) {
+  const keep = argv.includes('--keep');
+  const manifest = require(path.join(ROOT, 'package.json'));
+  const major = angularMajor(manifest);
+  const dirs = assertBuilt(path.join(ROOT, 'dist', '@ajsf'));
+  const version = builtVersion(dirs);
+
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'ajsf-smoke-'));
+  const app = path.join(work, 'smoke');
+  console.log(`[smoke] @ajsf ${version} into a new Angular ${major} project at ${work}`);
+
+  try {
+    run('npx', ['--yes', `@angular/cli@${major}`, 'new', 'smoke',
+      '--skip-git', '--skip-install', '--defaults', '--style=scss'], work);
+
+    // Packed rather than installed from npm, so this runs before a publish.
+    const tarballs = dirs.map((dir) => {
+      const packed = capture('npm', ['pack', dir, '--pack-destination', work], work);
+      return path.join(work, packed.split('\n').pop());
+    });
+
+    run('npm', ['install'], app);
+
+    // Exactly what docs/release-notes/<major>.md tells a consumer to do, so a
+    // failure here means either the packages or those instructions are wrong.
+    const core = capture('node', ['-p', "require('@angular/core/package.json').version"], app);
+    console.log(`[smoke] scaffold resolved @angular/core ${core}`);
+    run('npm', ['install', `@angular/animations@${core}`], app);
+    run('npm', ['install', `@angular/material@${major}`, `primeng@${major}`], app);
+    run('npm', ['install', ...tarballs], app);
+
+    fs.writeFileSync(path.join(app, 'src', 'main.ts'), smokeMain());
+    dropBundleBudgets(app);
+
+    run('npx', ['ng', 'build', '--configuration', 'production'], app);
+
+    const out = path.join(app, 'dist', 'smoke');
+    if (!fs.existsSync(out)) {
+      throw new Error(`the production build wrote nothing to ${out}`);
+    }
+    console.log(`[smoke] @ajsf ${version} installs into a new Angular ${major} project and builds`);
+    return 0;
+  } finally {
+    if (keep) {
+      console.log(`[smoke] kept ${work}`);
+    } else {
+      fs.rmSync(work, { recursive: true, force: true });
+    }
+  }
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (error) {
+    console.error(`[smoke] ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  angularMajor, assertBuilt, builtVersion, smokeMain, dropBundleBudgets, PACKAGES, FRAMEWORK_MODULES,
+};

--- a/scripts/smoke-consumer.spec.js
+++ b/scripts/smoke-consumer.spec.js
@@ -1,0 +1,131 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  angularMajor, assertBuilt, builtVersion, smokeMain, dropBundleBudgets, PACKAGES, FRAMEWORK_MODULES,
+} = require('./smoke-consumer');
+
+/** Writes a dist/@ajsf tree holding the named packages at the given versions. */
+function dist(versions) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ajsf-smoke-spec-'));
+  for (const [name, version] of Object.entries(versions)) {
+    fs.mkdirSync(path.join(dir, name), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, name, 'package.json'),
+      JSON.stringify({ name: `@ajsf/${name}`, version })
+    );
+  }
+  return dir;
+}
+
+const allAt = (version) =>
+  Object.fromEntries(PACKAGES.map((p) => [p, version]));
+
+describe('angularMajor', () => {
+  it('reads the major out of the declared range', () => {
+    expect(angularMajor({ dependencies: { '@angular/core': '^20.3.30' } })).toEqual('20');
+  });
+
+  it('reads a major from a pinned exact version', () => {
+    expect(angularMajor({ dependencies: { '@angular/core': '21.0.0' } })).toEqual('21');
+  });
+
+  it('refuses a workspace that does not depend on Angular', () => {
+    expect(() => angularMajor({ dependencies: {} }))
+      .toThrowError(/@angular\/core is not a dependency/);
+  });
+});
+
+describe('assertBuilt', () => {
+  it('returns one directory per package when dist is complete', () => {
+    const dir = dist(allAt('20.0.0'));
+    expect(assertBuilt(dir).length).toEqual(PACKAGES.length);
+  });
+
+  // The failure this replaces was a release publishing five of six packages,
+  // so a partial dist has to be named rather than left to npm.
+  it('names the packages that are missing', () => {
+    const dir = dist({ core: '20.0.0', material: '20.0.0' });
+    expect(() => assertBuilt(dir)).toThrowError(/bootstrap3, bootstrap4, bootstrap5, primeng/);
+  });
+
+  it('points at build:libs rather than just reporting absence', () => {
+    expect(() => assertBuilt(dist({}))).toThrowError(/npm run build:libs/);
+  });
+});
+
+describe('builtVersion', () => {
+  it('returns the version every package agrees on', () => {
+    const dir = dist(allAt('20.1.0'));
+    expect(builtVersion(assertBuilt(dir))).toEqual('20.1.0');
+  });
+
+  // A stale package left in dist would otherwise be smoke tested against the
+  // rest, and the packages version in lockstep.
+  it('refuses a dist holding more than one version', () => {
+    const dir = dist({ ...allAt('20.1.0'), primeng: '20.0.0' });
+    expect(() => builtVersion(assertBuilt(dir)))
+      .toThrowError(/more than one version/);
+  });
+});
+
+describe('smokeMain', () => {
+  const source = smokeMain();
+
+  it('imports every package, so AOT has to compile all of them', () => {
+    expect(source).toContain("from '@ajsf/core'");
+    FRAMEWORK_MODULES.forEach(([, pkg]) => expect(source).toContain(`from '${pkg}'`));
+  });
+
+  it('declares every framework module in the component imports', () => {
+    FRAMEWORK_MODULES.forEach(([mod]) => expect(source).toContain(mod));
+  });
+
+  it('renders the form component, so the templates compile too', () => {
+    expect(source).toContain('<json-schema-form');
+  });
+});
+
+describe('dropBundleBudgets', () => {
+  /** Writes the part of a scaffolded angular.json this touches. */
+  function scaffold(targetsKey) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ajsf-smoke-ng-'));
+    fs.writeFileSync(path.join(dir, 'angular.json'), JSON.stringify({
+      projects: {
+        smoke: {
+          [targetsKey]: {
+            build: {
+              configurations: {
+                production: {
+                  budgets: [{ type: 'initial', maximumWarning: '500kB', maximumError: '1MB' }],
+                  outputHashing: 'all',
+                },
+              },
+            },
+          },
+        },
+      },
+    }));
+    return dir;
+  }
+
+  // The smoke component imports all six frameworks into one bundle, which is
+  // 2.29 MB against the scaffold's 1 MB error threshold and says nothing about
+  // whether the packages install and compile.
+  it('removes the budgets that would fail the build on size alone', () => {
+    const dir = scaffold('architect');
+    expect(dropBundleBudgets(dir).budgets).toBeUndefined();
+    expect(JSON.parse(fs.readFileSync(path.join(dir, 'angular.json'), 'utf8'))
+      .projects.smoke.architect.build.configurations.production.budgets).toBeUndefined();
+  });
+
+  it('leaves the rest of the production configuration alone', () => {
+    expect(dropBundleBudgets(scaffold('architect')).outputHashing).toEqual('all');
+  });
+
+  // The CLI has used both keys for this across majors, and the script has to
+  // survive the scaffold changing under it.
+  it('accepts targets as well as architect', () => {
+    expect(dropBundleBudgets(scaffold('targets')).budgets).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a script that installs the built packages into a throwaway Angular project and builds it, and runs it in release verify so a publish is gated on the packages being installable.

## Changes

Nothing in the workspace can see this. The suites compile @ajsf/core through a tsconfig path mapping rather than resolving it from node_modules, and one lockfile pins every Angular package, so npm's resolution in a consumer's tree is invisible. That gap shipped: 20.0.0 needs @angular/animations at the exact Angular patch, found by installing the release into a new project afterwards.

The script scaffolds a project with the CLI, packs dist/@ajsf, installs the tarballs following the release notes for that major, and builds. Packing rather than installing from npm is what lets it run before a publish. It drops the scaffold's bundle budgets, since importing all six frameworks into one bundle is 2.29 MB against a 1 MB default and says nothing about installability.

## Release impact

None. Tooling and workflow only, so the version stays at 20.0.0.

## Validation

The script passed locally against the 20.0.0 build, and caught the budget failure above on its first run. Since the new step only runs in release verify, it was also proved on a GitHub runner behind a temporary CI step, since removed: it passed in 49 seconds. test:scripts reports 60 specs, 0 failures, 14 new.