### PR TITLE
docs: write the Angular 21 upgrade note

### DIFF
--- a/docs/release-notes/21.md
+++ b/docs/release-notes/21.md
@@ -1,0 +1,45 @@
+## Upgrading from 20.x
+
+Nothing in the form API changed. Every widget renders what it rendered in
+20.1.0, verified against the 444 entry corpus, and no export or component
+selector moved.
+
+Everything below is about what your project has to satisfy to install it.
+
+### Angular and Node
+
+The peer ranges move to `^21.0.0`, so Angular 20 no longer satisfies them.
+Angular 21 keeps the Node floor it had at 20, `^20.19.0 || ^22.12.0 ||
+>=24.0.0`, so a project already on Angular 20 needs no Node change. Note that
+Node 20 itself reached end of life on 2026-04-30; this library is built and
+tested on Node 24, the active LTS.
+
+Angular 21 requires TypeScript `>=5.9 <6.1`.
+
+### PrimeNG
+
+`@ajsf/primeng` peers on `primeng ^21.0.0`. PrimeNG majors track Angular's, so
+the two move together.
+
+The `@angular/animations` note from the 20 release still applies. PrimeNG
+declares it as a peer dependency, Angular does not add it to a new project, and
+the Angular framework packages peer on each other by exact patch, so install it
+at the same patch as the rest of your Angular packages:
+
+```shell
+# if your @angular/* packages are 21.2.23
+npm install @angular/animations@21.2.23
+```
+
+### If you wrote CSS against Bootstrap 4 output
+
+That changed in 20.1.0 rather than here, but if you are coming from 20.0.0 you
+will meet it on the way. `@ajsf/bootstrap4` previously emitted Bootstrap 3 class
+names; the replacements are tabled in that package's README.
+
+### Nothing else you can observe
+
+Angular 21 rewrote this library's templates from `*ngIf` and `*ngFor` to `@if`
+and `@for`, and its own test tooling moved to Vitest 4. Neither reaches a
+consumer: the published packages contain compiled output, and the corpus
+confirms the rendered result is unchanged.


### PR DESCRIPTION
## Summary

The release workflow appends `docs/release-notes/<major>.md` on a major's first stable release, so it has to exist before `21.0.0` is cut.

## Changes

Says what a consumer has to satisfy rather than what changed internally: peer ranges at `^21.0.0`, TypeScript `>=5.9 <6.1`, and `primeng ^21.0.0`. The Node floor is unchanged from Angular 20, with a note that Node 20 itself reached end of life on 2026-04-30 and that the library is built and tested on Node 24.

The `@angular/animations` caveat from the 20 note still applies and is repeated rather than linked, since someone upgrading from 20.0.0 may never have read it. It also records that nothing observable changed: the rewrite to `@if` and `@for` and the move to Vitest 4 are invisible to a consumer of compiled packages, which the corpus confirms.

## Release impact

None from this pull request. It is documentation, and the version is untouched; the `21.0.0` bump follows separately.

## Validation

`npm run test:scripts` reports 73 specs, 0 failures. The version numbers quoted were read from the installed tree rather than written from memory.