### PR TITLE
test: guard the workflows against the drift that has already happened

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,11 +268,15 @@ Each of these cost real debugging time. They look like bugs in your code and are
   restated the six suites with their Karma flags, so `20.0.0-rc.0` reached the
   release job and failed there, having passed CI on the same commit. Whenever
   you change how something is run, grep for every other caller before deciding
-  you are finished. `scripts/workflow-guards.spec.js` now asserts the ones that
-  bit: both workflows call `scripts/run-coverage.js` rather than naming suites,
-  no retired Karma flag survives outside a comment, every `npm run` target a
-  workflow or script names exists, every binary a script calls is installed,
-  and the release package count matches what `angular.json` declares.
+  you are finished. `scripts/workflow-guards.spec.js` asserts the ones that
+  bit. It parses the workflows with js-yaml and reads only what the steps run:
+  CI and release must run `node scripts/run-coverage.js` exactly, with no extra
+  argument, since the divergence that caused the failure was arguments; no
+  other path may reach the suites; no retired Karma flag survives; every
+  `npm run` target exists; every binary a script calls comes from a declared
+  dependency rather than merely being present in `node_modules/.bin`; and the
+  release package count matches `angular.json`. Local composite actions under
+  `.github/actions` are read too, and both `.yml` and `.yaml` count.
 
 - **`npm view pkg@missing-version` exits 0** with empty stdout. Only a missing *package* exits non-zero. Any "is this published" check must test the output, not the exit code, or it reports "already published" forever.
 - **`private: true` cannot be verified locally.** npm authenticates before it checks the flag, so an unauthenticated `npm publish` reports `ENEEDAUTH` whether or not the package is private, and `--dry-run` packs and exits 0 regardless. `scripts/package-guards.spec.js` asserts it instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,18 @@ Each of these cost real debugging time. They look like bugs in your code and are
   change, not a contributor-only doc, and it reaches consumers only when a
   version publishes.
 
+- **Every command has a second invocation path, and it is the one that rots.**
+  CI was updated through the whole Vitest migration while `release.yml`,
+  `npm run coverage` and `npm run stats` were not. The release job still
+  restated the six suites with their Karma flags, so `20.0.0-rc.0` reached the
+  release job and failed there, having passed CI on the same commit. Whenever
+  you change how something is run, grep for every other caller before deciding
+  you are finished. `scripts/workflow-guards.spec.js` now asserts the ones that
+  bit: both workflows call `scripts/run-coverage.js` rather than naming suites,
+  no retired Karma flag survives outside a comment, every `npm run` target a
+  workflow or script names exists, every binary a script calls is installed,
+  and the release package count matches what `angular.json` declares.
+
 - **`npm view pkg@missing-version` exits 0** with empty stdout. Only a missing *package* exits non-zero. Any "is this published" check must test the output, not the exit code, or it reports "already published" forever.
 - **`private: true` cannot be verified locally.** npm authenticates before it checks the flag, so an unauthenticated `npm publish` reports `ENEEDAUTH` whether or not the package is private, and `--dry-run` packs and exits 0 regardless. `scripts/package-guards.spec.js` asserts it instead.
 - **A tag pushed with `GITHUB_TOKEN` does not trigger another workflow**, by design, to prevent recursion. Any "create a tag, let the tag start a release" design silently never runs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@vitest/coverage-v8": "^3.2.7",
         "codelyzer": "^6.0.0",
         "jasmine": "^4.6.0",
+        "js-yaml": "^4.3.2",
         "jsdom": "^29.1.1",
         "ng-packagr": "^20.3.2",
         "primeng": "^20.4.0",
@@ -5491,13 +5492,11 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "3.0.0",
@@ -6683,6 +6682,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -7885,14 +7885,23 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
-      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -11021,8 +11030,9 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "13.0.1",
@@ -11574,6 +11584,16 @@
         "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
       }
     },
+    "node_modules/tslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/tslint/node_modules/builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -11581,6 +11601,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tslint/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/tslint/node_modules/mkdirp": {
@@ -15408,13 +15442,10 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "aria-query": {
       "version": "3.0.0",
@@ -17055,13 +17086,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
-      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsdom": {
@@ -19049,7 +19079,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "ssri": {
@@ -19439,11 +19469,30 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "builtin-modules": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+          "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "mkdirp": {
           "version": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@vitest/coverage-v8": "^3.2.7",
     "codelyzer": "^6.0.0",
     "jasmine": "^4.6.0",
+    "js-yaml": "^4.3.2",
     "jsdom": "^29.1.1",
     "ng-packagr": "^20.3.2",
     "primeng": "^20.4.0",

--- a/scripts/workflow-guards.spec.js
+++ b/scripts/workflow-guards.spec.js
@@ -19,15 +19,16 @@ function definitionFiles() {
       .filter((f) => /\.ya?ml$/.test(f))
       .forEach((f) => files.push(path.posix.join('.github/workflows', f)));
   }
-  const actions = path.join(root, '.github/actions');
-  if (fs.existsSync(actions)) {
-    fs.readdirSync(actions).forEach((entry) => {
-      ['action.yml', 'action.yaml'].forEach((name) => {
-        const file = path.posix.join('.github/actions', entry, name);
-        if (fs.existsSync(path.join(root, file))) { files.push(file); }
-      });
+  // Recursively: a local action is not required to sit one directory deep.
+  const walk = (dir) => {
+    if (!fs.existsSync(path.join(root, dir))) { return; }
+    fs.readdirSync(path.join(root, dir), { withFileTypes: true }).forEach((entry) => {
+      const child = path.posix.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(child); }
+      else if (/^action\.ya?ml$/.test(entry.name)) { files.push(child); }
     });
-  }
+  };
+  walk('.github/actions');
   return files;
 }
 
@@ -72,6 +73,17 @@ describe('suite invocation', () => {
     });
   });
 
+  // Exactness has to be global, not a property of those two files. A third
+  // workflow invoking the runner with a reporter flag of its own recreates the
+  // divergence without restating a suite or naming a retired flag.
+  it('invokes the runner canonically wherever it is invoked', () => {
+    everyRun.filter(([, run]) => run.includes('scripts/run-coverage.js')).forEach(([file, run]) => {
+      expect(run.trim())
+        .withContext(`${file} invokes the runner as something other than "${CANONICAL}"`)
+        .toEqual(CANONICAL);
+    });
+  });
+
   const ALTERNATE = [
     [/\bng test\b/, 'invokes the CLI test target instead of the runner'],
     [/npm run test:(core|bs3|bs4|bs5|material|primeng)\b/, 'names a single suite'],
@@ -89,8 +101,13 @@ describe('suite invocation', () => {
     });
   });
 
+  // Containment rather than equality, deliberately: this one wraps the runner
+  // in the clean and report steps, so it is the one caller that does more.
   it('keeps npm run coverage on the same runner', () => {
     expect(manifest.scripts.coverage).toContain(CANONICAL);
+    expect(manifest.scripts.coverage.split('&&').map((part) => part.trim()))
+      .withContext('coverage should reach the runner directly, not through another wrapper')
+      .toContain(CANONICAL);
   });
 });
 

--- a/scripts/workflow-guards.spec.js
+++ b/scripts/workflow-guards.spec.js
@@ -1,88 +1,114 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
 const root = path.join(__dirname, '..');
 const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
 const manifest = JSON.parse(read('package.json'));
-
-const WORKFLOW_DIR = '.github/workflows';
-const WORKFLOWS = fs.readdirSync(path.join(root, WORKFLOW_DIR)).filter((f) => f.endsWith('.yml'));
+const declaredDependencies = { ...manifest.dependencies, ...manifest.devDependencies };
 
 /**
- * A workflow with its comment lines removed.
- *
- * These files explain at length which flags were removed and why, so a scan
- * of the raw text reports the retired flags this guard exists to ban. Only
- * what the workflow actually runs counts.
+ * Every file that defines steps GitHub will run: the workflows and any local
+ * composite action, which is the other place a stale command can hide.
  */
-const workflow = (file) =>
-  read(path.join(WORKFLOW_DIR, file))
-    .split('\n')
-    .filter((line) => !/^\s*#/.test(line))
-    .join('\n');
-
-/** The one way to run the library suites. Anything else is a second path. */
-const SUITE_RUNNER = 'node scripts/run-coverage.js';
-
-/** Both places that run them: CI on every push, release before it publishes. */
-const RUNS_THE_SUITES = ['ci.yml', 'release.yml'];
-
-/** Binaries a script may call without being a declared dependency. */
-const SHELL = new Set(['cp', 'echo', 'rm', 'mkdir', 'node', 'npm', 'npx', 'true']);
-
-/** The leading command of each `&&` separated segment of an npm script. */
-function commands(script) {
-  return script.split(/&&|\|\|/)
-    .map((segment) => segment.trim().split(/\s+/)[0])
-    .filter(Boolean);
+function definitionFiles() {
+  const files = [];
+  const workflows = path.join(root, '.github/workflows');
+  if (fs.existsSync(workflows)) {
+    fs.readdirSync(workflows)
+      .filter((f) => /\.ya?ml$/.test(f))
+      .forEach((f) => files.push(path.posix.join('.github/workflows', f)));
+  }
+  const actions = path.join(root, '.github/actions');
+  if (fs.existsSync(actions)) {
+    fs.readdirSync(actions).forEach((entry) => {
+      ['action.yml', 'action.yaml'].forEach((name) => {
+        const file = path.posix.join('.github/actions', entry, name);
+        if (fs.existsSync(path.join(root, file))) { files.push(file); }
+      });
+    });
+  }
+  return files;
 }
 
+/**
+ * The shell each file actually runs.
+ *
+ * Parsed rather than scanned, because the raw text is the wrong layer twice
+ * over. These files explain at length which flags were removed, and the first
+ * version of this guard reported those explanations as violations. A folded
+ * scalar breaks the opposite way: `run: >` puts a newline inside what runs as
+ * one command, so a text match for it finds nothing.
+ */
+function runSteps(file) {
+  const doc = yaml.load(read(file)) || {};
+  const steps = [];
+  Object.values(doc.jobs || {}).forEach((job) => steps.push(...((job && job.steps) || [])));
+  steps.push(...((doc.runs && doc.runs.steps) || []));
+  return steps.filter((step) => step && typeof step.run === 'string').map((step) => step.run);
+}
+
+const FILES = definitionFiles();
+const everyRun = FILES.flatMap((file) => runSteps(file).map((run) => [file, run]));
+
+const CANONICAL = 'node scripts/run-coverage.js';
+const RUNS_THE_SUITES = ['.github/workflows/ci.yml', '.github/workflows/release.yml'];
 const scriptNames = Object.keys(manifest.scripts);
 
 describe('suite invocation', () => {
   // release.yml restated the six suites with their Karma flags and kept them
-  // after the move to Vitest, where --no-progress and --browsers fail schema
-  // validation. 20.0.0-rc.0 got as far as the release job before anyone found
-  // out, because CI had been updated through every migration and release.yml
-  // never had.
-  it('runs the suites through the one runner, in CI and at release', () => {
+  // after the move to Vitest, so 20.0.0-rc.0 passed CI and then failed in the
+  // release job on the same commit.
+  //
+  // Equality, not inclusion: the divergence that caused it was arguments, and
+  // a release-only flag appended to the canonical command would reproduce it
+  // while still containing the command.
+  it('runs the suites through the one runner, with no extra arguments', () => {
     RUNS_THE_SUITES.forEach((file) => {
-      expect(workflow(file).includes(SUITE_RUNNER))
-        .withContext(`${file} does not call ${SUITE_RUNNER}`)
-        .toBe(true);
+      const exact = runSteps(file).map((run) => run.trim()).filter((run) => run === CANONICAL);
+      expect(exact.length)
+        .withContext(`${file} should run exactly "${CANONICAL}" once, found ${exact.length}`)
+        .toEqual(1);
     });
   });
 
-  it('restates no individual suite in a workflow', () => {
-    WORKFLOWS.forEach((file) => {
-      expect(workflow(file))
-        .withContext(`${file} invokes a suite directly instead of the runner`)
-        .not.toMatch(/\bng test\b/);
-      expect(workflow(file))
-        .withContext(`${file} names a single suite instead of the runner`)
-        .not.toMatch(/npm run test:(core|bs3|bs4|bs5|material|primeng)\b/);
+  const ALTERNATE = [
+    [/\bng test\b/, 'invokes the CLI test target instead of the runner'],
+    [/npm run test:(core|bs3|bs4|bs5|material|primeng)\b/, 'names a single suite'],
+    [/\bvitest\b/, 'invokes Vitest directly instead of through the runner'],
+    [/\bkarma\b/, 'Karma is gone from this repository'],
+  ];
+
+  it('reaches the suites no other way', () => {
+    everyRun.forEach(([file, run]) => {
+      ALTERNATE.forEach(([pattern, why]) => {
+        expect(pattern.test(run))
+          .withContext(`${file} ${why}: ${run.trim().split('\n')[0]}`)
+          .toBe(false);
+      });
     });
   });
 
   it('keeps npm run coverage on the same runner', () => {
-    expect(manifest.scripts.coverage).toContain(SUITE_RUNNER);
+    expect(manifest.scripts.coverage).toContain(CANONICAL);
   });
 });
 
 describe('retired Karma flags', () => {
+  // Tombstones for the migration. The builder rejects these outright, so they
+  // fail at the point of use rather than degrading quietly.
   const RETIRED = [
     ['ChromeHeadless', 'a Karma browser name; leaving --browsers out selects jsdom'],
     ['ChromiumHeadless', 'a Karma browser name; leaving --browsers out selects jsdom'],
     ['--no-progress', 'the unit-test builder has no progress option and rejects it'],
     ['--browsers', 'must be absent rather than empty, or jsdom is not selected'],
-    ['karma', 'Karma is gone from this repository'],
   ];
 
-  it('appear in no workflow', () => {
-    WORKFLOWS.forEach((file) => {
+  it('appear in nothing a workflow runs', () => {
+    everyRun.forEach(([file, run]) => {
       RETIRED.forEach(([token, why]) => {
-        expect(workflow(file).includes(token))
-          .withContext(`${file} still passes ${token}, which is ${why}`)
+        expect(run.includes(token))
+          .withContext(`${file} passes ${token}, which is ${why}`)
           .toBe(false);
       });
     });
@@ -92,19 +118,19 @@ describe('retired Karma flags', () => {
     Object.entries(manifest.scripts).forEach(([name, script]) => {
       RETIRED.forEach(([token, why]) => {
         expect(script.includes(token))
-          .withContext(`${name} still passes ${token}, which is ${why}`)
+          .withContext(`${name} passes ${token}, which is ${why}`)
           .toBe(false);
       });
     });
   });
 });
 
-describe('command references', () => {
-  // A workflow naming a script that was renamed fails only when that workflow
-  // runs, which for the release path means at a release.
-  it('resolve every npm script a workflow runs', () => {
-    WORKFLOWS.forEach((file) => {
-      [...workflow(file).matchAll(/npm run ([\w:-]+)/g)].forEach(([, name]) => {
+describe('npm script references', () => {
+  const NPM_RUN = /npm run ([\w:-]+)/g;
+
+  it('resolve in everything a workflow runs', () => {
+    everyRun.forEach(([file, run]) => {
+      [...run.matchAll(NPM_RUN)].forEach(([, name]) => {
         expect(scriptNames)
           .withContext(`${file} runs npm run ${name}, which does not exist`)
           .toContain(name);
@@ -112,9 +138,9 @@ describe('command references', () => {
     });
   });
 
-  it('resolve every npm script another script runs', () => {
+  it('resolve in every other script', () => {
     Object.entries(manifest.scripts).forEach(([name, script]) => {
-      [...script.matchAll(/npm run ([\w:-]+)/g)].forEach(([, called]) => {
+      [...script.matchAll(NPM_RUN)].forEach(([, called]) => {
         expect(scriptNames)
           .withContext(`${name} runs npm run ${called}, which does not exist`)
           .toContain(called);
@@ -122,17 +148,87 @@ describe('command references', () => {
     });
   });
 
-  // `npm run stats` piped a production build into webpack-bundle-analyzer and
-  // kept doing so after esbuild replaced webpack and the package was dropped,
-  // so the script referenced a binary that was no longer installed. Running it
-  // is a full production build, too slow to belong here; this asks the cheaper
-  // question of whether what it calls is present.
-  it('resolve every binary an npm script calls', () => {
+  // `npm run <name>` is the only form the checks above recognise, so the
+  // equivalents have to be spelled that way rather than left to slip past.
+  it('use one npm syntax, so the checks above see them all', () => {
+    const OTHER = /npm\s+(?:-{1,2}\S+\s+)*run-script\b|npm\s+-{1,2}\S+\s+run\b|npm\s+exec\b/;
+    everyRun.forEach(([file, run]) => {
+      expect(OTHER.test(run))
+        .withContext(`${file} uses an npm form these guards do not read: ${run.trim().split('\n')[0]}`)
+        .toBe(false);
+    });
     Object.entries(manifest.scripts).forEach(([name, script]) => {
-      commands(script).forEach((command) => {
-        if (SHELL.has(command)) { return; }
-        expect(fs.existsSync(path.join(root, 'node_modules', '.bin', command)))
-          .withContext(`${name} calls ${command}, which is not installed`)
+      expect(OTHER.test(script))
+        .withContext(`${name} uses an npm form these guards do not read`)
+        .toBe(false);
+    });
+  });
+});
+
+describe('npm script commands', () => {
+  /** Shell builtins and coreutils, which no package provides. */
+  const SHELL = new Set(['cp', 'echo', 'rm', 'mkdir', 'true', 'test']);
+
+  /**
+   * The leading command of each segment, with any `VAR=value` prefix dropped.
+   *
+   * Quoted text is emptied first, because it is data rather than command
+   * structure: `coverage:clean` passes a program to `node -e` whose semicolons
+   * would otherwise read as separators and its `for` loop as a command.
+   *
+   * This reads simple scripts, which is all this repository has. It is not a
+   * shell parser, and the guards below are scoped to what it can actually see.
+   */
+  function segments(script) {
+    return script.replace(/"[^"]*"|'[^']*'/g, '""')
+      .split(/&&|\|\||[;|]/)
+      .map((segment) => segment.trim().split(/\s+/).filter((word) => !/^\w+=/.test(word)))
+      .filter((words) => words.length);
+  }
+
+  /** The package a bin comes from, by following the link npm wrote. */
+  function providingPackage(bin) {
+    const link = path.join(root, 'node_modules', '.bin', bin);
+    if (!fs.existsSync(link)) { return null; }
+    const target = fs.realpathSync(link);
+    const marker = `node_modules${path.sep}`;
+    const rel = target.slice(target.lastIndexOf(marker) + marker.length).split(path.sep);
+    return rel[0].startsWith('@') ? `${rel[0]}/${rel[1]}` : rel[0];
+  }
+
+  // `npm run stats` piped a production build into webpack-bundle-analyzer and
+  // kept doing so after esbuild replaced webpack and the package was dropped.
+  // Running the script is a full production build, too slow to belong here;
+  // this asks the cheaper question of whether what it calls is still there.
+  //
+  // A declared dependency rather than a present binary: a bin that arrives
+  // only through someone else's dependency disappears on an unrelated upgrade.
+  it('come from a declared dependency', () => {
+    Object.entries(manifest.scripts).forEach(([name, script]) => {
+      segments(script).forEach(([command]) => {
+        if (SHELL.has(command) || ['node', 'npm', 'npx'].includes(command)) { return; }
+        const provider = providingPackage(command);
+        expect(provider)
+          .withContext(`${name} calls ${command}, which no installed package provides`)
+          .not.toBeNull();
+        expect(Object.keys(declaredDependencies))
+          .withContext(`${name} calls ${command}, provided by ${provider}, which package.json does not declare`)
+          .toContain(provider);
+      });
+    });
+  });
+
+  // `node` and `npx` are exempt above, so their target is checked here instead
+  // of being taken on trust.
+  it('point at script files that exist', () => {
+    const scripts = [
+      ...Object.entries(manifest.scripts).map(([name, script]) => [name, script]),
+      ...everyRun,
+    ];
+    scripts.forEach(([where, script]) => {
+      [...script.matchAll(/node\s+(?!-)([\w./-]+\.js)/g)].forEach(([, file]) => {
+        expect(fs.existsSync(path.join(root, file)))
+          .withContext(`${where} runs node ${file}, which does not exist`)
           .toBe(true);
       });
     });
@@ -142,15 +238,19 @@ describe('command references', () => {
 describe('release package count', () => {
   // The publish list read "bootstrap3 bootstrap4 material" when bootstrap5 was
   // added, so the new package was skipped while the job reported success. The
-  // list is derived from dist now, but the count it is checked against is
-  // still written down, and a seventh package would make it wrong.
+  // list comes from dist now, but the count it is checked against is still
+  // written down, and a seventh package would make it wrong.
   it('matches the number of packages the workspace publishes', () => {
-    const projects = Object.keys(JSON.parse(read('angular.json')).projects)
+    const projects = Object.keys(yaml.load(read('angular.json')).projects)
       .filter((p) => p.startsWith('@ajsf/'));
-    const declared = /-ne (\d+)/.exec(workflow('release.yml'));
-    expect(declared).withContext('release.yml no longer checks a package count').not.toBeNull();
+    // The step that walks dist, rather than any `-ne` in the file.
+    const step = runSteps('.github/workflows/release.yml')
+      .find((run) => run.includes('dist/@ajsf/*/'));
+    expect(step).withContext('release.yml no longer walks dist/@ajsf').toBeDefined();
+    const declared = /-ne (\d+)/.exec(step);
+    expect(declared).withContext('that step no longer checks a package count').not.toBeNull();
     expect(Number(declared[1]))
-      .withContext(`release.yml expects ${declared[1]} packages, angular.json declares ${projects.length}`)
+      .withContext(`release.yml expects ${declared && declared[1]} packages, angular.json declares ${projects.length}`)
       .toEqual(projects.length);
   });
 });

--- a/scripts/workflow-guards.spec.js
+++ b/scripts/workflow-guards.spec.js
@@ -1,0 +1,156 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+const manifest = JSON.parse(read('package.json'));
+
+const WORKFLOW_DIR = '.github/workflows';
+const WORKFLOWS = fs.readdirSync(path.join(root, WORKFLOW_DIR)).filter((f) => f.endsWith('.yml'));
+
+/**
+ * A workflow with its comment lines removed.
+ *
+ * These files explain at length which flags were removed and why, so a scan
+ * of the raw text reports the retired flags this guard exists to ban. Only
+ * what the workflow actually runs counts.
+ */
+const workflow = (file) =>
+  read(path.join(WORKFLOW_DIR, file))
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+
+/** The one way to run the library suites. Anything else is a second path. */
+const SUITE_RUNNER = 'node scripts/run-coverage.js';
+
+/** Both places that run them: CI on every push, release before it publishes. */
+const RUNS_THE_SUITES = ['ci.yml', 'release.yml'];
+
+/** Binaries a script may call without being a declared dependency. */
+const SHELL = new Set(['cp', 'echo', 'rm', 'mkdir', 'node', 'npm', 'npx', 'true']);
+
+/** The leading command of each `&&` separated segment of an npm script. */
+function commands(script) {
+  return script.split(/&&|\|\|/)
+    .map((segment) => segment.trim().split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+const scriptNames = Object.keys(manifest.scripts);
+
+describe('suite invocation', () => {
+  // release.yml restated the six suites with their Karma flags and kept them
+  // after the move to Vitest, where --no-progress and --browsers fail schema
+  // validation. 20.0.0-rc.0 got as far as the release job before anyone found
+  // out, because CI had been updated through every migration and release.yml
+  // never had.
+  it('runs the suites through the one runner, in CI and at release', () => {
+    RUNS_THE_SUITES.forEach((file) => {
+      expect(workflow(file).includes(SUITE_RUNNER))
+        .withContext(`${file} does not call ${SUITE_RUNNER}`)
+        .toBe(true);
+    });
+  });
+
+  it('restates no individual suite in a workflow', () => {
+    WORKFLOWS.forEach((file) => {
+      expect(workflow(file))
+        .withContext(`${file} invokes a suite directly instead of the runner`)
+        .not.toMatch(/\bng test\b/);
+      expect(workflow(file))
+        .withContext(`${file} names a single suite instead of the runner`)
+        .not.toMatch(/npm run test:(core|bs3|bs4|bs5|material|primeng)\b/);
+    });
+  });
+
+  it('keeps npm run coverage on the same runner', () => {
+    expect(manifest.scripts.coverage).toContain(SUITE_RUNNER);
+  });
+});
+
+describe('retired Karma flags', () => {
+  const RETIRED = [
+    ['ChromeHeadless', 'a Karma browser name; leaving --browsers out selects jsdom'],
+    ['ChromiumHeadless', 'a Karma browser name; leaving --browsers out selects jsdom'],
+    ['--no-progress', 'the unit-test builder has no progress option and rejects it'],
+    ['--browsers', 'must be absent rather than empty, or jsdom is not selected'],
+    ['karma', 'Karma is gone from this repository'],
+  ];
+
+  it('appear in no workflow', () => {
+    WORKFLOWS.forEach((file) => {
+      RETIRED.forEach(([token, why]) => {
+        expect(workflow(file).includes(token))
+          .withContext(`${file} still passes ${token}, which is ${why}`)
+          .toBe(false);
+      });
+    });
+  });
+
+  it('appear in no npm script', () => {
+    Object.entries(manifest.scripts).forEach(([name, script]) => {
+      RETIRED.forEach(([token, why]) => {
+        expect(script.includes(token))
+          .withContext(`${name} still passes ${token}, which is ${why}`)
+          .toBe(false);
+      });
+    });
+  });
+});
+
+describe('command references', () => {
+  // A workflow naming a script that was renamed fails only when that workflow
+  // runs, which for the release path means at a release.
+  it('resolve every npm script a workflow runs', () => {
+    WORKFLOWS.forEach((file) => {
+      [...workflow(file).matchAll(/npm run ([\w:-]+)/g)].forEach(([, name]) => {
+        expect(scriptNames)
+          .withContext(`${file} runs npm run ${name}, which does not exist`)
+          .toContain(name);
+      });
+    });
+  });
+
+  it('resolve every npm script another script runs', () => {
+    Object.entries(manifest.scripts).forEach(([name, script]) => {
+      [...script.matchAll(/npm run ([\w:-]+)/g)].forEach(([, called]) => {
+        expect(scriptNames)
+          .withContext(`${name} runs npm run ${called}, which does not exist`)
+          .toContain(called);
+      });
+    });
+  });
+
+  // `npm run stats` piped a production build into webpack-bundle-analyzer and
+  // kept doing so after esbuild replaced webpack and the package was dropped,
+  // so the script referenced a binary that was no longer installed. Running it
+  // is a full production build, too slow to belong here; this asks the cheaper
+  // question of whether what it calls is present.
+  it('resolve every binary an npm script calls', () => {
+    Object.entries(manifest.scripts).forEach(([name, script]) => {
+      commands(script).forEach((command) => {
+        if (SHELL.has(command)) { return; }
+        expect(fs.existsSync(path.join(root, 'node_modules', '.bin', command)))
+          .withContext(`${name} calls ${command}, which is not installed`)
+          .toBe(true);
+      });
+    });
+  });
+});
+
+describe('release package count', () => {
+  // The publish list read "bootstrap3 bootstrap4 material" when bootstrap5 was
+  // added, so the new package was skipped while the job reported success. The
+  // list is derived from dist now, but the count it is checked against is
+  // still written down, and a seventh package would make it wrong.
+  it('matches the number of packages the workspace publishes', () => {
+    const projects = Object.keys(JSON.parse(read('angular.json')).projects)
+      .filter((p) => p.startsWith('@ajsf/'));
+    const declared = /-ne (\d+)/.exec(workflow('release.yml'));
+    expect(declared).withContext('release.yml no longer checks a package count').not.toBeNull();
+    expect(Number(declared[1]))
+      .withContext(`release.yml expects ${declared[1]} packages, angular.json declares ${projects.length}`)
+      .toEqual(projects.length);
+  });
+});


### PR DESCRIPTION
## Summary

Three commands had a second invocation path that went stale while the first was kept current, which cost a release candidate. These guards assert that class of drift and run inside test:scripts, so they cost nothing.

## Changes

CI was updated through the Vitest migration and release.yml was not, so the release job still restated the six suites with flags the builder rejects and 20.0.0-rc.0 failed there after passing CI on the same commit.

The guards parse the workflows with js-yaml, now a declared devDependency, and read only what steps run. Any invocation of the suite runner must equal the canonical command exactly, wherever it appears, since the divergence that caused the failure was arguments rather than a banned word. No other path may reach the suites, no retired Karma flag survives, every npm run target exists, every binary a script calls comes from a declared dependency rather than merely sitting in node_modules/.bin, and the release package count matches angular.json. Local composite actions are walked too.

## Release impact

None. Tests and contributor documentation only, so the version stays at 20.0.0.

## Validation

Thirteen mutations were checked, each reintroducing drift the guard targets: a release workflow restating suites, an extra argument on the canonical command, a folded scalar hiding a command from a text scan, a .yaml workflow, a nested composite action, a transitive-only binary, a renamed script, a seventh package, and more. All fail naming the file and cause, and pass again on revert. test:scripts reports 73 specs, 0 failures.