### PR TITLE
chore: 22.1.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.0.0",
+    "@ajsf/core": "^22.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.0.0",
+    "@ajsf/core": "^22.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.0.0",
+    "@ajsf/core": "^22.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.0.0",
+    "@ajsf/core": "^22.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/primeng",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.0.0",
+    "@ajsf/core": "^22.1.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Sets the version to 22.1.0 across the six packages, publishing what is already on main.

## Changes

Only the output of `npm run version:set -- 22.1.0 22`: the version in each package manifest and the internal `@ajsf/core` range the five framework packages depend on. No source, test or documentation change.

## Release impact

Publishes 22.1.0 to the latest dist-tag. The one consumer visible change in it is the checkbox and radio restructure from #511, which gave `@ajsf/bootstrap4` and `@ajsf/bootstrap5` their own widget components so both render the sibling markup their Bootstrap majors document. Both package READMEs already name 22.1.0 as the version carrying it, so those npm pages are wrong until this publishes.

## Validation

Verified on main before the bump: six suites green at core 2156, bs3 76, bs4 107, bs5 115, material 104, primeng 206, the corpus baseline unmoved, and `build:demo` and `smoke:consumer` both passing on Angular 22.1.6.
