### PR TITLE
chore: point the package metadata at this repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ajsf-workspace",
   "private": true,
   "version": "0.0.0",
-  "author": "https://github.com/hamzahamidi/Angular6-json-schema-form/graphs/contributors",
+  "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "description": "Angular JSON Schema Form workspace: builds the @ajsf packages and the demo",
   "engines": {
     "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
@@ -30,12 +30,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/angular6-json-schema-form"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
-    "url": "https://github.com/hamzahamidi/angular6-json-schema-form/issues"
+    "url": "https://github.com/hamzahamidi/ajsf/issues"
   },
-  "homepage": "https://github.com/hamzahamidi/Angular6-json-schema-form#readme",
+  "homepage": "https://github.com/hamzahamidi/ajsf#readme",
   "scripts": {
     "ng": "ng",
     "prestart": "npm run build:libs",

--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hamzahamidi/ajsf"
+    "url": "git+https://github.com/hamzahamidi/ajsf.git"
   },
   "bugs": {
     "url": "https://github.com/hamzahamidi/ajsf/issues"


### PR DESCRIPTION
## Summary

The workspace manifest still named `angular6-json-schema-form` in four fields, and the six published manifests declared a repository URL that npm normalised on every publish.

## Changes

`author`, `repository`, `bugs` and `homepage` in the workspace manifest all pointed at the repository's former name. It is private, so none of that reached npm, but it is what a contributor reads. `author` keeps its shape: it holds a contributors page rather than a person, which is unusual but deliberate, so it now points at this repository's contributors page rather than becoming an authorship change.

The six published manifests named the right repository without the `.git` suffix, which npm normalises and then asks you to correct at source. That is metadata rather than behaviour, so it reaches npm with whatever ships next.

The former name stays where it is load bearing: the README links to that branch for the old documentation, and `codeql-analysis.yml` still scans it.

## Release impact

None. The version stays at 22.0.0, and the corrected manifests publish with the next release rather than prompting one.

## Validation

`npm run test:scripts` reports 73 specs, 0 failures, which includes the package guards asserting the workspace stays private at 0.0.0 and the six libraries stay publishable.