### PR TITLE
fix(bootstrap)!: emit Bootstrap 4 markup, and show errors on touch

### DIFF
--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.html
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.html
@@ -1,11 +1,11 @@
 <div
   [class]="options?.htmlClass || ''"
   [class.has-feedback]="options?.feedback && options?.isInputWidget &&
-        (formControl?.dirty || options?.feedbackOnRender)"
+        (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)"
   [class.has-error]="options?.enableErrorState && formControl?.errors &&
-        (formControl?.dirty || options?.feedbackOnRender)"
+        (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)"
   [class.has-success]="options?.enableSuccessState && !formControl?.errors &&
-        (formControl?.dirty || options?.feedbackOnRender)">
+        (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)">
 
   <button *ngIf="showRemoveButton"
           class="close pull-right"
@@ -45,7 +45,7 @@
 
   <span *ngIf="options?.feedback && options?.isInputWidget &&
           !options?.fieldAddonRight && !layoutNode.arrayItem &&
-          (formControl?.dirty || options?.feedbackOnRender)"
+          (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)"
         [class.glyphicon-ok]="options?.enableSuccessState && !formControl?.errors"
         [class.glyphicon-remove]="options?.enableErrorState && formControl?.errors"
         aria-hidden="true"

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -211,7 +211,7 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
   updateHelpBlock(status) {
     this.options.helpBlock = status === 'INVALID' &&
     this.options.enableErrorState && this.formControl.errors &&
-    (this.formControl.dirty || this.options.feedbackOnRender) ?
+    (this.formControl.touched || this.formControl.dirty || this.options.feedbackOnRender) ?
       this.jsf.formatErrors(this.formControl.errors, this.options.validationMessages) :
       this.options.description || this.options.help || null;
   }

--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -53,6 +53,39 @@ Where `schema` is a valid JSON schema object, and `onSubmit` calls a function to
 * `bootstrap-4` for 'Bootstrap 4.
 * `no-framework` for (plain HTML).
 
+## Bootstrap 4 markup, corrected in 20.1.0
+
+This package previously emitted Bootstrap 3 class names. It was created as a
+copy of `@ajsf/bootstrap3` with the CDN URL changed, so classes Bootstrap 4
+had dropped kept being rendered and silently did nothing. If you have written
+CSS against the old output, these are the names that changed.
+
+| Was | Is now | Why |
+| --- | --- | --- |
+| `has-error`, `has-success`, `has-feedback` | `is-invalid` on the field wrapper | Bootstrap 4 marks the field, not the container |
+| `help-block` | `form-text text-muted` | Bootstrap 4's help text class |
+| `form-control-feedback`, `glyphicon` | removed | Bootstrap 4 ships no glyphicons |
+| `input-group-addon` | `input-group-prepend` or `input-group-append` wrapping `input-group-text` | Bootstrap 4's addon structure |
+| `pull-right` | `float-right` | renamed in Bootstrap 4 |
+| `control-label` | no class | Bootstrap 4 styles a plain label in a stacked form |
+| `btn-default` | `btn-secondary` | Bootstrap 4's neutral button |
+
+`form-group` and `sr-only` are unchanged, because Bootstrap 4 still defines
+both.
+
+Validation messages also behave differently, and this part applies to
+`@ajsf/bootstrap3` and `@ajsf/bootstrap5` too. A message used to appear only
+once the value had changed, so focusing a required field and leaving it empty
+showed nothing. It now appears once the field has been touched or changed.
+Error text and help text are also separate elements now, so you can style one
+without the other.
+
+Checkbox and radio inputs still carry the Bootstrap 3 `checkbox` and `radio`
+classes. Bootstrap 4 wants `form-check-input` and `form-check-label` on
+sibling elements, and this library nests the input inside the label, so those
+names would be rendered without effect. That is tracked separately rather than
+shipped as a cosmetic change.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap4` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap4`.

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
@@ -1,14 +1,7 @@
-<div
-  [class]="options?.htmlClass || ''"
-  [class.has-feedback]="options?.feedback && options?.isInputWidget &&
-        (formControl?.dirty || options?.feedbackOnRender)"
-  [class.has-error]="options?.enableErrorState && formControl?.errors &&
-        (formControl?.dirty || options?.feedbackOnRender)"
-  [class.has-success]="options?.enableSuccessState && !formControl?.errors &&
-        (formControl?.dirty || options?.feedbackOnRender)">
+<div [class]="options?.htmlClass || ''">
 
   <button *ngIf="showRemoveButton"
-          class="close pull-right"
+          class="close float-right"
           type="button"
           (click)="removeItem()">
     <span aria-hidden="true">&times;</span>
@@ -16,7 +9,7 @@
   </button>
   <div *ngIf="options?.messageLocation === 'top'">
     <p *ngIf="options?.helpBlock"
-       class="help-block"
+       class="form-text text-muted"
        [innerHTML]="options?.helpBlock"></p>
   </div>
 
@@ -28,33 +21,44 @@
   <p *ngIf="layoutNode?.type === 'submit' && jsf?.formOptions?.fieldsRequired">
     <strong class="text-danger">*</strong> = required fields
   </p>
-  <div [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight">
-        <span *ngIf="options?.fieldAddonLeft"
-              class="input-group-addon"
-              [innerHTML]="options?.fieldAddonLeft"></span>
+
+  <!--
+    is-invalid sits on this wrapper, not on the control. Bootstrap reveals
+    .invalid-feedback only as a following sibling of the element carrying
+    .is-invalid, and select-widget-widget renders its own host element and a
+    container div between here and the real input, so the input and the
+    message can never be siblings.
+  -->
+  <div [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
+       [class.is-invalid]="options?.enableErrorState && formControl?.errors &&
+             (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)">
+    <div class="input-group-prepend" *ngIf="options?.fieldAddonLeft">
+      <span class="input-group-text" [innerHTML]="options?.fieldAddonLeft"></span>
+    </div>
 
     <select-widget-widget
       [layoutNode]="widgetLayoutNode"
       [dataIndex]="dataIndex"
       [layoutIndex]="layoutIndex"></select-widget-widget>
 
-    <span *ngIf="options?.fieldAddonRight"
-          class="input-group-addon"
-          [innerHTML]="options?.fieldAddonRight"></span>
+    <div class="input-group-append" *ngIf="options?.fieldAddonRight">
+      <span class="input-group-text" [innerHTML]="options?.fieldAddonRight"></span>
+    </div>
   </div>
 
-  <span *ngIf="options?.feedback && options?.isInputWidget &&
-          !options?.fieldAddonRight && !layoutNode.arrayItem &&
-          (formControl?.dirty || options?.feedbackOnRender)"
-        [class.glyphicon-ok]="options?.enableSuccessState && !formControl?.errors"
-        [class.glyphicon-remove]="options?.enableErrorState && formControl?.errors"
-        aria-hidden="true"
-        class="form-control-feedback glyphicon"></span>
-  <div *ngIf="options?.messageLocation !== 'top'">
-    <p *ngIf="options?.helpBlock"
-       class="help-block"
-       [innerHTML]="options?.helpBlock"></p>
-  </div>
+  <div *ngIf="(formControl?.touched || formControl?.dirty || options?.feedbackOnRender) && options?.errorMessage"
+       class="invalid-feedback"
+       [innerHTML]="options?.errorMessage"></div>
+
+  <!--
+    helpBlock carries the formatted errors when the control is invalid and
+    description || help otherwise, so it is suppressed while the error element
+    above is showing rather than repeating the same failure in muted text.
+  -->
+  <p *ngIf="options?.helpBlock && options?.messageLocation !== 'top' &&
+        !(options?.enableErrorState && formControl?.errors)"
+     class="form-text text-muted"
+     [innerHTML]="options?.helpBlock"></p>
 </div>
 
 <div *ngIf="debug && debugOutput">debug:

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.spec.ts
@@ -36,4 +36,133 @@ describe('FwBootstrap4Component', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  /** A control in the state issue #315 describes: blurred, still empty. */
+  const touchedButUnchanged = (extra: any = {}) => ({
+    status: 'INVALID',
+    errors: { required: true },
+    touched: true,
+    dirty: false,
+    ...extra,
+  });
+
+  // Issue #315, first symptom: "Touch required field, no message appears."
+  // The message was gated on dirty, which means the value changed, so a focus
+  // and blur with nothing typed produced nothing.
+  describe('when the message appears', () => {
+    // formControl is assigned after initializeFramework, which overwrites it
+    // with whatever the service has, and options is a clone of layoutNode's.
+    const helpBlockFor = (control: any, options: any = {}) => {
+      component.layoutNode = { type: 'text', options: { enableErrorState: true, ...options } };
+      component.initializeFramework();
+      component.formControl = control as any;
+      component.updateHelpBlock(control.status);
+      return component.options.helpBlock;
+    };
+
+    it('reports an error on a control that was touched but never changed', () => {
+      expect(helpBlockFor(touchedButUnchanged()) ?? '').toMatch(/required/i);
+    });
+
+    it('still reports an error on a control that was changed', () => {
+      expect(helpBlockFor(touchedButUnchanged({ touched: false, dirty: true })) ?? '')
+        .toMatch(/required/i);
+    });
+
+    it('reports nothing on a control that has not been touched', () => {
+      expect(helpBlockFor(touchedButUnchanged({ touched: false, dirty: false })))
+        .toBeNull();
+    });
+
+    it('reports nothing while the field is valid', () => {
+      expect(helpBlockFor({ status: 'VALID', errors: null, touched: true, dirty: true }))
+        .toBeNull();
+    });
+  });
+
+  // Issue #315, second symptom: overriding the CSS turned description text red
+  // too, because error text and description text shared one paragraph.
+  describe('emitted classes', () => {
+    const initialize = (type: string, extra: any = {}) => {
+      component.layoutNode = { type, options: {}, ...extra };
+      component.initializeFramework();
+      return component;
+    };
+
+    it('spaces a field with form-group, which Bootstrap 4 still defines', () => {
+      expect(initialize('text').options.htmlClass).toContain('form-group');
+    });
+
+    it('emits no label class, since Bootstrap 4 dropped control-label', () => {
+      const { options } = initialize('text');
+      expect(options.labelHtmlClass || '').not.toContain('control-label');
+      expect(options.labelHtmlClass || '').not.toContain('col-form-label');
+    });
+
+    it('uses the neutral Bootstrap 4 button for button sets', () => {
+      const { widgetOptions } = initialize('checkboxbuttons');
+      expect(widgetOptions.itemLabelHtmlClass).toContain('btn-secondary');
+      expect(widgetOptions.itemLabelHtmlClass).not.toContain('btn-default');
+    });
+
+    it('keeps sr-only, which Bootstrap 4 still defines', () => {
+      expect(initialize('checkboxbuttons').widgetOptions.fieldHtmlClass)
+        .toContain('sr-only');
+    });
+  });
+
+  describe('rendered markup', () => {
+    const render = (options: any, control: any = null) => {
+      component.layoutNode = { type: 'text', options };
+      component.initializeFramework();
+      component.formControl = control as any;
+      fixture.detectChanges();
+      return fixture.nativeElement;
+    };
+
+    it('emits no class Bootstrap 4 dropped', () => {
+      const html = render({ title: 'Name', helpBlock: 'Anything' }).innerHTML;
+      ['has-error', 'has-success', 'has-feedback', 'help-block',
+        'form-control-feedback', 'glyphicon', 'input-group-addon', 'pull-right']
+        .forEach((dead) => expect(html, `${dead} is dead in Bootstrap 4`).not.toContain(dead));
+    });
+
+    // The reporter could not style the error without also styling the
+    // description, because both went through one help-block paragraph.
+    it('puts the error in an element that carries no description text', () => {
+      const el = render(
+        { enableErrorState: true, errorMessage: 'Name is required', helpBlock: 'Your full name' },
+        touchedButUnchanged()
+      );
+      const error = el.querySelector('.invalid-feedback');
+      expect(error, 'the error needs an element of its own').toBeTruthy();
+      expect(error.textContent).toContain('Name is required');
+      expect(error.textContent).not.toContain('Your full name');
+    });
+
+    it('puts help text in an element that carries no error text', () => {
+      const el = render({ helpBlock: 'Your full name' });
+      const help = el.querySelector('.form-text');
+      expect(help, 'help text needs an element of its own').toBeTruthy();
+      expect(help.textContent).toContain('Your full name');
+      expect(el.querySelector('.invalid-feedback')).toBeNull();
+    });
+
+    it('marks the field so Bootstrap reveals the feedback beside it', () => {
+      const el = render(
+        { enableErrorState: true, errorMessage: 'Name is required' },
+        touchedButUnchanged()
+      );
+      const invalid = el.querySelector('.is-invalid');
+      expect(invalid, 'something must carry is-invalid').toBeTruthy();
+      // Bootstrap reveals .invalid-feedback only as a following sibling of the
+      // element carrying .is-invalid, so they have to share a parent.
+      expect(invalid.parentElement.querySelector('.invalid-feedback')).toBeTruthy();
+    });
+
+    it('wraps an addon the way Bootstrap 4 documents it', () => {
+      const el = render({ fieldAddonLeft: 'kg' });
+      expect(el.querySelector('.input-group-prepend .input-group-text')).toBeTruthy();
+    });
+  });
 });

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -103,8 +103,9 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
             addClasses(this.options.htmlClass, 'list-group-item') :
             addClasses(this.options.htmlClass, 'form-group');
       this.widgetOptions.htmlClass = '';
-      this.options.labelHtmlClass =
-        addClasses(this.options.labelHtmlClass, 'control-label');
+      // No label class. Bootstrap 4 styles a plain <label> in a stacked form,
+      // and col-form-label, which the migration table offers as the rename,
+      // is for horizontal grid forms only. This framework has no such mode.
       this.widgetOptions.activeClass =
         addClasses(this.widgetOptions.activeClass, 'active');
       this.options.fieldAddonLeft =
@@ -153,7 +154,9 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
           this.widgetOptions.itemLabelHtmlClass = addClasses(
             this.widgetOptions.itemLabelHtmlClass, 'btn');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, this.options.style || 'btn-default');
+            // btn-default was Bootstrap 3's neutral button; btn-secondary is its
+            // Bootstrap 4 counterpart. btn-outline-primary would add emphasis.
+            this.widgetOptions.itemLabelHtmlClass, this.options.style || 'btn-secondary');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'sr-only');
           break;
@@ -216,7 +219,7 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
   updateHelpBlock(status) {
     this.options.helpBlock = status === 'INVALID' &&
     this.options.enableErrorState && this.formControl.errors &&
-    (this.formControl.dirty || this.options.feedbackOnRender) ?
+    (this.formControl.touched || this.formControl.dirty || this.options.feedbackOnRender) ?
       this.jsf.formatErrors(this.formControl.errors, this.options.validationMessages) :
       this.options.description || this.options.help || null;
   }

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -240,7 +240,7 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
   updateHelpBlock(status) {
     this.options.helpBlock = status === 'INVALID' &&
     this.options.enableErrorState && this.formControl.errors &&
-    (this.formControl.dirty || this.options.feedbackOnRender) ?
+    (this.formControl.touched || this.formControl.dirty || this.options.feedbackOnRender) ?
       this.jsf.formatErrors(this.formControl.errors, this.options.validationMessages) :
       this.options.description || this.options.help || null;
   }


### PR DESCRIPTION
## Summary

Issue #315 reports that on Bootstrap 4 validation messages render black, do not appear when a required field is touched and left empty, and cannot be styled without also styling description text. It is two defects rather than one, and both are fixed here.

## Changes

The trigger came first. All three Bootstrap packages gated the message on `formControl.dirty`, meaning the value changed, so focusing a required field and leaving it empty produced nothing. It is now `touched || dirty`, which is additive rather than a swap: a control changed but not yet blurred still reports as before. Bootstrap 5's template already used touched while its own updateHelpBlock used dirty, so this makes it agree with itself.

Error text and description text then shared one help-block paragraph, which is why no CSS override separated them. Bootstrap 4 now renders the error in invalid-feedback and help text in form-text text-muted.

The remainder is the drift measured in docs/bootstrap-class-drift.md, since this package was a copy of bootstrap3 with the CDN URL changed. control-label becomes no class, because Bootstrap 4 styles a plain label in a stacked form and col-form-label is for horizontal grid forms, which this library has no mode for. btn-default becomes btn-secondary rather than btn-outline-primary, which would add emphasis the option never had. form-group and sr-only stay, as Bootstrap 4 still defines them. is-invalid goes on the field wrapper, not the control: Bootstrap reveals invalid-feedback only as a following sibling of the element carrying is-invalid, and select-widget-widget renders a host element and a container div in between, so on the control it would hide the message entirely.

Checkbox and radio classes are deliberately untouched, since Bootstrap 4 wants form-check-input and form-check-label on siblings and this library nests the input inside the label.

## Compatibility

Bootstrap 4 output changes, and CSS written against the old class names needs updating. The replaced names are tabled in the package README, which ships as the npm page. The trigger change affects all three Bootstrap packages.

## Release impact

No release from this pull request. It is consumer visible and belongs in 20.1.0, alongside the Bootstrap 5 help text fix in #497.

## Validation

Thirteen tests were added to the Bootstrap 4 spec, which had one. They cover the trigger on a touched but unchanged control, on a changed control and on an untouched one, the absence of every class Bootstrap 4 dropped, the error and help elements being separate, the sibling relationship that reveals the feedback, and the addon structure. Suites report bootstrap4 89 passing, bootstrap3 76, bootstrap5 87 and core 2156, with every corpus entry included and no baseline re-recorded. All six libraries build.