### PR TITLE
chore: 22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "author": "https://github.com/hamzahamidi/Angular6-json-schema-form/graphs/contributors",
   "description": "Angular JSON Schema Form workspace: builds the @ajsf packages and the demo",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
     "npm": ">=8.5.0"
   },
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^21.0.0",
+    "@ajsf/core": "^22.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0"
   }
 }

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^21.0.0",
+    "@ajsf/core": "^22.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0"
   }
 }

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^21.0.0",
+    "@ajsf/core": "^22.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0"
   }
 }

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/core",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -32,10 +32,10 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0",
-    "@angular/forms": "^21.0.0",
-    "@angular/platform-browser": "^21.0.0",
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0",
+    "@angular/forms": "^22.0.0",
+    "@angular/platform-browser": "^22.0.0",
     "rxjs": "^7.0.0"
   }
 }

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/material",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -29,11 +29,11 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^21.0.0",
+    "@ajsf/core": "^22.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/material": "^21.0.0",
-    "@angular/cdk": "^21.0.0"
+    "@angular/material": "^22.0.0",
+    "@angular/cdk": "^22.0.0"
   }
 }

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ajsf/primeng",
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
     "Angular",
     "ng",
-    "Angular21",
-    "Angular 21",
-    "ng21",
+    "Angular22",
+    "Angular 22",
+    "ng22",
     "JSON Schema",
     "form",
     "forms",
@@ -28,12 +28,12 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^21.0.0",
+    "@ajsf/core": "^22.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0",
-    "primeng": "^21.0.0"
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0",
+    "primeng": "^22.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Publishes all six packages at 22.0.0, the Angular 22 release and the last major in the upgrade walk. Only the version changes here.

## Changes

`npm run version:set -- 22.0.0 22` set the version on the six manifests, the internal `@ajsf/core` range to `^22.0.0`, the Angular peer ranges to `^22.0.0`, the `primeng` peer to `^22.0.0` since its majors track Angular's, and the workspace keywords.

The release carries the Angular 22 upgrade in #506. The upgrade note is `docs/release-notes/22.md`, which the release workflow appends to the page for a major's first stable release. It leads with TypeScript 6, which Angular 22 requires and which turns `strict` on by default.

## Release impact

Publishes `@ajsf/core`, `@ajsf/material`, `@ajsf/bootstrap3`, `@ajsf/bootstrap4`, `@ajsf/bootstrap5` and `@ajsf/primeng` at 22.0.0 on the `latest` dist-tag, once the `npm-publish` deployment is approved. Angular 21 no longer satisfies the peer ranges.

## Validation

main is green at a323dd9. `test:scripts` reports 73 specs, 0 failures. The upgrade itself was validated on #506: all six suites passing, two PrimeNG corpus entries re-recorded for a slider markup change in PrimeNG rather than in this library, coverage producing six non-empty reports, all six libraries and the demo building, and the consumer smoke test confirming the packages install into a new Angular 22 project and build.