### PR TITLE
fix(demo): drop the tsconfig @angular path mapping that broke ng serve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,4 +276,18 @@ Each of these cost real debugging time. They look like bugs in your code and are
 
   Check whether a package still needs this with `npm view @ajsf/<name> version --prefer-online`. Do not trust a plain registry fetch straight after publishing: it returns 404 for several minutes while the package propagates, which looks exactly like a failed publish.
 
+- **Do not add an `@angular/*` entry to `tsconfig.json` paths.** One sat there
+  from 2020 (`"@angular/*": ["./node_modules/@angular/*"]`) doing nothing under
+  webpack, and broke `ng serve` the moment the application builder brought the
+  Vite dev server in. A path mapping resolves Angular to an absolute file,
+  which bypasses dependency prebundling, so `main.js` carried a second copy of
+  the core runtime beside the prebundled one: 9.4 MB served instead of 2.4 MB.
+  Two runtimes have separate instruction state, so the compiled template ran
+  against an empty one and the demo failed to bootstrap with `ASSERTION ERROR:
+  Array must be defined`, a blank page and no other clue. Only the dev server
+  is affected, because the production build has nothing to prebundle and
+  dedupes to one copy, which is why it went unnoticed. `scripts/package-guards.spec.js`
+  asserts the mapping stays gone. The `@ajsf/*` mappings are fine: those point
+  at `dist`, which is the intended source for them.
+
 - **`@angular/flex-layout` is deprecated and stops at `15.0.0-beta.42`.** It has no Angular 16 or later release and never will. Removing it is tracked work, not an incidental cleanup.

--- a/scripts/package-guards.spec.js
+++ b/scripts/package-guards.spec.js
@@ -13,6 +13,27 @@ const LIBRARIES = [
   'projects/ajsf-primeng',
 ];
 
+describe('tsconfig guards', () => {
+  const tsconfig = JSON.parse(
+    fs.readFileSync(path.join(root, 'tsconfig.json'), 'utf8').replace(/^\s*\/\/.*$/gm, '')
+  );
+
+  // A "@angular/*": ["./node_modules/@angular/*"] mapping sat here from 2020
+  // until it met the Vite dev server. It resolves Angular to an absolute path,
+  // which bypasses dependency prebundling, so main.js carried a second copy of
+  // the core runtime beside the prebundled one. Two runtimes meant the
+  // compiled template ran against empty instruction state and the demo failed
+  // to bootstrap with "ASSERTION ERROR: Array must be defined", in `ng serve`
+  // only: the production build has nothing to prebundle and dedupes to one.
+  it('maps no @angular package, which would give the dev server two runtimes', () => {
+    const mapped = Object.keys(tsconfig.compilerOptions.paths || {})
+      .filter((p) => p.startsWith('@angular'));
+    expect(mapped)
+      .withContext(`these bypass Vite prebundling: ${mapped.join(', ')}`)
+      .toEqual([]);
+  });
+});
+
 describe('package guards', () => {
   it('keeps the root package private so it can never be published', () => {
     expect(readManifest('package.json').private).toBe(true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,6 @@
       "dom"
     ],
     "paths": {
-      "@angular/*": [
-        "./node_modules/@angular/*"
-      ],
       "@ajsf/core": [
         "dist/@ajsf/core"
       ],


### PR DESCRIPTION
## Summary

`ng serve` rendered a blank page and logged only `ASSERTION ERROR: Array must be defined`. Removing one six-year-old tsconfig path mapping fixes it.

## Changes

The stack showed two copies of the Angular core runtime loaded at once: the compiled template and its instruction calls ran from main.js while the renderer and ApplicationRef.bootstrap ran from Vite's prebundled deps chunk. They have separate instruction state, so the template executed against an empty one.

The second copy came from a paths entry mapping @angular/* into node_modules. A path mapping resolves Angular to an absolute file rather than a bare specifier, which bypasses dependency prebundling and bundles the runtime into main.js: 9.4 MB served, against 2.4 MB without it. The entry dates from January 2020 and did nothing under webpack; the Angular 20 move to the application builder brought the Vite dev server and the prebundling it defeats. Only the dev server was affected, since the production build has nothing to prebundle, which is why this never showed on the release path. The @ajsf/* mappings stay, as those point at dist by design.

## Release impact

None. Tooling and the demo only, so the version stays at 20.0.0.

## Validation

The demo now boots under `ng serve`: toolbar, form and 15 inputs render, with no console errors or warnings, and main.js no longer contains the core runtime. The production build of all six libraries and the demo still succeeds. Core reported 2156 passing, material 104, primeng 206. A new guard in package-guards.spec.js was checked both ways: it passes now and fails naming the mapping when it is put back.