### PR TITLE
docs: write the Angular 22 upgrade note

### DIFF
--- a/docs/release-notes/22.md
+++ b/docs/release-notes/22.md
@@ -1,0 +1,49 @@
+## Upgrading from 21.x
+
+Nothing in the form API changed. No export or component selector moved, and
+every widget renders what it rendered in 21.0.0 apart from one third party
+change noted below.
+
+Everything below is about what your project has to satisfy to install it.
+
+### Angular, TypeScript and Node
+
+The peer ranges move to `^22.0.0`, so Angular 21 no longer satisfies them.
+
+Angular 22 requires **TypeScript 6**, `>=6.0 <6.1`. That is a major on its own
+and it turns `strict` on by default, so a project that relied on the previous
+default will see `TS7006` and similar until it either sets `strict: false` or
+annotates the code. TypeScript 6 also deprecates `baseUrl` with `TS5101`; if you
+remove it, every `paths` target needs a leading `./` or you get `TS5090`.
+
+Angular 22 raises the Node floor to `^22.22.3 || ^24.15.0 || >=26.0.0`. Node 20
+is not merely unsupported here, it reached end of life on 2026-04-30. This
+library is built and tested on Node 24, the active LTS.
+
+### PrimeNG
+
+`@ajsf/primeng` peers on `primeng ^22.0.0`. PrimeNG majors track Angular's, so
+the two move together.
+
+One rendering change comes from PrimeNG rather than from this library. Its
+slider now renders an internal `<input>` that it did not render at 21, so a
+`range` field produces one more form control in the DOM than before. Nothing
+about the value, validation or layout changed. If you count or query inputs in
+your own tests, that is where the difference comes from.
+
+The `@angular/animations` note from the 20 release still applies. PrimeNG
+declares it as a peer dependency, Angular does not add it to a new project, and
+the Angular framework packages peer on each other by exact patch, so install it
+at the same patch as the rest of your Angular packages:
+
+```shell
+# if your @angular/* packages are 22.1.6
+npm install @angular/animations@22.1.6
+```
+
+### Nothing else you can observe
+
+Angular 22's migration wraps optional chaining in templates and rewrites some
+compiler options. Neither reaches a consumer: the published packages contain
+compiled output, and the corpus confirms the rendered result is unchanged apart
+from the PrimeNG slider above.


### PR DESCRIPTION
## Summary

The release workflow appends `docs/release-notes/<major>.md` on a major's first stable release, so it has to exist before `22.0.0` is cut.

## Changes

Leads with TypeScript 6, because that is the part a consumer has to act on: Angular 22 requires `>=6.0 <6.1`, it turns `strict` on by default, and it deprecates `baseUrl` in a way whose fix produces a second error. Those cost the most time in the upgrade here and will cost a consumer the same. It also records the raised Node floor and that Node 20 is end of life.

It names the one rendering difference rather than claiming nothing changed. PrimeNG 22's slider renders an internal input, so a `range` field produces one more form control in the DOM. That comes from PrimeNG rather than from this library, and it matters only to someone counting inputs in their own tests.

## Release impact

None from this pull request. It is documentation, and the version is untouched; the `22.0.0` bump follows separately.

## Validation

`npm run test:scripts` reports 73 specs, 0 failures. The version numbers and the Node range quoted were read from the installed tree and the published manifests rather than written from memory.