### PR TITLE
fix(bootstrap)!: render checkboxes and radios as siblings on Bootstrap 4 and 5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,14 @@ them per file, because both are deliberate:
   exports, the component selectors, and the layout `type` values that resolve
   to them.
 
+- **`activeClass` and `style.selected` apply to the label, not the control.**
+  That is what makes the toggle-button idiom work, where the label is the
+  button. Since the Bootstrap 4 and 5 checkbox and radio widgets moved to
+  sibling markup, the label no longer wraps the input for plain checks, so
+  those two options style a label that does not contain the control.
+  Redefining what they target is a consumer visible option change and needs
+  its own decision, not a quiet fix.
+
 - **Do not upgrade Angular as a side effect** of another change. Angular majors move one at a time, in their own PR.
 - `@ajsf/core` uses `any` widely by design, because it processes arbitrary JSON Schema. Do not "fix" that.
 

--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -70,18 +70,21 @@ The one type that needs the framework div is the single `checkbox`, since
 `radios` widgets already bind `htmlClass` per item, and the inline variants take
 `form-check form-check-inline` on the item label.
 
-## Still open
+## Closed in 22.1.0
 
-`form-check-label` emits no declarations in this DOM shape. Bootstrap defines it
-only through sibling selectors such as `.form-check-input:disabled ~
-.form-check-label`, and the widgets nest the input inside the label. So the
-class is emitted as the contract, but disabled and validation label states stay
-inert until the input becomes a sibling. That is a core restructure across
-`checkbox`, `checkboxes` and `radios`, affecting four packages.
+`form-check-label` emitted no declarations while the input sat inside the label,
+because Bootstrap defines the class only through sibling selectors such as
+`.form-check-input:disabled ~ .form-check-label`. 22.1.0 moved the input out:
+`@ajsf/bootstrap4` and `@ajsf/bootstrap5` each supply their own `checkbox`,
+`checkboxes` and `radios` components, subclassing the `@ajsf/core` widget and
+overriding the template only, so no core file changed and the other four
+packages render as they did.
 
-The button set path (`checkboxbuttons`, `radiobuttons`) is migrated off the dead
-`btn-default` and `sr-only` but not measured. Bootstrap 5's own idiom there is
-`btn-check`, which also wants the input as a sibling of the label.
+The button set path is where the two majors part. Bootstrap 5 uses `btn-check`
+on a sibling input, so its button sets took the sibling shape with everything
+else. Bootstrap 4 has no `btn-check` and documents `.btn-group-toggle` with the
+input inside the label, so its `checkboxbuttons` and `radiobuttons` stay nested
+deliberately.
 
 ## Two layout defects, shared by all three
 

--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -68,7 +68,7 @@ canonical Bootstrap markup the geometry is identical, and no core file changed.
 The one type that needs the framework div is the single `checkbox`, since
 `checkbox-widget` reads no `htmlClass` at all. The vertical `checkboxes` and
 `radios` widgets already bind `htmlClass` per item, and the inline variants take
-`form-check form-check-inline` on the item label.
+`form-check form-check-inline` on a per-item wrapper.
 
 ## Closed in 22.1.0
 

--- a/docs/bootstrap-class-drift.md
+++ b/docs/bootstrap-class-drift.md
@@ -65,10 +65,10 @@ The first reading of this said it needed a core widget change, because
 around the widget, so the class reaches the input from there. Measured against
 canonical Bootstrap markup the geometry is identical, and no core file changed.
 
-The one type that needs the framework div is the single `checkbox`, since
-`checkbox-widget` reads no `htmlClass` at all. The vertical `checkboxes` and
-`radios` widgets already bind `htmlClass` per item, and the inline variants take
-`form-check form-check-inline` on a per-item wrapper.
+The one type that needs the framework div is the single `checkbox` on
+Bootstrap 5, whose switch case adds nothing to `htmlClass`. The vertical
+`checkboxes` and `radios` widgets bind `htmlClass` per item, and the inline
+variants take `form-check form-check-inline` on a per-item wrapper.
 
 ## Closed in 22.1.0
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,10 +140,11 @@ that issue #315 was two defects rather than one: the message was gated on
 class change addresses. That is `touched || dirty` now, in all three Bootstrap
 packages.
 
-Checkbox and radio inputs still carry `checkbox` and `radio`. Bootstrap 4 and 5
-both want `form-check-input` and `form-check-label` on sibling elements, and
-the core widgets nest the input inside the label, so emitting those names would
-look conformant and do nothing. That is the restructure below, not class drift.
+Checkboxes and radios were left alone. Bootstrap 4 and 5 both want
+`form-check-input` and `form-check-label` on sibling elements, the core widgets
+nested the input inside the label, and emitting those names against the nested
+shape would have looked conformant and done nothing. That was a restructure
+rather than class drift, and it shipped separately in 22.1.0: see below.
 
 Measured class by class in [Bootstrap class drift](./bootstrap-class-drift.md).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,11 +33,13 @@ anything in this library: one extra control per `range` field, which is what
 identified it. Everything else rendered identically through a template rewrite
 that touched every widget.
 
-### Checkbox and radio markup, and the array layout defects
+### The array layout defects
 
-The two pieces of user visible work that the Bootstrap pass in 20.1.0
-deliberately stopped short of, now the next thing rather than the thing after
-the upgrade. Both are described below under Correctness, and both need a design
+The checkbox and radio half of the work the Bootstrap pass in 20.1.0
+deliberately stopped short of is done: Bootstrap 4 and 5 render checkboxes and
+radios as siblings through their own widget components, described below under
+Correctness. What is left is the array remove button and the duplicated array
+title, described further down under Correctness, which still need a design
 pass before code because they change shared widget structure rather than one
 package's class list.
 
@@ -147,9 +149,14 @@ Measured class by class in [Bootstrap class drift](./bootstrap-class-drift.md).
 
 ### Checkbox and radio markup, and what shares what
 
-Bootstrap 3 documents the input nested inside the label; 4 and 5 document them
-as siblings and style state through sibling selectors. No class mapping
-reconciles those, which is the limit `20.1.0` stopped at.
+Bootstrap 4 and 5 now render checkboxes and radios as siblings through their
+own widget components, each subclassing the corresponding `@ajsf/core` widget
+and overriding template metadata only. Bootstrap 3, `@ajsf/core`'s plain HTML
+output, `@ajsf/material` and `@ajsf/primeng` are unchanged: they keep the
+nested form deliberately. Bootstrap 4's toggle buttons (`checkboxbuttons`,
+`radiobuttons`) stay nested too, because Bootstrap 4 documents
+`.btn-group-toggle` with the input inside the label and has no `.btn-check`.
+Bootstrap 5's button sets render as siblings because it does.
 
 The same shape blocks validation. Bootstrap reveals `.invalid-feedback` only as
 a following sibling of the element carrying `.is-invalid`, and
@@ -157,13 +164,6 @@ a following sibling of the element carrying `.is-invalid`, and
 between the field wrapper and the real input, so the control and its message
 can never be siblings. Bootstrap 4 and 5 therefore both put `is-invalid` on the
 wrapper, which shows the message but does not mark the control.
-
-Fixing it properly means the framework packages specialising a rendering recipe
-(classes, element relationships, placement) rather than a class list, with the
-AJSF concerns shared: roughly three quarters of the Bootstrap 4 template's 62
-lines are structure and Angular bindings with no Bootstrap content at all. The
-recipe boundary is worth extracting from one correct implementation rather than
-designed up front.
 
 ### The array remove button and the duplicated array title
 

--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -80,11 +80,28 @@ showed nothing. It now appears once the field has been touched or changed.
 Error text and help text are also separate elements now, so you can style one
 without the other.
 
-Checkbox and radio inputs still carry the Bootstrap 3 `checkbox` and `radio`
-classes. Bootstrap 4 wants `form-check-input` and `form-check-label` on
-sibling elements, and this library nests the input inside the label, so those
-names would be rendered without effect. That is tracked separately rather than
-shipped as a cosmetic change.
+## Checkbox and radio structure, changed in 22.1.0
+
+Checkboxes and radios previously rendered the `<input>` inside its `<label>`,
+which is the Bootstrap 3 shape this package was copied from. They now render
+as siblings inside a `.form-check` wrapper, which is what Bootstrap 4
+documents and what its state styling requires:
+
+    <div class="form-check">
+      <input class="form-check-input" id="control1" type="checkbox">
+      <label class="form-check-label" for="control1">Accept</label>
+    </div>
+
+The inline variants (`checkboxes-inline`, `radios-inline`) moved the same way,
+from the deleted Bootstrap 3 `checkbox-inline` and `radio-inline` classes to
+`form-check form-check-inline` on the same sibling shape.
+
+Toggle buttons (`checkboxbuttons`, `radiobuttons`) are unchanged. Bootstrap 4
+documents those as `.btn-group-toggle` with the input inside the label, and
+has no `.btn-check`.
+
+If you wrote CSS selecting `label > input` or styling the label as the
+control's ancestor, that is where the difference is.
 
 ## Code scaffolding
 

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -143,9 +143,11 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
           break;
         case 'checkboxes-inline':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'checkbox');
+            this.widgetOptions.htmlClass, 'form-check form-check-inline');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, 'checkbox-inline');
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         // Radio controls
         case 'radio':

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -134,12 +134,12 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
             this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'checkboxes':
-          // Keeps the Bootstrap 3 class: this type still renders core's
-          // CheckboxesComponent, which nests the input inside the label, and
-          // .form-check is written for sibling markup. Move to the
-          // form-check trio once 'checkboxes' has its own sibling widget.
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'checkbox');
+            this.widgetOptions.htmlClass, 'form-check');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'checkboxes-inline':
           this.widgetOptions.htmlClass = addClasses(

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -128,7 +128,11 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         case 'checkbox':
         case 'checkboxes':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'checkbox');
+            this.widgetOptions.htmlClass, 'form-check');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'checkboxes-inline':
           this.widgetOptions.htmlClass = addClasses(

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -153,13 +153,19 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         case 'radio':
         case 'radios':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'radio');
+            this.widgetOptions.htmlClass, 'form-check');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
+          this.widgetOptions.itemLabelHtmlClass = addClasses(
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'radios-inline':
           this.widgetOptions.htmlClass = addClasses(
-            this.widgetOptions.htmlClass, 'radio');
+            this.widgetOptions.htmlClass, 'form-check form-check-inline');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass, 'radio-inline');
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         // Button sets - checkboxbuttons and radiobuttons
         case 'checkboxbuttons':

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -126,13 +126,20 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
       switch (this.layoutNode.type) {
         // Checkbox controls
         case 'checkbox':
-        case 'checkboxes':
           this.widgetOptions.htmlClass = addClasses(
             this.widgetOptions.htmlClass, 'form-check');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
             this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
+          break;
+        case 'checkboxes':
+          // Keeps the Bootstrap 3 class: this type still renders core's
+          // CheckboxesComponent, which nests the input inside the label, and
+          // .form-check is written for sibling markup. Move to the
+          // form-check trio once 'checkboxes' has its own sibling widget.
+          this.widgetOptions.htmlClass = addClasses(
+            this.widgetOptions.htmlClass, 'checkbox');
           break;
         case 'checkboxes-inline':
           this.widgetOptions.htmlClass = addClasses(

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.module.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.module.ts
@@ -10,6 +10,7 @@ import {
 } from '@ajsf/core';
 import {Bootstrap4Framework} from './bootstrap4.framework';
 import {Bootstrap4FrameworkComponent} from './bootstrap4-framework.component';
+import {BOOTSTRAP4_FRAMEWORK_COMPONENTS} from './widgets/public_api';
 
 @NgModule({
     imports: [
@@ -19,10 +20,12 @@ import {Bootstrap4FrameworkComponent} from './bootstrap4-framework.component';
     ],
     declarations: [
         Bootstrap4FrameworkComponent,
+        ...BOOTSTRAP4_FRAMEWORK_COMPONENTS,
     ],
     exports: [
         JsonSchemaFormModule,
         Bootstrap4FrameworkComponent,
+        ...BOOTSTRAP4_FRAMEWORK_COMPONENTS,
     ],
     providers: [
         JsonSchemaFormService,

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {Framework} from '@ajsf/core';
 import {Bootstrap4FrameworkComponent} from './bootstrap4-framework.component';
 import {Bootstrap4CheckboxComponent} from './widgets/bootstrap4-checkbox.component';
+import {Bootstrap4CheckboxesComponent} from './widgets/bootstrap4-checkboxes.component';
 
 // Bootstrap 4 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -14,6 +15,7 @@ export class Bootstrap4Framework extends Framework {
 
   widgets = {
     'checkbox': Bootstrap4CheckboxComponent,
+    'checkboxes': Bootstrap4CheckboxesComponent,
   };
 
   stylesheets = [

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Framework} from '@ajsf/core';
 import {Bootstrap4FrameworkComponent} from './bootstrap4-framework.component';
+import {Bootstrap4CheckboxComponent} from './widgets/bootstrap4-checkbox.component';
 
 // Bootstrap 4 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -10,6 +11,10 @@ export class Bootstrap4Framework extends Framework {
   name = 'bootstrap-4';
 
   framework = Bootstrap4FrameworkComponent;
+
+  widgets = {
+    'checkbox': Bootstrap4CheckboxComponent,
+  };
 
   stylesheets = [
     '//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css'

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4.framework.ts
@@ -3,6 +3,7 @@ import {Framework} from '@ajsf/core';
 import {Bootstrap4FrameworkComponent} from './bootstrap4-framework.component';
 import {Bootstrap4CheckboxComponent} from './widgets/bootstrap4-checkbox.component';
 import {Bootstrap4CheckboxesComponent} from './widgets/bootstrap4-checkboxes.component';
+import {Bootstrap4RadiosComponent} from './widgets/bootstrap4-radios.component';
 
 // Bootstrap 4 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -16,6 +17,7 @@ export class Bootstrap4Framework extends Framework {
   widgets = {
     'checkbox': Bootstrap4CheckboxComponent,
     'checkboxes': Bootstrap4CheckboxesComponent,
+    'radios': Bootstrap4RadiosComponent,
   };
 
   stylesheets = [

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
@@ -1,0 +1,56 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CheckboxComponent } from '@ajsf/core';
+
+/**
+ * Bootstrap 4 wants the input and label as siblings inside .form-check. The
+ * core widget nests the input inside the label, which is the Bootstrap 3
+ * shape this package was originally copied from.
+ *
+ * Template only. No constructor: Angular inherits the base's injection
+ * through its generated factory, and adding one would break that.
+ */
+@Component({
+  selector: 'bootstrap4-checkbox-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+  template: `
+    <div [class]="options?.htmlClass || ''">
+      @if (boundControl) {
+        <input
+          [formControl]="formControl"
+          [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+          [class]="(options?.fieldHtmlClass || '') + (isChecked ?
+            (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+            (' ' + (options?.style?.unselected || '')))"
+          [id]="'control' + layoutNode?._id"
+          [name]="controlName"
+          [readonly]="options?.readonly ? 'readonly' : null"
+          type="checkbox">
+      }
+      @if (!boundControl) {
+        <input
+          [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+          [checked]="isChecked ? 'checked' : null"
+          [class]="(options?.fieldHtmlClass || '') + (isChecked ?
+            (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+            (' ' + (options?.style?.unselected || '')))"
+          [disabled]="controlDisabled"
+          [id]="'control' + layoutNode?._id"
+          [name]="controlName"
+          [readonly]="options?.readonly ? 'readonly' : null"
+          [value]="controlValue"
+          type="checkbox"
+          (change)="updateValue($event)">
+      }
+      <label
+        [attr.for]="'control' + layoutNode?._id"
+        [class]="options?.itemLabelHtmlClass || ''">
+        @if (options?.title) {
+          <span
+            [style.display]="options?.notitle ? 'none' : ''"
+            [innerHTML]="options?.title"></span>
+        }
+      </label>
+    </div>`,
+})
+export class Bootstrap4CheckboxComponent extends CheckboxComponent {}

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
@@ -5,10 +5,12 @@ import { CheckboxesComponent } from '@ajsf/core';
  * Bootstrap 4 splits these two ways, so this template does too.
  *
  * Vertical checkboxes take the sibling form, which is what Bootstrap 4
- * documents for .form-check. The horizontal branch serves checkboxes-inline
- * and checkboxbuttons, and keeps the input inside the label: Bootstrap 4's
- * toggle buttons are .btn-group-toggle with a nested input, and it has no
- * .btn-check. That is deliberate, not a widget that was missed.
+ * documents for .form-check. The horizontal branch splits again on
+ * layoutNode.type: checkboxes-inline is .form-check.form-check-inline, the
+ * same sibling shape as vertical, while checkboxbuttons keeps the input
+ * inside the label, because Bootstrap 4's toggle buttons are
+ * .btn-group-toggle with a nested input and it has no .btn-check. That is
+ * deliberate, not a widget that was missed.
  *
  * Template only. No constructor.
  */
@@ -25,27 +27,52 @@ import { CheckboxesComponent } from '@ajsf/core';
     }
 
     @if (layoutOrientation === 'horizontal') {
-      <div [class]="options?.htmlClass || ''">
-        @for (checkboxItem of checkboxList; track checkboxItem) {
-          <label
-            [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
-            [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
-              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
-              (' ' + (options?.style?.unselected || '')))">
-            <input type="checkbox"
-              [attr.required]="options?.required"
-              [checked]="checkboxItem.checked"
-              [class]="options?.fieldHtmlClass || ''"
-              [disabled]="controlDisabled"
-              [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
-              [name]="checkboxItem?.name"
-              [readonly]="options?.readonly ? 'readonly' : null"
-              [value]="checkboxItem.value"
-              (change)="updateValue($event, checkboxItem)">
-            <span [innerHTML]="checkboxItem.name"></span>
-          </label>
-        }
-      </div>
+      @if (layoutNode?.type === 'checkboxbuttons') {
+        <div [class]="options?.htmlClass || ''">
+          @for (checkboxItem of checkboxList; track checkboxItem) {
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))">
+              <input type="checkbox"
+                [attr.required]="options?.required"
+                [checked]="checkboxItem.checked"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+                [name]="checkboxItem?.name"
+                [readonly]="options?.readonly ? 'readonly' : null"
+                [value]="checkboxItem.value"
+                (change)="updateValue($event, checkboxItem)">
+              <span [innerHTML]="checkboxItem.name"></span>
+            </label>
+          }
+        </div>
+      } @else {
+        <div>
+          @for (checkboxItem of checkboxList; track checkboxItem) {
+            <div [class]="options?.htmlClass || ''">
+              <input type="checkbox"
+                [attr.required]="options?.required"
+                [checked]="checkboxItem.checked"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+                [name]="checkboxItem?.name"
+                [readonly]="options?.readonly ? 'readonly' : null"
+                [value]="checkboxItem.value"
+                (change)="updateValue($event, checkboxItem)">
+              <label
+                [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+                [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                  (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                  (' ' + (options?.style?.unselected || '')))"
+                [innerHTML]="checkboxItem.name"></label>
+            </div>
+          }
+        </div>
+      }
     }
 
     @if (layoutOrientation === 'vertical') {

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
@@ -1,0 +1,76 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CheckboxesComponent } from '@ajsf/core';
+
+/**
+ * Bootstrap 4 splits these two ways, so this template does too.
+ *
+ * Vertical checkboxes take the sibling form, which is what Bootstrap 4
+ * documents for .form-check. The horizontal branch serves checkboxes-inline
+ * and checkboxbuttons, and keeps the input inside the label: Bootstrap 4's
+ * toggle buttons are .btn-group-toggle with a nested input, and it has no
+ * .btn-check. That is deliberate, not a widget that was missed.
+ *
+ * Template only. No constructor.
+ */
+@Component({
+  selector: 'bootstrap4-checkboxes-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+  template: `
+    @if (options?.title) {
+      <label
+        [class]="options?.labelHtmlClass || ''"
+        [style.display]="options?.notitle ? 'none' : ''"
+        [innerHTML]="options?.title"></label>
+    }
+
+    @if (layoutOrientation === 'horizontal') {
+      <div [class]="options?.htmlClass || ''">
+        @for (checkboxItem of checkboxList; track checkboxItem) {
+          <label
+            [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+            [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+              (' ' + (options?.style?.unselected || '')))">
+            <input type="checkbox"
+              [attr.required]="options?.required"
+              [checked]="checkboxItem.checked"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [name]="checkboxItem?.name"
+              [readonly]="options?.readonly ? 'readonly' : null"
+              [value]="checkboxItem.value"
+              (change)="updateValue($event, checkboxItem)">
+            <span [innerHTML]="checkboxItem.name"></span>
+          </label>
+        }
+      </div>
+    }
+
+    @if (layoutOrientation === 'vertical') {
+      <div>
+        @for (checkboxItem of checkboxList; track checkboxItem) {
+          <div [class]="options?.htmlClass || ''">
+            <input type="checkbox"
+              [attr.required]="options?.required"
+              [checked]="checkboxItem.checked"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [name]="checkboxItem?.name"
+              [readonly]="options?.readonly ? 'readonly' : null"
+              [value]="checkboxItem.value"
+              (change)="updateValue($event, checkboxItem)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="checkboxItem.name"></label>
+          </div>
+        }
+      </div>
+    }`,
+})
+export class Bootstrap4CheckboxesComponent extends CheckboxesComponent {}

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
@@ -1,0 +1,110 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RadiosComponent } from '@ajsf/core';
+
+/**
+ * Bootstrap 4 splits these two ways, so this template does too.
+ *
+ * Vertical radios take the sibling form, which is what Bootstrap 4
+ * documents for .form-check. The horizontal branch splits again on
+ * layoutNode.type: radios-inline is .form-check.form-check-inline, the
+ * same sibling shape as vertical, while radiobuttons keeps the input
+ * inside the label, because Bootstrap 4's toggle buttons are
+ * .btn-group-toggle with a nested input and it has no .btn-check. That is
+ * deliberate, not a widget that was missed.
+ *
+ * Template only. No constructor.
+ */
+@Component({
+  selector: 'bootstrap4-radios-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+  template: `
+    @if (options?.title) {
+      <label
+        [attr.for]="'control' + layoutNode?._id"
+        [class]="options?.labelHtmlClass || ''"
+        [style.display]="options?.notitle ? 'none' : ''"
+        [innerHTML]="options?.title"></label>
+    }
+
+    @if (layoutOrientation === 'horizontal') {
+      @if (layoutNode?.type === 'radiobuttons') {
+        <div [class]="options?.htmlClass || ''">
+          @for (radioItem of radiosList; track radioItem) {
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [class]="(options?.itemLabelHtmlClass || '') +
+                ((controlValue + '' === radioItem?.value + '') ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))">
+              <input type="radio"
+                [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+                [attr.readonly]="options?.readonly ? 'readonly' : null"
+                [attr.required]="options?.required"
+                [checked]="radioItem?.value === controlValue"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+                [name]="controlName"
+                [value]="radioItem?.value"
+                (change)="updateValue($event)">
+              <span [innerHTML]="radioItem?.name"></span>
+            </label>
+          }
+        </div>
+      } @else {
+        <div>
+          @for (radioItem of radiosList; track radioItem) {
+            <div [class]="options?.htmlClass || ''">
+              <input type="radio"
+                [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+                [attr.readonly]="options?.readonly ? 'readonly' : null"
+                [attr.required]="options?.required"
+                [checked]="radioItem?.value === controlValue"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+                [name]="controlName"
+                [value]="radioItem?.value"
+                (change)="updateValue($event)">
+              <label
+                [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+                [class]="(options?.itemLabelHtmlClass || '') +
+                  ((controlValue + '' === radioItem?.value + '') ?
+                  (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                  (' ' + (options?.style?.unselected || '')))"
+                [innerHTML]="radioItem?.name"></label>
+            </div>
+          }
+        </div>
+      }
+    }
+
+    @if (layoutOrientation !== 'horizontal') {
+      <div>
+        @for (radioItem of radiosList; track radioItem) {
+          <div [class]="options?.htmlClass || ''">
+            <input type="radio"
+              [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+              [attr.readonly]="options?.readonly ? 'readonly' : null"
+              [attr.required]="options?.required"
+              [checked]="radioItem?.value === controlValue"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [name]="controlName"
+              [value]="radioItem?.value"
+              (change)="updateValue($event)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [class]="(options?.itemLabelHtmlClass || '') +
+                ((controlValue + '' === radioItem?.value + '') ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="radioItem?.name"></label>
+          </div>
+        }
+      </div>
+    }`,
+})
+export class Bootstrap4RadiosComponent extends RadiosComponent {}

--- a/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
@@ -1,10 +1,13 @@
 import { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
 import { Bootstrap4CheckboxesComponent } from './bootstrap4-checkboxes.component';
+import { Bootstrap4RadiosComponent } from './bootstrap4-radios.component';
 
 export { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
 export { Bootstrap4CheckboxesComponent } from './bootstrap4-checkboxes.component';
+export { Bootstrap4RadiosComponent } from './bootstrap4-radios.component';
 
 export const BOOTSTRAP4_FRAMEWORK_COMPONENTS = [
   Bootstrap4CheckboxComponent,
   Bootstrap4CheckboxesComponent,
+  Bootstrap4RadiosComponent,
 ];

--- a/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
@@ -1,7 +1,10 @@
 import { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
+import { Bootstrap4CheckboxesComponent } from './bootstrap4-checkboxes.component';
 
 export { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
+export { Bootstrap4CheckboxesComponent } from './bootstrap4-checkboxes.component';
 
 export const BOOTSTRAP4_FRAMEWORK_COMPONENTS = [
   Bootstrap4CheckboxComponent,
+  Bootstrap4CheckboxesComponent,
 ];

--- a/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/public_api.ts
@@ -1,0 +1,7 @@
+import { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
+
+export { Bootstrap4CheckboxComponent } from './bootstrap4-checkbox.component';
+
+export const BOOTSTRAP4_FRAMEWORK_COMPONENTS = [
+  Bootstrap4CheckboxComponent,
+];

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -1,0 +1,74 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Bootstrap4FrameworkModule } from '../bootstrap4-framework.module';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap4FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form [form]="form" framework="bootstrap-4"></json-schema-form>`,
+})
+class MarkupHost {
+  form: any;
+}
+
+describe('Bootstrap 4 check and radio markup', () => {
+  let fixture: ComponentFixture<MarkupHost>;
+
+  const renderForm = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(MarkupHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [MarkupHost] }).compileComponents();
+  });
+
+  describe('single checkbox', () => {
+    const form = {
+      schema: { accept: { type: 'boolean', title: 'Accept' } },
+      form: [{ key: 'accept', type: 'checkbox' }],
+    };
+
+    it('renders the input and its label as siblings', () => {
+      const input = renderForm(form).querySelector('input[type=checkbox]');
+      const label = input.parentElement.querySelector('label');
+      expect(input, 'the checkbox should render').toBeTruthy();
+      expect(label, 'the label should be a sibling, not an ancestor').toBeTruthy();
+      expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+    });
+
+    it('pairs label[for] with input[id]', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]');
+      const label = el.querySelector('label');
+      expect(input.getAttribute('id')).toBeTruthy();
+      expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+    });
+
+    it('classes them as Bootstrap 4 documents, not as Bootstrap 3', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]');
+      const label = el.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+      expect(input.closest('.checkbox'), 'the Bootstrap 3 wrapper class is gone').toBeNull();
+    });
+
+    it('still toggles the control when the label is clicked', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+      const before = input.checked;
+      (el.querySelector('label') as HTMLLabelElement).click();
+      fixture.detectChanges();
+      expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
+    });
+  });
+});

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -1,15 +1,41 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { JsonSchemaFormService } from '@ajsf/core';
 import { Bootstrap4FrameworkModule } from '../bootstrap4-framework.module';
 
 @Component({
   standalone: true,
   imports: [Bootstrap4FrameworkModule],
   changeDetection: ChangeDetectionStrategy.Eager,
-  template: `<json-schema-form [form]="form" framework="bootstrap-4"></json-schema-form>`,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-4"
+    (onChanges)="value = $event"></json-schema-form>`,
 })
 class MarkupHost {
   form: any;
+  value: any;
+}
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap4FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<bootstrap4-checkboxes-widget
+      [layoutNode]="checkboxes" [dataIndex]="[]" [layoutIndex]="[]"></bootstrap4-checkboxes-widget>
+    <bootstrap4-radios-widget
+      [layoutNode]="radios" [dataIndex]="[]" [layoutIndex]="[]"></bootstrap4-radios-widget>`,
+  providers: [JsonSchemaFormService],
+})
+class StandaloneHost {
+  checkboxes: any = {
+    _id: 1, type: 'checkboxes', dataPointer: '/colours',
+    options: { title: 'Colours', enum: ['red', 'green'] },
+  };
+  radios: any = {
+    _id: 2, type: 'radios', dataPointer: '/size',
+    options: { title: 'Size', enum: ['small', 'large'] },
+  };
 }
 
 describe('Bootstrap 4 check and radio markup', () => {
@@ -69,6 +95,23 @@ describe('Bootstrap 4 check and radio markup', () => {
       (el.querySelector('label') as HTMLLabelElement).click();
       fixture.detectChanges();
       expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
+    });
+
+    // A layout item with no key gets no form control, and the widget renders
+    // its unbound input instead, which is a second copy of the markup.
+    it('renders the unbound input as a sibling too', () => {
+      const el = renderForm({
+        schema: { accept: { type: 'boolean', title: 'Accept' } },
+        form: [{ type: 'checkbox', title: 'Accept' }],
+      });
+      const input = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+      const label = input.parentElement.querySelector('label');
+      expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+      expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      expect(input.className).toContain('form-check-input');
+      (label as HTMLLabelElement).click();
+      fixture.detectChanges();
+      expect(input.checked, 'clicking the label should still reach the input').toBe(true);
     });
   });
 
@@ -138,6 +181,17 @@ describe('Bootstrap 4 check and radio markup', () => {
           'a shared wrapper would hold every input').toEqual(1);
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
+      });
+    });
+
+    it('reports the clicked value from every layout variant', () => {
+      ['checkboxes', 'checkboxes-inline', 'checkboxbuttons'].forEach((type) => {
+        const el = renderForm({ ...form, form: [{ key: 'colours', type }] });
+        const red = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+        (el.querySelector(`label[for="${red.id}"]`) as HTMLLabelElement).click();
+        fixture.detectChanges();
+        expect(fixture.componentInstance.value.colours,
+          `${type} should report the item the label points at`).toEqual(['red']);
       });
     });
   });
@@ -212,6 +266,47 @@ describe('Bootstrap 4 check and radio markup', () => {
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
       });
+    });
+
+    it('reports the clicked value from every layout variant', () => {
+      ['radios', 'radios-inline', 'radiobuttons'].forEach((type) => {
+        const el = renderForm({ ...form, form: [{ key: 'size', type }] });
+        const large = [...el.querySelectorAll('input[type=radio]')].pop() as HTMLInputElement;
+        (el.querySelector(`label[for="${large.id}"]`) as HTMLLabelElement).click();
+        fixture.detectChanges();
+        expect(fixture.componentInstance.value.size,
+          `${type} should report the item the label points at`).toEqual('large');
+      });
+    });
+  });
+
+  // The framework component renders the group title itself and blanks the one
+  // it passes on, so this title only appears when the widget is used directly,
+  // which the package's public API allows.
+  describe('a widget used without the framework', () => {
+    const render = (): HTMLElement => {
+      const standalone = TestBed.createComponent(StandaloneHost);
+      standalone.detectChanges();
+      return standalone.nativeElement;
+    };
+
+    it('renders its own group title', () => {
+      const el = render();
+      const checkboxes = el.querySelector('bootstrap4-checkboxes-widget');
+      const radios = el.querySelector('bootstrap4-radios-widget');
+      expect(checkboxes.querySelector('label').textContent).toEqual('Colours');
+      expect(radios.querySelector('label').textContent).toEqual('Size');
+      expect(checkboxes.querySelectorAll('input').length,
+        'the items should render beneath the title').toEqual(2);
+    });
+
+    it('hides the group title when notitle is set', () => {
+      const standalone = TestBed.createComponent(StandaloneHost);
+      standalone.componentInstance.checkboxes.options.notitle = true;
+      standalone.detectChanges();
+      const title = standalone.nativeElement
+        .querySelector('bootstrap4-checkboxes-widget label') as HTMLElement;
+      expect(title.style.display, 'notitle should hide the title, not drop it').toEqual('none');
     });
   });
 });

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -71,4 +71,49 @@ describe('Bootstrap 4 check and radio markup', () => {
       expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
     });
   });
+
+  describe('checkbox list', () => {
+    const form = {
+      schema: {
+        colours: { type: 'array', title: 'Colours', items: { type: 'string', enum: ['red', 'green'] } },
+      },
+      form: [{ key: 'colours', type: 'checkboxes' }],
+    };
+
+    it('renders every item as an input beside its own label', () => {
+      const el = renderForm(form);
+      const inputs = [...el.querySelectorAll('input[type=checkbox]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      });
+    });
+
+    it('classes each item as Bootstrap 4 documents', () => {
+      const input = renderForm(form).querySelector('input[type=checkbox]');
+      const label = input.parentElement.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+    });
+
+    // Bootstrap 4 has no btn-check. Its toggle buttons keep the input inside
+    // the label, so this exception is asserted rather than assumed.
+    it('keeps the input inside the label for button sets, as Bootstrap 4 documents', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'colours', type: 'checkboxbuttons' }],
+      });
+      const input = el.querySelector('input[type=checkbox]');
+      const label = input.closest('label');
+      expect(label, 'a Bootstrap 4 toggle button wraps its input').toBeTruthy();
+    });
+  });
 });

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -115,5 +115,28 @@ describe('Bootstrap 4 check and radio markup', () => {
       const label = input.closest('label');
       expect(label, 'a Bootstrap 4 toggle button wraps its input').toBeTruthy();
     });
+
+    it('renders inline checkboxes as siblings, as Bootstrap 4 documents', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'colours', type: 'checkboxes-inline' }],
+      });
+      const inputs = [...el.querySelectorAll('input[type=checkbox]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+
+        const wrapper = input.closest('.form-check-inline');
+        expect(wrapper, 'the input must sit inside a form-check-inline element').toBeTruthy();
+        expect(label.closest('.form-check-inline')).toBe(wrapper);
+        expect(wrapper.parentElement.closest('.form-check-inline'),
+          'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(input.className).toContain('form-check-input');
+        expect(label.className).toContain('form-check-label');
+      });
+    });
   });
 });

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -139,4 +139,61 @@ describe('Bootstrap 4 check and radio markup', () => {
       });
     });
   });
+
+  describe('radio list', () => {
+    const form = {
+      schema: { size: { type: 'string', title: 'Size', enum: ['small', 'large'] } },
+      form: [{ key: 'size', type: 'radios' }],
+    };
+
+    it('renders every item as an input beside its own label', () => {
+      const el = renderForm(form);
+      const inputs = [...el.querySelectorAll('input[type=radio]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      });
+    });
+
+    it('classes each item as Bootstrap 4 documents', () => {
+      const input = renderForm(form).querySelector('input[type=radio]');
+      const label = input.parentElement.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+    });
+
+    it('keeps the input inside the label for button sets, as Bootstrap 4 documents', () => {
+      const el = renderForm({ ...form, form: [{ key: 'size', type: 'radiobuttons' }] });
+      const input = el.querySelector('input[type=radio]');
+      expect(input.closest('label'), 'a Bootstrap 4 toggle button wraps its input').toBeTruthy();
+    });
+
+    it('renders inline radios as siblings, as Bootstrap 4 documents', () => {
+      const el = renderForm({ ...form, form: [{ key: 'size', type: 'radios-inline' }] });
+      const inputs = [...el.querySelectorAll('input[type=radio]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+
+        const wrapper = input.closest('.form-check-inline');
+        expect(wrapper, 'the input must sit inside a form-check-inline element').toBeTruthy();
+        expect(label.closest('.form-check-inline')).toBe(wrapper);
+        expect(wrapper.parentElement.closest('.form-check-inline'),
+          'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(input.className).toContain('form-check-input');
+        expect(label.className).toContain('form-check-label');
+      });
+    });
+  });
 });

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -170,6 +170,23 @@ describe('Bootstrap 4 check and radio markup', () => {
       expect(label.className).toContain('form-check-label');
     });
 
+    // The 'radios' control is a plain FormControl, so a layout-level
+    // disabled flag reaches formControl.disabled and, through it, every
+    // rendered input. The 'checkboxes' control is a FormArray instead, which
+    // core never disables from that same flag, so there is no equivalent
+    // assertion for the checkbox list.
+    it('disables every rendered input when the control is disabled', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'size', type: 'radios', disabled: true }],
+      });
+      const inputs = [...el.querySelectorAll('input[type=radio]')] as HTMLInputElement[];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        expect(input.disabled, 'the disabled attribute belongs on the input').toBe(true);
+      });
+    });
+
     it('keeps the input inside the label for button sets, as Bootstrap 4 documents', () => {
       const el = renderForm({ ...form, form: [{ key: 'size', type: 'radiobuttons' }] });
       const input = el.querySelector('input[type=radio]');

--- a/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/widget-markup.spec.ts
@@ -134,6 +134,8 @@ describe('Bootstrap 4 check and radio markup', () => {
         expect(label.closest('.form-check-inline')).toBe(wrapper);
         expect(wrapper.parentElement.closest('.form-check-inline'),
           'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(wrapper.querySelectorAll('input').length,
+          'a shared wrapper would hold every input').toEqual(1);
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
       });
@@ -170,11 +172,8 @@ describe('Bootstrap 4 check and radio markup', () => {
       expect(label.className).toContain('form-check-label');
     });
 
-    // The 'radios' control is a plain FormControl, so a layout-level
-    // disabled flag reaches formControl.disabled and, through it, every
-    // rendered input. The 'checkboxes' control is a FormArray instead, which
-    // core never disables from that same flag, so there is no equivalent
-    // assertion for the checkbox list.
+    // A checkbox list is a FormArray, which core never disables from this
+    // flag, so only the radio list can assert it.
     it('disables every rendered input when the control is disabled', () => {
       const el = renderForm({
         ...form,
@@ -208,6 +207,8 @@ describe('Bootstrap 4 check and radio markup', () => {
         expect(label.closest('.form-check-inline')).toBe(wrapper);
         expect(wrapper.parentElement.closest('.form-check-inline'),
           'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(wrapper.querySelectorAll('input').length,
+          'a shared wrapper would hold every input').toEqual(1);
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
       });

--- a/projects/ajsf-bootstrap4/src/public_api.ts
+++ b/projects/ajsf-bootstrap4/src/public_api.ts
@@ -5,3 +5,4 @@
 export * from './lib/bootstrap4-framework.module';
 export * from './lib/bootstrap4-framework.component';
 export * from './lib/bootstrap4.framework';
+export * from './lib/widgets/public_api';

--- a/projects/ajsf-bootstrap5/README.md
+++ b/projects/ajsf-bootstrap5/README.md
@@ -53,6 +53,26 @@ Where `schema` is a valid JSON schema object, and `onSubmit` calls a function to
 * `bootstrap-5` for 'Bootstrap 5.
 * `no-framework` for (plain HTML).
 
+## Checkbox and radio structure, changed in 22.1.0
+
+Checkboxes and radios previously rendered the `<input>` inside its `<label>`,
+which is the Bootstrap 3 shape this package was copied from. They now render
+as siblings inside a `.form-check` wrapper, which is what Bootstrap 5
+documents and what its state styling requires:
+
+    <div class="form-check">
+      <input class="form-check-input" id="control1" type="checkbox">
+      <label class="form-check-label" for="control1">Accept</label>
+    </div>
+
+Every variant takes this sibling shape, including toggle buttons
+(`checkboxbuttons`, `radiobuttons`) and the inline forms (`checkboxes-inline`,
+`radios-inline`), because Bootstrap 5 styles its `.btn-check` toggle buttons
+through a sibling input too, unlike Bootstrap 4's nested `.btn-group-toggle`.
+
+If you wrote CSS selecting `label > input` or styling the label as the
+control's ancestor, that is where the difference is.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap5` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap5`.

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -190,7 +190,8 @@ describe('FwBootstrap5Component', () => {
     it('uses a live Bootstrap 5 button class for button sets', () => {
       const { widgetOptions } = initialize('radiobuttons');
       expect(widgetOptions.itemLabelHtmlClass).toContain('btn-outline-primary');
-      expect(widgetOptions.fieldHtmlClass).toContain('visually-hidden');
+      expect(widgetOptions.fieldHtmlClass).toContain('btn-check');
+      expect(widgetOptions.fieldHtmlClass).not.toContain('visually-hidden');
       expect(widgetOptions.fieldHtmlClass).not.toContain('sr-only');
     });
   });

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -156,13 +156,20 @@ describe('FwBootstrap5Component', () => {
       expect(radios.widgetOptions.fieldHtmlClass).toContain('form-check-input');
     });
 
-    it('marks inline checks and radios with form-check-inline', () => {
-      for (const type of ['checkboxes-inline', 'radios-inline']) {
-        const { widgetOptions } = initialize(type);
-        expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-inline');
-        expect(widgetOptions.itemLabelHtmlClass).not.toContain('checkbox-inline');
-        expect(widgetOptions.itemLabelHtmlClass).not.toContain('radio-inline');
-      }
+    it('marks the inline checkbox list with form-check-inline on its wrapper', () => {
+      // Sibling markup: the wrapper div is the input's ancestor, the label is
+      // not, so the class has to live on htmlClass rather than on the label.
+      const { widgetOptions } = initialize('checkboxes-inline');
+      expect(widgetOptions.htmlClass).toContain('form-check-inline');
+      expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-label');
+      expect(widgetOptions.itemLabelHtmlClass).not.toContain('form-check-inline');
+      expect(widgetOptions.htmlClass).not.toContain('checkbox-inline');
+    });
+
+    it('marks inline radios with form-check-inline', () => {
+      const { widgetOptions } = initialize('radios-inline');
+      expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-inline');
+      expect(widgetOptions.itemLabelHtmlClass).not.toContain('radio-inline');
     });
 
     it('stops emitting the Bootstrap 3 checkbox and radio classes', () => {

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -196,8 +196,8 @@ describe('FwBootstrap5Component', () => {
     });
   });
 
-  // The single checkbox has no element of its own carrying htmlClass, so
-  // .form-check has to come from the framework's own wrapper div.
+  // The switch below never puts .form-check on htmlClass for a single
+  // checkbox, so it has to come from the framework's own wrapper div.
   describe('single checkbox wrapper', () => {
     const render = (node: any) => {
       component.layoutNode = node;

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.spec.ts
@@ -166,10 +166,14 @@ describe('FwBootstrap5Component', () => {
       expect(widgetOptions.htmlClass).not.toContain('checkbox-inline');
     });
 
-    it('marks inline radios with form-check-inline', () => {
+    it('marks inline radios with form-check-inline on its wrapper', () => {
+      // Sibling markup: the wrapper div is the input's ancestor, the label is
+      // not, so the class has to live on htmlClass rather than on the label.
       const { widgetOptions } = initialize('radios-inline');
-      expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-inline');
-      expect(widgetOptions.itemLabelHtmlClass).not.toContain('radio-inline');
+      expect(widgetOptions.htmlClass).toContain('form-check-inline');
+      expect(widgetOptions.itemLabelHtmlClass).toContain('form-check-label');
+      expect(widgetOptions.itemLabelHtmlClass).not.toContain('form-check-inline');
+      expect(widgetOptions.htmlClass).not.toContain('radio-inline');
     });
 
     it('stops emitting the Bootstrap 3 checkbox and radio classes', () => {

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -130,8 +130,9 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
       // Set miscelaneous styles and settings for each control type
       switch (this.layoutNode.type) {
         // Checkbox controls
-        // CheckboxComponent renders no element carrying htmlClass, so the
-        // single checkbox takes .form-check from the framework's own div.
+        // The framework template puts [class.form-check]="isSingleCheck" on
+        // its own wrapper div, so the single checkbox takes .form-check from
+        // there rather than from this switch.
         case 'checkbox':
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'form-check-input');
@@ -182,8 +183,6 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
           this.widgetOptions.itemLabelHtmlClass = addClasses(
             this.widgetOptions.itemLabelHtmlClass,
             this.options.style || 'btn-outline-primary');
-          this.widgetOptions.fieldHtmlClass = addClasses(
-            this.widgetOptions.fieldHtmlClass, 'visually-hidden');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'btn-check');
           break;

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -165,11 +165,12 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
             this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'radios-inline':
+          this.widgetOptions.htmlClass = addClasses(
+            this.widgetOptions.htmlClass, 'form-check form-check-inline');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass,
-            'form-check form-check-inline form-check-label');
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         // Button sets - checkboxbuttons and radiobuttons
         case 'checkboxbuttons':

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -147,11 +147,12 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
             this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         case 'checkboxes-inline':
+          this.widgetOptions.htmlClass = addClasses(
+            this.widgetOptions.htmlClass, 'form-check form-check-inline');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'form-check-input');
           this.widgetOptions.itemLabelHtmlClass = addClasses(
-            this.widgetOptions.itemLabelHtmlClass,
-            'form-check form-check-inline form-check-label');
+            this.widgetOptions.itemLabelHtmlClass, 'form-check-label');
           break;
         // Radio controls
         case 'radio':
@@ -182,6 +183,8 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
             this.options.style || 'btn-outline-primary');
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'visually-hidden');
+          this.widgetOptions.fieldHtmlClass = addClasses(
+            this.widgetOptions.fieldHtmlClass, 'btn-check');
           break;
         // Single button controls
         case 'button':

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
@@ -10,8 +10,7 @@ import {
 } from '@ajsf/core';
 import {Bootstrap5Framework} from './bootstrap5.framework';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
-import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
-import {Bootstrap5CheckboxesComponent} from './widgets/bootstrap5-checkboxes.component';
+import {BOOTSTRAP5_FRAMEWORK_COMPONENTS} from './widgets/public_api';
 
 @NgModule({
     imports: [
@@ -21,14 +20,12 @@ import {Bootstrap5CheckboxesComponent} from './widgets/bootstrap5-checkboxes.com
     ],
     declarations: [
         Bootstrap5FrameworkComponent,
-        Bootstrap5CheckboxComponent,
-        Bootstrap5CheckboxesComponent,
+        ...BOOTSTRAP5_FRAMEWORK_COMPONENTS,
     ],
     exports: [
         JsonSchemaFormModule,
         Bootstrap5FrameworkComponent,
-        Bootstrap5CheckboxComponent,
-        Bootstrap5CheckboxesComponent,
+        ...BOOTSTRAP5_FRAMEWORK_COMPONENTS,
     ],
     providers: [
         JsonSchemaFormService,

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
@@ -11,6 +11,7 @@ import {
 import {Bootstrap5Framework} from './bootstrap5.framework';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
 import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
+import {Bootstrap5CheckboxesComponent} from './widgets/bootstrap5-checkboxes.component';
 
 @NgModule({
     imports: [
@@ -21,11 +22,13 @@ import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.compone
     declarations: [
         Bootstrap5FrameworkComponent,
         Bootstrap5CheckboxComponent,
+        Bootstrap5CheckboxesComponent,
     ],
     exports: [
         JsonSchemaFormModule,
         Bootstrap5FrameworkComponent,
         Bootstrap5CheckboxComponent,
+        Bootstrap5CheckboxesComponent,
     ],
     providers: [
         JsonSchemaFormService,

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.module.ts
@@ -10,6 +10,7 @@ import {
 } from '@ajsf/core';
 import {Bootstrap5Framework} from './bootstrap5.framework';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
+import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
 
 @NgModule({
     imports: [
@@ -19,10 +20,12 @@ import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
     ],
     declarations: [
         Bootstrap5FrameworkComponent,
+        Bootstrap5CheckboxComponent,
     ],
     exports: [
         JsonSchemaFormModule,
         Bootstrap5FrameworkComponent,
+        Bootstrap5CheckboxComponent,
     ],
     providers: [
         JsonSchemaFormService,

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {Framework} from '@ajsf/core';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
 import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
+import {Bootstrap5CheckboxesComponent} from './widgets/bootstrap5-checkboxes.component';
 
 // Bootstrap 5 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -14,6 +15,7 @@ export class Bootstrap5Framework extends Framework {
 
   widgets = {
     'checkbox': Bootstrap5CheckboxComponent,
+    'checkboxes': Bootstrap5CheckboxesComponent,
   };
 
   stylesheets = [

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Framework} from '@ajsf/core';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
+import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
 
 // Bootstrap 5 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -10,6 +11,10 @@ export class Bootstrap5Framework extends Framework {
   name = 'bootstrap-5';
 
   framework = Bootstrap5FrameworkComponent;
+
+  widgets = {
+    'checkbox': Bootstrap5CheckboxComponent,
+  };
 
   stylesheets = [
     '//cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css'

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5.framework.ts
@@ -3,6 +3,7 @@ import {Framework} from '@ajsf/core';
 import {Bootstrap5FrameworkComponent} from './bootstrap5-framework.component';
 import {Bootstrap5CheckboxComponent} from './widgets/bootstrap5-checkbox.component';
 import {Bootstrap5CheckboxesComponent} from './widgets/bootstrap5-checkboxes.component';
+import {Bootstrap5RadiosComponent} from './widgets/bootstrap5-radios.component';
 
 // Bootstrap 5 Framework
 // https://github.com/ng-bootstrap/ng-bootstrap
@@ -16,6 +17,7 @@ export class Bootstrap5Framework extends Framework {
   widgets = {
     'checkbox': Bootstrap5CheckboxComponent,
     'checkboxes': Bootstrap5CheckboxesComponent,
+    'radios': Bootstrap5RadiosComponent,
   };
 
   stylesheets = [

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CheckboxComponent } from '@ajsf/core';
 
 /**
@@ -11,6 +11,7 @@ import { CheckboxComponent } from '@ajsf/core';
  */
 @Component({
   selector: 'bootstrap5-checkbox-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
   template: `
     <div [class]="options?.htmlClass || ''">

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+import { CheckboxComponent } from '@ajsf/core';
+
+/**
+ * Bootstrap 5 wants the input and label as siblings inside .form-check, and
+ * styles the input's state through sibling selectors. The core widget nests
+ * the input inside the label, which is the Bootstrap 3 shape.
+ *
+ * Template only. No constructor: Angular inherits the base's injection
+ * through its generated factory, and adding one would break that.
+ */
+@Component({
+  selector: 'bootstrap5-checkbox-widget',
+  standalone: false,
+  template: `
+    <div [class]="options?.htmlClass || ''">
+      @if (boundControl) {
+        <input
+          [formControl]="formControl"
+          [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+          [class]="(options?.fieldHtmlClass || '') + (isChecked ?
+            (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+            (' ' + (options?.style?.unselected || '')))"
+          [id]="'control' + layoutNode?._id"
+          [name]="controlName"
+          [readonly]="options?.readonly ? 'readonly' : null"
+          type="checkbox">
+      }
+      @if (!boundControl) {
+        <input
+          [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+          [checked]="isChecked ? 'checked' : null"
+          [class]="(options?.fieldHtmlClass || '') + (isChecked ?
+            (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+            (' ' + (options?.style?.unselected || '')))"
+          [disabled]="controlDisabled"
+          [id]="'control' + layoutNode?._id"
+          [name]="controlName"
+          [readonly]="options?.readonly ? 'readonly' : null"
+          [value]="controlValue"
+          type="checkbox"
+          (change)="updateValue($event)">
+      }
+      <label
+        [attr.for]="'control' + layoutNode?._id"
+        [class]="options?.itemLabelHtmlClass || ''">
+        @if (options?.title) {
+          <span
+            [style.display]="options?.notitle ? 'none' : ''"
+            [innerHTML]="options?.title"></span>
+        }
+      </label>
+    </div>`,
+})
+export class Bootstrap5CheckboxComponent extends CheckboxComponent {}

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
@@ -1,0 +1,74 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CheckboxesComponent } from '@ajsf/core';
+
+/**
+ * Sibling input and label per item, for checkboxes, checkboxes-inline and
+ * checkboxbuttons alike. Bootstrap 5 replaced the nested toggle-button idiom
+ * with btn-check, so all three variants take the same shape here.
+ *
+ * activeClass and style.selected stay on the label, where the core widget
+ * puts them, so the button idiom keeps working.
+ *
+ * Template only. No constructor.
+ */
+@Component({
+  selector: 'bootstrap5-checkboxes-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+  template: `
+    @if (options?.title) {
+      <label
+        [class]="options?.labelHtmlClass || ''"
+        [style.display]="options?.notitle ? 'none' : ''"
+        [innerHTML]="options?.title"></label>
+    }
+
+    @if (layoutOrientation === 'horizontal') {
+      <div [class]="options?.htmlClass || ''">
+        @for (checkboxItem of checkboxList; track checkboxItem) {
+          <input type="checkbox"
+            [attr.required]="options?.required"
+            [checked]="checkboxItem.checked"
+            [class]="options?.fieldHtmlClass || ''"
+            [disabled]="controlDisabled"
+            [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+            [name]="checkboxItem?.name"
+            [readonly]="options?.readonly ? 'readonly' : null"
+            [value]="checkboxItem.value"
+            (change)="updateValue($event, checkboxItem)">
+          <label
+            [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+            [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+              (' ' + (options?.style?.unselected || '')))"
+            [innerHTML]="checkboxItem.name"></label>
+        }
+      </div>
+    }
+
+    @if (layoutOrientation === 'vertical') {
+      <div>
+        @for (checkboxItem of checkboxList; track checkboxItem) {
+          <div [class]="options?.htmlClass || ''">
+            <input type="checkbox"
+              [attr.required]="options?.required"
+              [checked]="checkboxItem.checked"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [name]="checkboxItem?.name"
+              [readonly]="options?.readonly ? 'readonly' : null"
+              [value]="checkboxItem.value"
+              (change)="updateValue($event, checkboxItem)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="checkboxItem.name"></label>
+          </div>
+        }
+      </div>
+    }`,
+})
+export class Bootstrap5CheckboxesComponent extends CheckboxesComponent {}

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
@@ -3,8 +3,12 @@ import { CheckboxesComponent } from '@ajsf/core';
 
 /**
  * Sibling input and label per item, for checkboxes, checkboxes-inline and
- * checkboxbuttons alike. Bootstrap 5 replaced the nested toggle-button idiom
- * with btn-check, so all three variants take the same shape here.
+ * checkboxbuttons alike. The horizontal branch splits on layoutNode.type:
+ * checkboxbuttons keeps the one shared wrapper, because btn-group belongs on
+ * a single element around the whole set and Bootstrap 5's btn-check idiom is
+ * a sibling input there too. checkboxes-inline gives each item its own
+ * wrapper, because Bootstrap 5 documents one .form-check.form-check-inline
+ * per item, not one around the whole set.
  *
  * activeClass and style.selected stay on the label, where the core widget
  * puts them, so the button idiom keeps working.
@@ -24,26 +28,51 @@ import { CheckboxesComponent } from '@ajsf/core';
     }
 
     @if (layoutOrientation === 'horizontal') {
-      <div [class]="options?.htmlClass || ''">
-        @for (checkboxItem of checkboxList; track checkboxItem) {
-          <input type="checkbox"
-            [attr.required]="options?.required"
-            [checked]="checkboxItem.checked"
-            [class]="options?.fieldHtmlClass || ''"
-            [disabled]="controlDisabled"
-            [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
-            [name]="checkboxItem?.name"
-            [readonly]="options?.readonly ? 'readonly' : null"
-            [value]="checkboxItem.value"
-            (change)="updateValue($event, checkboxItem)">
-          <label
-            [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
-            [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
-              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
-              (' ' + (options?.style?.unselected || '')))"
-            [innerHTML]="checkboxItem.name"></label>
-        }
-      </div>
+      @if (layoutNode?.type === 'checkboxbuttons') {
+        <div [class]="options?.htmlClass || ''">
+          @for (checkboxItem of checkboxList; track checkboxItem) {
+            <input type="checkbox"
+              [attr.required]="options?.required"
+              [checked]="checkboxItem.checked"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [name]="checkboxItem?.name"
+              [readonly]="options?.readonly ? 'readonly' : null"
+              [value]="checkboxItem.value"
+              (change)="updateValue($event, checkboxItem)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+              [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="checkboxItem.name"></label>
+          }
+        </div>
+      } @else {
+        <div>
+          @for (checkboxItem of checkboxList; track checkboxItem) {
+            <div [class]="options?.htmlClass || ''">
+              <input type="checkbox"
+                [attr.required]="options?.required"
+                [checked]="checkboxItem.checked"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+                [name]="checkboxItem?.name"
+                [readonly]="options?.readonly ? 'readonly' : null"
+                [value]="checkboxItem.value"
+                (change)="updateValue($event, checkboxItem)">
+              <label
+                [attr.for]="'control' + layoutNode?._id + '/' + checkboxItem.value"
+                [class]="(options?.itemLabelHtmlClass || '') + (checkboxItem.checked ?
+                  (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                  (' ' + (options?.style?.unselected || '')))"
+                [innerHTML]="checkboxItem.name"></label>
+            </div>
+          }
+        </div>
+      }
     }
 
     @if (layoutOrientation === 'vertical') {

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
@@ -1,0 +1,76 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RadiosComponent } from '@ajsf/core';
+
+/**
+ * Sibling input and label per item, for radios, radios-inline and
+ * radiobuttons alike. Bootstrap 5's btn-check idiom is a sibling input too,
+ * so all three variants take the same shape.
+ *
+ * Template only. No constructor.
+ */
+@Component({
+  selector: 'bootstrap5-radios-widget',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+  template: `
+    @if (options?.title) {
+      <label
+        [attr.for]="'control' + layoutNode?._id"
+        [class]="options?.labelHtmlClass || ''"
+        [style.display]="options?.notitle ? 'none' : ''"
+        [innerHTML]="options?.title"></label>
+    }
+
+    @if (layoutOrientation === 'horizontal') {
+      <div [class]="options?.htmlClass || ''">
+        @for (radioItem of radiosList; track radioItem) {
+          <input type="radio"
+            [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+            [attr.readonly]="options?.readonly ? 'readonly' : null"
+            [attr.required]="options?.required"
+            [checked]="radioItem?.value === controlValue"
+            [class]="options?.fieldHtmlClass || ''"
+            [disabled]="controlDisabled"
+            [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+            [name]="controlName"
+            [value]="radioItem?.value"
+            (change)="updateValue($event)">
+          <label
+            [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+            [class]="(options?.itemLabelHtmlClass || '') +
+              ((controlValue + '' === radioItem?.value + '') ?
+              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+              (' ' + (options?.style?.unselected || '')))"
+            [innerHTML]="radioItem?.name"></label>
+        }
+      </div>
+    }
+
+    @if (layoutOrientation !== 'horizontal') {
+      <div>
+        @for (radioItem of radiosList; track radioItem) {
+          <div [class]="options?.htmlClass || ''">
+            <input type="radio"
+              [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+              [attr.readonly]="options?.readonly ? 'readonly' : null"
+              [attr.required]="options?.required"
+              [checked]="radioItem?.value === controlValue"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [name]="controlName"
+              [value]="radioItem?.value"
+              (change)="updateValue($event)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [class]="(options?.itemLabelHtmlClass || '') +
+                ((controlValue + '' === radioItem?.value + '') ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="radioItem?.name"></label>
+          </div>
+        }
+      </div>
+    }`,
+})
+export class Bootstrap5RadiosComponent extends RadiosComponent {}

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
@@ -3,8 +3,12 @@ import { RadiosComponent } from '@ajsf/core';
 
 /**
  * Sibling input and label per item, for radios, radios-inline and
- * radiobuttons alike. Bootstrap 5's btn-check idiom is a sibling input too,
- * so all three variants take the same shape.
+ * radiobuttons alike. The horizontal branch splits on layoutNode.type:
+ * radiobuttons keeps the one shared wrapper, because btn-group belongs on a
+ * single element around the whole set and Bootstrap 5's btn-check idiom is a
+ * sibling input there too. radios-inline gives each item its own wrapper,
+ * because Bootstrap 5 documents one .form-check.form-check-inline per item,
+ * not one around the whole set.
  *
  * Template only. No constructor.
  */
@@ -22,28 +26,55 @@ import { RadiosComponent } from '@ajsf/core';
     }
 
     @if (layoutOrientation === 'horizontal') {
-      <div [class]="options?.htmlClass || ''">
-        @for (radioItem of radiosList; track radioItem) {
-          <input type="radio"
-            [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
-            [attr.readonly]="options?.readonly ? 'readonly' : null"
-            [attr.required]="options?.required"
-            [checked]="radioItem?.value === controlValue"
-            [class]="options?.fieldHtmlClass || ''"
-            [disabled]="controlDisabled"
-            [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
-            [name]="controlName"
-            [value]="radioItem?.value"
-            (change)="updateValue($event)">
-          <label
-            [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
-            [class]="(options?.itemLabelHtmlClass || '') +
-              ((controlValue + '' === radioItem?.value + '') ?
-              (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
-              (' ' + (options?.style?.unselected || '')))"
-            [innerHTML]="radioItem?.name"></label>
-        }
-      </div>
+      @if (layoutNode?.type === 'radiobuttons') {
+        <div [class]="options?.htmlClass || ''">
+          @for (radioItem of radiosList; track radioItem) {
+            <input type="radio"
+              [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+              [attr.readonly]="options?.readonly ? 'readonly' : null"
+              [attr.required]="options?.required"
+              [checked]="radioItem?.value === controlValue"
+              [class]="options?.fieldHtmlClass || ''"
+              [disabled]="controlDisabled"
+              [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [name]="controlName"
+              [value]="radioItem?.value"
+              (change)="updateValue($event)">
+            <label
+              [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+              [class]="(options?.itemLabelHtmlClass || '') +
+                ((controlValue + '' === radioItem?.value + '') ?
+                (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                (' ' + (options?.style?.unselected || '')))"
+              [innerHTML]="radioItem?.name"></label>
+          }
+        </div>
+      } @else {
+        <div>
+          @for (radioItem of radiosList; track radioItem) {
+            <div [class]="options?.htmlClass || ''">
+              <input type="radio"
+                [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+                [attr.readonly]="options?.readonly ? 'readonly' : null"
+                [attr.required]="options?.required"
+                [checked]="radioItem?.value === controlValue"
+                [class]="options?.fieldHtmlClass || ''"
+                [disabled]="controlDisabled"
+                [id]="'control' + layoutNode?._id + '/' + radioItem?.value"
+                [name]="controlName"
+                [value]="radioItem?.value"
+                (change)="updateValue($event)">
+              <label
+                [attr.for]="'control' + layoutNode?._id + '/' + radioItem?.value"
+                [class]="(options?.itemLabelHtmlClass || '') +
+                  ((controlValue + '' === radioItem?.value + '') ?
+                  (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
+                  (' ' + (options?.style?.unselected || '')))"
+                [innerHTML]="radioItem?.name"></label>
+            </div>
+          }
+        </div>
+      }
     }
 
     @if (layoutOrientation !== 'horizontal') {

--- a/projects/ajsf-bootstrap5/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/public_api.ts
@@ -1,10 +1,13 @@
 import { Bootstrap5CheckboxComponent } from './bootstrap5-checkbox.component';
 import { Bootstrap5CheckboxesComponent } from './bootstrap5-checkboxes.component';
+import { Bootstrap5RadiosComponent } from './bootstrap5-radios.component';
 
 export { Bootstrap5CheckboxComponent } from './bootstrap5-checkbox.component';
 export { Bootstrap5CheckboxesComponent } from './bootstrap5-checkboxes.component';
+export { Bootstrap5RadiosComponent } from './bootstrap5-radios.component';
 
 export const BOOTSTRAP5_FRAMEWORK_COMPONENTS = [
   Bootstrap5CheckboxComponent,
   Bootstrap5CheckboxesComponent,
+  Bootstrap5RadiosComponent,
 ];

--- a/projects/ajsf-bootstrap5/src/lib/widgets/public_api.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/public_api.ts
@@ -1,0 +1,10 @@
+import { Bootstrap5CheckboxComponent } from './bootstrap5-checkbox.component';
+import { Bootstrap5CheckboxesComponent } from './bootstrap5-checkboxes.component';
+
+export { Bootstrap5CheckboxComponent } from './bootstrap5-checkbox.component';
+export { Bootstrap5CheckboxesComponent } from './bootstrap5-checkboxes.component';
+
+export const BOOTSTRAP5_FRAMEWORK_COMPONENTS = [
+  Bootstrap5CheckboxComponent,
+  Bootstrap5CheckboxesComponent,
+];

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -105,14 +105,27 @@ describe('Bootstrap 5 check and radio markup', () => {
       expect(label.className).toContain('form-check-label');
     });
 
-    it('marks the inline variant with form-check-inline', () => {
+    it('renders inline checkboxes as siblings, each in its own wrapper', () => {
       const el = renderForm({
         ...form,
         form: [{ key: 'colours', type: 'checkboxes-inline' }],
       });
-      const input = el.querySelector('input[type=checkbox]');
-      expect(input.closest('.form-check-inline'),
-        'the inline variant wraps items in .form-check-inline').toBeTruthy();
+      const inputs = [...el.querySelectorAll('input[type=checkbox]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+
+        const wrapper = input.closest('.form-check-inline');
+        expect(wrapper, 'the input must sit inside a form-check-inline element').toBeTruthy();
+        expect(label.closest('.form-check-inline')).toBe(wrapper);
+        expect(wrapper.parentElement.closest('.form-check-inline'),
+          'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(input.className).toContain('form-check-input');
+        expect(label.className).toContain('form-check-label');
+      });
     });
 
     // Bootstrap 5 replaced the nested toggle-button idiom with btn-check on a
@@ -159,10 +172,51 @@ describe('Bootstrap 5 check and radio markup', () => {
       expect(label.className).toContain('form-check-label');
     });
 
-    it('marks the inline variant with form-check-inline', () => {
+    // The 'radios' control is a plain FormControl, so a layout-level
+    // disabled flag reaches formControl.disabled and, through it, every
+    // rendered input. The 'checkboxes' control is a FormArray instead, which
+    // core never disables from that same flag, so there is no equivalent
+    // assertion for the checkbox list.
+    it('disables every rendered input when the control is disabled', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'size', type: 'radios', disabled: true }],
+      });
+      const inputs = [...el.querySelectorAll('input[type=radio]')] as HTMLInputElement[];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        expect(input.disabled, 'the disabled attribute belongs on the input').toBe(true);
+      });
+    });
+
+    it('renders inline radios as siblings, each in its own wrapper', () => {
       const el = renderForm({ ...form, form: [{ key: 'size', type: 'radios-inline' }] });
-      expect(el.querySelector('input[type=radio]').closest('.form-check-inline'),
-        'the inline variant wraps items in .form-check-inline').toBeTruthy();
+      const inputs = [...el.querySelectorAll('input[type=radio]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+
+        const wrapper = input.closest('.form-check-inline');
+        expect(wrapper, 'the input must sit inside a form-check-inline element').toBeTruthy();
+        expect(label.closest('.form-check-inline')).toBe(wrapper);
+        expect(wrapper.parentElement.closest('.form-check-inline'),
+          'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(input.className).toContain('form-check-input');
+        expect(label.className).toContain('form-check-label');
+      });
+    });
+
+    // Bootstrap 4 nests the input inside the label for toggle buttons; this
+    // pins the opposite for Bootstrap 5, which uses the btn-check idiom here too.
+    it('uses the btn-check idiom for radio button sets, unlike Bootstrap 4', () => {
+      const el = renderForm({ ...form, form: [{ key: 'size', type: 'radiobuttons' }] });
+      const input = el.querySelector('input[type=radio]');
+      const label = input.parentElement.querySelector('label');
+      expect(input.className).toContain('btn-check');
+      expect(label.contains(input), 'btn-check keeps the input outside the label').toBe(false);
     });
 
     it('selects the item matching the control value', () => {

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -123,6 +123,8 @@ describe('Bootstrap 5 check and radio markup', () => {
         expect(label.closest('.form-check-inline')).toBe(wrapper);
         expect(wrapper.parentElement.closest('.form-check-inline'),
           'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(wrapper.querySelectorAll('input').length,
+          'a shared wrapper would hold every input').toEqual(1);
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
       });
@@ -172,11 +174,8 @@ describe('Bootstrap 5 check and radio markup', () => {
       expect(label.className).toContain('form-check-label');
     });
 
-    // The 'radios' control is a plain FormControl, so a layout-level
-    // disabled flag reaches formControl.disabled and, through it, every
-    // rendered input. The 'checkboxes' control is a FormArray instead, which
-    // core never disables from that same flag, so there is no equivalent
-    // assertion for the checkbox list.
+    // A checkbox list is a FormArray, which core never disables from this
+    // flag, so only the radio list can assert it.
     it('disables every rendered input when the control is disabled', () => {
       const el = renderForm({
         ...form,
@@ -204,6 +203,8 @@ describe('Bootstrap 5 check and radio markup', () => {
         expect(label.closest('.form-check-inline')).toBe(wrapper);
         expect(wrapper.parentElement.closest('.form-check-inline'),
           'each item must own its wrapper rather than sharing one').toBeNull();
+        expect(wrapper.querySelectorAll('input').length,
+          'a shared wrapper would hold every input').toEqual(1);
         expect(input.className).toContain('form-check-input');
         expect(label.className).toContain('form-check-label');
       });

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -128,4 +128,52 @@ describe('Bootstrap 5 check and radio markup', () => {
       expect(label.contains(input), 'btn-check keeps the input outside the label').toBe(false);
     });
   });
+
+  describe('radio list', () => {
+    const form = {
+      schema: { size: { type: 'string', title: 'Size', enum: ['small', 'large'] } },
+      form: [{ key: 'size', type: 'radios' }],
+    };
+
+    it('renders every item as an input beside its own label', () => {
+      const el = renderForm(form);
+      const inputs = [...el.querySelectorAll('input[type=radio]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      });
+    });
+
+    it('classes each item as Bootstrap 5 documents', () => {
+      const input = renderForm(form).querySelector('input[type=radio]');
+      const label = input.parentElement.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+    });
+
+    it('marks the inline variant with form-check-inline', () => {
+      const el = renderForm({ ...form, form: [{ key: 'size', type: 'radios-inline' }] });
+      expect(el.querySelector('input[type=radio]').closest('.form-check-inline'),
+        'the inline variant wraps items in .form-check-inline').toBeTruthy();
+    });
+
+    it('selects the item matching the control value', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'size', type: 'radios' }],
+        formData: { size: 'large' },
+      });
+      const checked = [...el.querySelectorAll('input[type=radio]')]
+        .filter((i: HTMLInputElement) => i.checked);
+      expect(checked.length, 'exactly one radio should be checked').toEqual(1);
+    });
+  });
 });

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -1,0 +1,75 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Bootstrap5FrameworkModule } from '../bootstrap5-framework.module';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap5FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form [form]="form" framework="bootstrap-5"></json-schema-form>`,
+})
+class MarkupHost {
+  form: any;
+}
+
+describe('Bootstrap 5 check and radio markup', () => {
+  let fixture: ComponentFixture<MarkupHost>;
+
+  /** Renders a whole form, which is how a consumer reaches these widgets. */
+  const renderForm = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(MarkupHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [MarkupHost] }).compileComponents();
+  });
+
+  describe('single checkbox', () => {
+    const form = {
+      schema: { accept: { type: 'boolean', title: 'Accept' } },
+      form: [{ key: 'accept', type: 'checkbox' }],
+    };
+
+    it('renders the input and its label as siblings', () => {
+      const input = renderForm(form).querySelector('input[type=checkbox]');
+      const label = input.parentElement.querySelector('label');
+      expect(input, 'the checkbox should render').toBeTruthy();
+      expect(label, 'the label should be a sibling, not an ancestor').toBeTruthy();
+      expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+    });
+
+    // The pairing is the whole reason a sibling label still toggles the input.
+    it('pairs label[for] with input[id]', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]');
+      const label = el.querySelector('label');
+      expect(input.getAttribute('id')).toBeTruthy();
+      expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+    });
+
+    it('wraps them in form-check and classes them as Bootstrap 5 documents', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]');
+      const label = el.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+    });
+
+    it('still toggles the control when the label is clicked', () => {
+      const el = renderForm(form);
+      const input = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+      const before = input.checked;
+      (el.querySelector('label') as HTMLLabelElement).click();
+      fixture.detectChanges();
+      expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
+    });
+  });
+});

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -1,15 +1,41 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { JsonSchemaFormService } from '@ajsf/core';
 import { Bootstrap5FrameworkModule } from '../bootstrap5-framework.module';
 
 @Component({
   standalone: true,
   imports: [Bootstrap5FrameworkModule],
   changeDetection: ChangeDetectionStrategy.Eager,
-  template: `<json-schema-form [form]="form" framework="bootstrap-5"></json-schema-form>`,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-5"
+    (onChanges)="value = $event"></json-schema-form>`,
 })
 class MarkupHost {
   form: any;
+  value: any;
+}
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap5FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<bootstrap5-checkboxes-widget
+      [layoutNode]="checkboxes" [dataIndex]="[]" [layoutIndex]="[]"></bootstrap5-checkboxes-widget>
+    <bootstrap5-radios-widget
+      [layoutNode]="radios" [dataIndex]="[]" [layoutIndex]="[]"></bootstrap5-radios-widget>`,
+  providers: [JsonSchemaFormService],
+})
+class StandaloneHost {
+  checkboxes: any = {
+    _id: 1, type: 'checkboxes', dataPointer: '/colours',
+    options: { title: 'Colours', enum: ['red', 'green'] },
+  };
+  radios: any = {
+    _id: 2, type: 'radios', dataPointer: '/size',
+    options: { title: 'Size', enum: ['small', 'large'] },
+  };
 }
 
 describe('Bootstrap 5 check and radio markup', () => {
@@ -70,6 +96,23 @@ describe('Bootstrap 5 check and radio markup', () => {
       (el.querySelector('label') as HTMLLabelElement).click();
       fixture.detectChanges();
       expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
+    });
+
+    // A layout item with no key gets no form control, and the widget renders
+    // its unbound input instead, which is a second copy of the markup.
+    it('renders the unbound input as a sibling too', () => {
+      const el = renderForm({
+        schema: { accept: { type: 'boolean', title: 'Accept' } },
+        form: [{ type: 'checkbox', title: 'Accept' }],
+      });
+      const input = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+      const label = input.parentElement.querySelector('label');
+      expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+      expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      expect(input.className).toContain('form-check-input');
+      (label as HTMLLabelElement).click();
+      fixture.detectChanges();
+      expect(input.checked, 'clicking the label should still reach the input').toBe(true);
     });
   });
 
@@ -141,6 +184,17 @@ describe('Bootstrap 5 check and radio markup', () => {
       const label = input.parentElement.querySelector('label');
       expect(input.className).toContain('btn-check');
       expect(label.contains(input), 'btn-check keeps the input outside the label').toBe(false);
+    });
+
+    it('reports the clicked value from every layout variant', () => {
+      ['checkboxes', 'checkboxes-inline', 'checkboxbuttons'].forEach((type) => {
+        const el = renderForm({ ...form, form: [{ key: 'colours', type }] });
+        const red = el.querySelector('input[type=checkbox]') as HTMLInputElement;
+        (el.querySelector(`label[for="${red.id}"]`) as HTMLLabelElement).click();
+        fixture.detectChanges();
+        expect(fixture.componentInstance.value.colours,
+          `${type} should report the item the label points at`).toEqual(['red']);
+      });
     });
   });
 
@@ -229,6 +283,47 @@ describe('Bootstrap 5 check and radio markup', () => {
       const checked = [...el.querySelectorAll('input[type=radio]')]
         .filter((i: HTMLInputElement) => i.checked);
       expect(checked.length, 'exactly one radio should be checked').toEqual(1);
+    });
+
+    it('reports the clicked value from every layout variant', () => {
+      ['radios', 'radios-inline', 'radiobuttons'].forEach((type) => {
+        const el = renderForm({ ...form, form: [{ key: 'size', type }] });
+        const large = [...el.querySelectorAll('input[type=radio]')].pop() as HTMLInputElement;
+        (el.querySelector(`label[for="${large.id}"]`) as HTMLLabelElement).click();
+        fixture.detectChanges();
+        expect(fixture.componentInstance.value.size,
+          `${type} should report the item the label points at`).toEqual('large');
+      });
+    });
+  });
+
+  // The framework component renders the group title itself and blanks the one
+  // it passes on, so this title only appears when the widget is used directly,
+  // which the package's public API allows.
+  describe('a widget used without the framework', () => {
+    const render = (): HTMLElement => {
+      const standalone = TestBed.createComponent(StandaloneHost);
+      standalone.detectChanges();
+      return standalone.nativeElement;
+    };
+
+    it('renders its own group title', () => {
+      const el = render();
+      const checkboxes = el.querySelector('bootstrap5-checkboxes-widget');
+      const radios = el.querySelector('bootstrap5-radios-widget');
+      expect(checkboxes.querySelector('label').textContent).toEqual('Colours');
+      expect(radios.querySelector('label').textContent).toEqual('Size');
+      expect(checkboxes.querySelectorAll('input').length,
+        'the items should render beneath the title').toEqual(2);
+    });
+
+    it('hides the group title when notitle is set', () => {
+      const standalone = TestBed.createComponent(StandaloneHost);
+      standalone.componentInstance.checkboxes.options.notitle = true;
+      standalone.detectChanges();
+      const title = standalone.nativeElement
+        .querySelector('bootstrap5-checkboxes-widget label') as HTMLElement;
+      expect(title.style.display, 'notitle should hide the title, not drop it').toEqual('none');
     });
   });
 });

--- a/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/widget-markup.spec.ts
@@ -72,4 +72,60 @@ describe('Bootstrap 5 check and radio markup', () => {
       expect(input.checked, 'clicking the label should toggle the input').toEqual(!before);
     });
   });
+
+  describe('checkbox list', () => {
+    const form = {
+      schema: {
+        colours: { type: 'array', title: 'Colours', items: { type: 'string', enum: ['red', 'green'] } },
+      },
+      form: [{ key: 'colours', type: 'checkboxes' }],
+    };
+
+    it('renders every item as an input beside its own label', () => {
+      const el = renderForm(form);
+      const inputs = [...el.querySelectorAll('input[type=checkbox]')];
+      expect(inputs.length, 'both enum values should render').toEqual(2);
+      inputs.forEach((input) => {
+        const label = input.parentElement.querySelector('label');
+        expect(label, 'each item needs its own label').toBeTruthy();
+        expect(label.contains(input), 'the label must not wrap the input').toBe(false);
+        expect(label.getAttribute('for')).toEqual(input.getAttribute('id'));
+      });
+    });
+
+    it('classes each item as Bootstrap 5 documents', () => {
+      const input = renderForm(form).querySelector('input[type=checkbox]');
+      const label = input.parentElement.querySelector('label');
+      const wrapper = input.closest('.form-check');
+      expect(wrapper, 'the input must sit inside a .form-check').toBeTruthy();
+      expect(label.closest('.form-check')).toBe(wrapper);
+      expect(wrapper.parentElement.closest('.form-check'),
+        'nesting two .form-check elements doubles Bootstrap padding').toBeNull();
+      expect(input.className).toContain('form-check-input');
+      expect(label.className).toContain('form-check-label');
+    });
+
+    it('marks the inline variant with form-check-inline', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'colours', type: 'checkboxes-inline' }],
+      });
+      const input = el.querySelector('input[type=checkbox]');
+      expect(input.closest('.form-check-inline'),
+        'the inline variant wraps items in .form-check-inline').toBeTruthy();
+    });
+
+    // Bootstrap 5 replaced the nested toggle-button idiom with btn-check on a
+    // sibling input beside a label.btn.
+    it('uses the btn-check idiom for button sets', () => {
+      const el = renderForm({
+        ...form,
+        form: [{ key: 'colours', type: 'checkboxbuttons' }],
+      });
+      const input = el.querySelector('input[type=checkbox]');
+      const label = input.parentElement.querySelector('label');
+      expect(input.className).toContain('btn-check');
+      expect(label.contains(input), 'btn-check keeps the input outside the label').toBe(false);
+    });
+  });
 });

--- a/projects/ajsf-bootstrap5/src/public_api.ts
+++ b/projects/ajsf-bootstrap5/src/public_api.ts
@@ -5,3 +5,4 @@
 export * from './lib/bootstrap5-framework.module';
 export * from './lib/bootstrap5-framework.component';
 export * from './lib/bootstrap5.framework';
+export * from './lib/widgets/public_api';


### PR DESCRIPTION
## Summary

Bootstrap 4 and 5 document a checkbox or radio as sibling input and label and style state through sibling selectors, but the shared core widgets render Bootstrap 3's nested shape, so the class names those two packages emit could never take effect.

## Changes

Each package now registers its own checkbox, checkboxes and radios components, subclassing the corresponding core widget and overriding template metadata only, so no core file changes. Bootstrap 4's toggle buttons stay nested, because it documents btn-group-toggle with a nested input and has no btn-check, while Bootstrap 5's take the sibling form. Bootstrap 4's inline variants move off the deleted checkbox-inline and radio-inline onto a per-item form-check form-check-inline wrapper. Both package READMEs, the roadmap and the class drift measurement follow.

## Release impact

No publish. Intended for 22.1.0, whose bump is a separate pull request.

## Compatibility

No export, selector or layout type value changes. Bootstrap 3, Material, PrimeNG and the plain HTML output are untouched. CSS selecting label > input is where the difference lands.

## Validation

Six suites green: core 2156, bs3 76, bs4 102, bs5 110, material 104, primeng 206. The corpus baseline did not move. build:demo and smoke:consumer both passed, the latter on Angular 22.1.6.
