### PR TITLE
chore: 21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.1.0",
+    "@ajsf/core": "^21.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0"
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0"
   }
 }

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.1.0",
+    "@ajsf/core": "^21.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0"
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0"
   }
 }

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.1.0",
+    "@ajsf/core": "^21.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0"
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0"
   }
 }

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/core",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -32,10 +32,10 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0",
-    "@angular/forms": "^20.0.0",
-    "@angular/platform-browser": "^20.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
     "rxjs": "^7.0.0"
   }
 }

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/material",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.1.0",
+    "@ajsf/core": "^21.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/material": "^20.0.0",
-    "@angular/cdk": "^20.0.0"
+    "@angular/material": "^21.0.0",
+    "@angular/cdk": "^21.0.0"
   }
 }

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/primeng",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular20",
-    "Angular 20",
-    "ng20",
+    "Angular21",
+    "Angular 21",
+    "ng21",
     "JSON Schema",
     "form",
     "forms",
@@ -28,12 +28,12 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^20.1.0",
+    "@ajsf/core": "^21.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0",
-    "primeng": "^20.0.0"
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "primeng": "^21.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Publishes all six packages at 21.0.0, the Angular 21 release. Only the version changes here.

## Changes

`npm run version:set -- 21.0.0 21` set the version on the six manifests, the internal `@ajsf/core` range to `^21.0.0`, the Angular peer ranges to `^21.0.0`, the `primeng` peer to `^21.0.0` since its majors track Angular's, and the workspace keywords.

The release carries the Angular 21 upgrade in #503. Nothing a consumer renders changed: all 444 corpus entries pass unmoved, and no export or component selector was touched. The upgrade note is `docs/release-notes/21.md`, which the release workflow appends to the page for a major's first stable release.

## Release impact

Publishes `@ajsf/core`, `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4`, `@ajsf/bootstrap5` and `@ajsf/primeng` at 21.0.0 on the `latest` dist-tag, once the `npm-publish` deployment is approved. Angular 20 no longer satisfies the peer ranges.

## Validation

main is green at 4adc3a2. `test:scripts` reports 73 specs, 0 failures. The upgrade itself was validated on #503: all six suites at their Angular 20 counts with no baseline re-recorded, `npm run coverage` producing six non-empty reports, all six libraries and the demo building, and the consumer smoke test confirming the packages install into a new Angular 21 project and build.