### PR TITLE
fix(bootstrap5): render help text again

### DIFF
--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -52,11 +52,13 @@
 
     <!--
       description || help is the order updateHelpBlock uses for options.helpBlock,
-      which this block replaced. Reading description alone lost help entirely,
-      because the only remaining helpBlock paragraph is guarded by
-      messageLocation === 'top' and nothing sets messageLocation here.
+      which this block replaced. Reading description alone lost help entirely.
+      The messageLocation guard mirrors the paragraph above: containers set it
+      to 'top', and without it the same text renders in both places.
     -->
-    <div *ngIf="(options?.description || options?.help) && (!options?.showErrors || !options?.errorMessage)"
+    <div *ngIf="(options?.description || options?.help) &&
+          options?.messageLocation !== 'top' &&
+          (!options?.showErrors || !options?.errorMessage)"
     class="form-text text-muted"
     [innerHTML]="options?.description || options?.help"></div>
 </div>

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -50,9 +50,15 @@
     class="invalid-feedback"
     [innerHTML]="options?.errorMessage"></div>
 
-    <div *ngIf="options?.description && (!options?.showErrors || !options?.errorMessage)"
+    <!--
+      description || help is the order updateHelpBlock uses for options.helpBlock,
+      which this block replaced. Reading description alone lost help entirely,
+      because the only remaining helpBlock paragraph is guarded by
+      messageLocation === 'top' and nothing sets messageLocation here.
+    -->
+    <div *ngIf="(options?.description || options?.help) && (!options?.showErrors || !options?.errorMessage)"
     class="form-text text-muted"
-    [innerHTML]="options?.description"></div>
+    [innerHTML]="options?.description || options?.help"></div>
 </div>
 
 <div *ngIf="debug && debugOutput">debug:

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -67,6 +67,44 @@ describe('FwBootstrap5Component', () => {
       const text = render({ description: 'Two letters' });
       expect(text.split('Two letters').length - 1).toEqual(1);
     });
+
+    // Containers set messageLocation to 'top'. updateHelpBlock only runs when
+    // there is a formControl, which a container has not got and this fixture
+    // never provides, so asserting through the component would pass without
+    // the upper paragraph ever rendering. These set helpBlock directly, which
+    // is the state the template has to cope with.
+    const containerOptions = (extra: any) =>
+      ({ messageLocation: 'top', helpBlock: 'Container help', ...extra });
+
+    it('renders help once when the layout asks for it at the top', () => {
+      const text = render(containerOptions({ help: 'Container help' }));
+      expect(text.split('Container help').length - 1).toEqual(1);
+    });
+
+    it('renders a description once when the layout asks for it at the top', () => {
+      const text = render(containerOptions({ description: 'Container help' }));
+      expect(text.split('Container help').length - 1).toEqual(1);
+    });
+
+    it('puts it above the field, where the layout asked for it', () => {
+      component.layoutNode = { type: 'text', options: containerOptions({ help: 'Container help' }) };
+      component.initializeFramework();
+      fixture.detectChanges();
+      const html = fixture.nativeElement.innerHTML;
+      expect(html.indexOf('Container help')).toBeLessThan(html.indexOf('select-widget-widget'));
+    });
+
+    const CONTAINERS = ['array', 'fieldset', 'section', 'conditional',
+      'advancedfieldset', 'authfieldset', 'selectfieldset', 'optionfieldset'];
+
+    it('sets messageLocation to top for every container type', () => {
+      CONTAINERS.forEach((type) => {
+        component.layoutNode = { type, options: {} };
+        component.initializeFramework();
+        expect(component.options.messageLocation, `${type} should ask for its message at the top`)
+          .toEqual('top');
+      });
+    });
   });
 
   // Bootstrap 5 defines neither .form-group nor .control-label, so emitting

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -37,6 +37,38 @@ describe('FwBootstrap5Component', () => {
     expect(component).toBeTruthy();
   });
 
+  // The migration dropped the paragraph that rendered options.helpBlock below
+  // the field, keeping only the copy guarded by messageLocation === 'top'.
+  // Nothing sets messageLocation on this path, so that branch never runs and
+  // help text rendered nowhere, while updateHelpBlock went on computing it.
+  describe('help text', () => {
+    const render = (options: any) => {
+      component.layoutNode = { type: 'text', options };
+      component.initializeFramework();
+      fixture.detectChanges();
+      return fixture.nativeElement.textContent;
+    };
+
+    it('renders help text when the field has no error', () => {
+      expect(render({ help: 'Use your work address' })).toContain('Use your work address');
+    });
+
+    it('renders a description when the field has no error', () => {
+      expect(render({ description: 'Two letters' })).toContain('Two letters');
+    });
+
+    it('prefers the description over help, as updateHelpBlock does', () => {
+      const text = render({ description: 'Two letters', help: 'Use your work address' });
+      expect(text).toContain('Two letters');
+      expect(text).not.toContain('Use your work address');
+    });
+
+    it('renders the description once, not once per block', () => {
+      const text = render({ description: 'Two letters' });
+      expect(text.split('Two letters').length - 1).toEqual(1);
+    });
+  });
+
   // Bootstrap 5 defines neither .form-group nor .control-label, so emitting
   // them costs the field its spacing with nothing to show that it happened.
   describe('emitted classes', () => {


### PR DESCRIPTION
## Summary

`options.help` renders nowhere on Bootstrap 5. The block that replaced the old help paragraph reads `options.description` alone, dropping the help fallback.

## Changes

`updateHelpBlock` sets `options.helpBlock` to the formatted errors when the control is invalid, and to `description || help` otherwise. The migration replaced the paragraph rendering it below the field with a block reading only `description`. The one remaining `helpBlock` paragraph is guarded by `messageLocation === 'top'`, which nothing sets on the ordinary field path, so help text reached no element. Descriptions were unaffected, which is why it went unnoticed.

The block now reads `description || help`, matching the order `updateHelpBlock` uses, and carries the same `messageLocation` guard as the paragraph above it. Without that guard the eight container types, which do set `messageLocation` to top, rendered the text twice. Containers still render no help, which is not new: their `helpBlock` is never populated in any of the three Bootstrap packages.

## Compatibility

Help text configured through the `help` option reappears below the field on Bootstrap 5. No public export or selector is touched.

## Release impact

No release from this pull request. The fix is consumer visible and ships in the next version bump.

## Validation

The first test failed before the change with `expected '' to contain 'Use your work address'`. A first attempt at the container regression test passed while proving nothing, because `updateHelpBlock` runs only when a formControl exists and the fixture supplies none; setting `helpBlock` directly, which is the state the template must handle, failed with `expected 2 to deeply equal 1` before the guard. The Bootstrap 5 suite reports 95 passing across 2 files, its 74 corpus entries included, so no baseline moved.