### PR TITLE
chore: 20.1.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.0.0",
+    "@ajsf/core": "^20.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.0.0",
+    "@ajsf/core": "^20.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.0.0",
+    "@ajsf/core": "^20.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.0.0",
+    "@ajsf/core": "^20.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/primeng",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.0.0",
+    "@ajsf/core": "^20.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Publishes all six packages at 20.1.0. Only the version changes here.

## Changes

`npm run version:set -- 20.1.0 20` set the version on the six manifests and the internal `@ajsf/core` range to `^20.1.0`. The Angular peer ranges already targeted major 20 and are unchanged.

The release carries two consumer visible fixes, each reviewed on its own pull request. #498 makes `@ajsf/bootstrap4` emit Bootstrap 4 markup rather than the Bootstrap 3 markup it was copied with, and makes validation messages appear once a field is touched rather than only once its value changed, which closes #315. #497 restores help text on `@ajsf/bootstrap5`, which its own migration had stopped rendering.

## Release impact

Publishes `@ajsf/core`, `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4`, `@ajsf/bootstrap5` and `@ajsf/primeng` at 20.1.0 on the `latest` dist-tag, once the `npm-publish` deployment is approved. Bootstrap 4 consumers with CSS written against the old class names are affected; the replaced names are tabled in that package's README, which ships as its npm page.

## Validation

main is green at 48bfd55. All six suites were run on this commit: core 2156 passing, primeng 206, material 104, bootstrap5 95, bootstrap4 89, bootstrap3 76, with every corpus entry included and no baseline re-recorded. `test:scripts` reports 73. All six libraries build.