### PR TITLE
fix(bootstrap)!: align the array remove button with the field it removes

### DIFF
--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -107,8 +107,10 @@ control's ancestor, that is where the difference is.
 
 The remove button on an array item used to be the first child of the field
 wrapper and floated, so it left normal flow and sat at the top of the row
-rather than beside the control. It now shares a flex row with the field and
-aligns to its centre.
+rather than beside the control. It now shares a flex row with the field. Beside
+a single control it aligns to that control's centre; when the item is a group
+of fields it anchors at the group's top edge, because a group's midpoint moves
+as its contents grow.
 
 Two details matter if you have written CSS against the old output. Every field
 gains one wrapper element between the outer `form-group` container and the field

--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -103,6 +103,20 @@ has no `.btn-check`.
 If you wrote CSS selecting `label > input` or styling the label as the
 control's ancestor, that is where the difference is.
 
+## Array row layout, changed in 22.2.0
+
+The remove button on an array item used to be the first child of the field
+wrapper and floated, so it left normal flow and sat at the top of the row
+rather than beside the control. It now shares a flex row with the field and
+aligns to its centre.
+
+Two details matter if you have written CSS against the old output. Every field
+gains one wrapper element between the outer `form-group` container and the field
+itself, and that wrapper becomes a flex container only on a removable array
+item. The invalid marker moved onto that wrapper, so a selector written as
+`.input-group.is-invalid` no longer matches; the marker is now on the
+element directly above it.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap4` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap4`.

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -91,6 +91,27 @@ describe('Bootstrap 4 array row', () => {
       'the row really does hold a group rather than one control').toBeGreaterThan(1);
   });
 
+
+  // A group is a group because of what the layout resolved it to, not because
+  // of how many controls it happens to contain. A child count or a height
+  // would call this one centred.
+  it('treats a group holding a single field as a group', () => {
+    const el = render({
+      schema: {
+        people: {
+          type: 'array',
+          title: 'People',
+          items: { type: 'object', properties: { first: { type: 'string' } } },
+        },
+      },
+      data: { people: [{ first: 'Jane' }] },
+    });
+    const row = (el.querySelector('.d-flex > button') as HTMLElement).parentElement;
+    expect(row.querySelectorAll('input, select, textarea').length,
+      'exactly one control, and it is still a group').toEqual(1);
+    expect(row.className, 'so it anchors at the top').toContain('align-items-start');
+  });
+
   // showRemoveButton flips while the form is live, so this has to be one
   // fixture crossing minItems rather than two separate renders. Two branches
   // for wrapped and unwrapped would rebuild the surviving control here, taking

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -193,3 +193,42 @@ describe('Bootstrap 4 invalid feedback placement', () => {
       'the message must follow the element carrying is-invalid, not merely exist').toEqual(1);
   });
 });
+
+describe('Bootstrap 4 input widget classification', () => {
+  let component: Bootstrap4FrameworkComponent;
+  let fixture: ComponentFixture<Bootstrap4FrameworkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JsonSchemaFormModule, CommonModule, WidgetLibraryModule],
+      declarations: [Bootstrap4FrameworkComponent],
+      providers: [JsonSchemaFormService],
+    }).compileComponents();
+    fixture = TestBed.createComponent(Bootstrap4FrameworkComponent);
+    component = fixture.componentInstance;
+    component.layoutIndex = [];
+    component.dataIndex = [];
+  });
+
+  const classify = (type: string) => {
+    component.layoutNode = { type, options: {} };
+    component.initializeFramework();
+    return component.options.isInputWidget;
+  };
+
+  // The row alignment reads this flag, so a control missing from the list is
+  // aligned as though it were a group. checkboxbuttons was the one omission,
+  // beside radiobuttons and every other check and radio variant.
+  it('counts every check and radio variant as a control', () => {
+    ['checkbox', 'checkboxes', 'checkboxes-inline', 'checkboxbuttons',
+      'radio', 'radios', 'radios-inline', 'radiobuttons'].forEach((type) => {
+      expect(classify(type), `${type} is a control, not a group`).toBe(true);
+    });
+  });
+
+  it('still counts a container as a group', () => {
+    ['array', 'fieldset', 'section'].forEach((type) => {
+      expect(classify(type), `${type} is a group`).toBeFalsy();
+    });
+  });
+});

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { Subject } from 'rxjs';
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { JsonSchemaFormModule, JsonSchemaFormService, WidgetLibraryModule } from '@ajsf/core';
 import { Bootstrap4FrameworkModule } from './bootstrap4-framework.module';
@@ -63,22 +64,38 @@ describe('Bootstrap 4 array row', () => {
       'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-right');
   });
 
-  // showRemoveButton depends on array length against minItems, so it flips while
-  // the form is live. One structure rather than two branches is what stops the
-  // surviving controls being torn down and rebuilt when it does.
-  it('renders one structure whether or not the button is there', () => {
-    const withButton = render(arrayForm(0, 2));
-    expect(withButton.querySelector('button[type=button]'), 'removable').toBeTruthy();
-    const removableDepth = fieldWrapper(withButton).parentElement.className;
+  // showRemoveButton flips while the form is live, so this has to be one
+  // fixture crossing minItems rather than two separate renders. Two branches
+  // for wrapped and unwrapped would rebuild the surviving control here, taking
+  // its focus and its state with it.
+  it('keeps the surviving control across a removal that crosses minItems', () => {
+    const el = render(arrayForm(1, 2));
+    const items = () => [...el.querySelectorAll('input:not([type=submit])')] as HTMLInputElement[];
+    const removers = () => [...el.querySelectorAll('.d-flex > button')] as HTMLElement[];
 
-    const locked = render(arrayForm(2, 2));
-    expect(locked.querySelector('button[type=button]'),
-      'at minItems there is nothing to remove').toBeFalsy();
-    expect(fieldWrapper(locked).querySelector('input'),
-      'the control still renders at the same depth').toBeTruthy();
-    expect(removableDepth).toContain('d-flex');
-    expect(fieldWrapper(locked).parentElement.className,
-      'the wrapper is always there, it just stops being a flex row').not.toContain('d-flex');
+    expect(items().length, 'two entries render two inputs').toEqual(2);
+    expect(removers().length, 'both are removable above minItems').toEqual(2);
+
+    const survivor = items()[0];
+    const survivorWrapper = survivor.closest('select-widget-widget').parentElement;
+    const survivorRow = survivorWrapper.parentElement;
+    const jsf = fixture.debugElement.query(By.css('json-schema-form'))
+      .injector.get(JsonSchemaFormService);
+    const control = jsf.formGroup.get(['contacts', '0']);
+
+    removers()[1].click();
+    fixture.detectChanges();
+
+    expect(items().length, 'one entry left').toEqual(1);
+    expect(items()[0], 'the surviving input must be the same node').toBe(survivor);
+    expect(items()[0].closest('select-widget-widget').parentElement,
+      'and sit in the same wrapper').toBe(survivorWrapper);
+    expect(survivorWrapper.parentElement, 'inside the same row').toBe(survivorRow);
+    expect(jsf.formGroup.get(['contacts', '0']),
+      'backed by the same control').toBe(control);
+    expect(removers().length, 'at minItems the button goes').toEqual(0);
+    expect(survivorRow.className,
+      'and the row stops being a flex container without being replaced').not.toContain('d-flex');
   });
 
   it('leaves a field outside an array alone', () => {

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -1,0 +1,130 @@
+import { vi } from 'vitest';
+import { Subject } from 'rxjs';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { JsonSchemaFormModule, JsonSchemaFormService, WidgetLibraryModule } from '@ajsf/core';
+import { Bootstrap4FrameworkModule } from './bootstrap4-framework.module';
+import { Bootstrap4FrameworkComponent } from './bootstrap4-framework.component';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap4FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-4"></json-schema-form>`,
+})
+class ArrayHost {
+  form: any;
+}
+
+const arrayForm = (minItems: number, items: number) => ({
+  schema: {
+    contacts: {
+      type: 'array',
+      title: 'Contacts',
+      minItems,
+      items: { type: 'string', title: 'Contact' },
+    },
+  },
+  data: { contacts: Array.from({ length: items }, (_, i) => `c${i}`) },
+});
+
+describe('Bootstrap 4 array row', () => {
+  let fixture: ComponentFixture<ArrayHost>;
+
+  const render = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(ArrayHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  /** The field wrapper of the first array item, whatever classes it carries. */
+  const fieldWrapper = (el: HTMLElement): HTMLElement =>
+    el.querySelector('input').closest('select-widget-widget').parentElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [ArrayHost] }).compileComponents();
+  });
+
+  it('puts the remove button and the field in one flex row', () => {
+    const el = render(arrayForm(0, 2));
+    const button = el.querySelector('button[type=button]') as HTMLElement;
+    expect(button, 'an array item should offer a remove button').toBeTruthy();
+    const row = button.parentElement;
+    expect(row.className, 'the row must be a flex container, or the float stands').toContain('d-flex');
+    expect(row.className, 'the button aligns against the field, not the whole group')
+      .toContain('align-items-center');
+    expect(fieldWrapper(el).parentElement,
+      'the button and the field must be siblings in that row').toBe(row);
+    expect(button.className,
+      'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-right');
+  });
+
+  // showRemoveButton depends on array length against minItems, so it flips while
+  // the form is live. One structure rather than two branches is what stops the
+  // surviving controls being torn down and rebuilt when it does.
+  it('renders one structure whether or not the button is there', () => {
+    const withButton = render(arrayForm(0, 2));
+    expect(withButton.querySelector('button[type=button]'), 'removable').toBeTruthy();
+    const removableDepth = fieldWrapper(withButton).parentElement.className;
+
+    const locked = render(arrayForm(2, 2));
+    expect(locked.querySelector('button[type=button]'),
+      'at minItems there is nothing to remove').toBeFalsy();
+    expect(fieldWrapper(locked).querySelector('input'),
+      'the control still renders at the same depth').toBeTruthy();
+    expect(removableDepth).toContain('d-flex');
+    expect(fieldWrapper(locked).parentElement.className,
+      'the wrapper is always there, it just stops being a flex row').not.toContain('d-flex');
+  });
+
+  it('leaves a field outside an array alone', () => {
+    const el = render({ schema: { name: { type: 'string', title: 'Name' } } });
+    expect(el.querySelector('button[type=button]'), 'nothing to remove').toBeFalsy();
+    expect(el.querySelectorAll('.d-flex').length, 'no flex row without a button').toEqual(0);
+  });
+});
+
+describe('Bootstrap 4 invalid feedback placement', () => {
+  let component: Bootstrap4FrameworkComponent;
+  let fixture: ComponentFixture<Bootstrap4FrameworkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JsonSchemaFormModule, CommonModule, WidgetLibraryModule],
+      declarations: [Bootstrap4FrameworkComponent],
+      providers: [JsonSchemaFormService],
+    }).compileComponents();
+    fixture = TestBed.createComponent(Bootstrap4FrameworkComponent);
+    component = fixture.componentInstance;
+    component.layoutIndex = [];
+    component.dataIndex = [];
+  });
+
+  // Bootstrap reveals .invalid-feedback only as a following sibling of the
+  // element carrying .is-invalid. The row the remove button joined now carries
+  // that marker, so this is the assertion that the move preserved the rule.
+  it('renders the message as a following sibling of the invalid element', () => {
+    // initializeFramework reassigns formControl from the service, so the stub
+    // has to be the service's answer rather than a field set on the component.
+    const jsf = TestBed.inject(JsonSchemaFormService);
+    vi.spyOn(jsf, 'getFormControl').mockReturnValue({
+      status: 'INVALID',
+      errors: { minLength: true },
+      touched: true,
+      dirty: false,
+      statusChanges: new Subject(),
+    } as any);
+    component.layoutNode = { type: 'text', options: { errorMessage: 'Too short', enableErrorState: true } };
+    component.initializeFramework();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.is-invalid'), 'the invalid marker should render').toBeTruthy();
+    expect(el.querySelector('.invalid-feedback'), 'the message should render').toBeTruthy();
+    expect(el.querySelectorAll('.is-invalid ~ .invalid-feedback').length,
+      'the message must follow the element carrying is-invalid, not merely exist').toEqual(1);
+  });
+});

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -64,6 +64,33 @@ describe('Bootstrap 4 array row', () => {
       'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-right');
   });
 
+
+  // A group-level action anchors at the group's upper edge: the midpoint of a
+  // nested item moves as its contents grow, which would leave the button
+  // looking attached to whichever child happened to sit halfway down.
+  it('anchors the button at the top when the item is a group', () => {
+    const el = render({
+      schema: {
+        people: {
+          type: 'array',
+          title: 'People',
+          items: {
+            type: 'object',
+            properties: { first: { type: 'string' }, last: { type: 'string' } },
+          },
+        },
+      },
+      data: { people: [{ first: 'Jane', last: 'Doe' }] },
+    });
+    const button = el.querySelector('.d-flex > button') as HTMLElement;
+    expect(button, 'a group item is still removable').toBeTruthy();
+    const row = button.parentElement;
+    expect(row.className, 'a group anchors at its top').toContain('align-items-start');
+    expect(row.className, 'and is not centred on its contents').not.toContain('align-items-center');
+    expect(row.querySelectorAll('input').length,
+      'the row really does hold a group rather than one control').toBeGreaterThan(1);
+  });
+
   // showRemoveButton flips while the form is live, so this has to be one
   // fixture crossing minItems rather than two separate renders. Two branches
   // for wrapped and unwrapped would rebuild the surviving control here, taking

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
@@ -1,14 +1,5 @@
 <div [class]="options?.htmlClass || ''">
 
-  @if (showRemoveButton) {
-    <button
-      class="close float-right"
-      type="button"
-      (click)="removeItem()">
-      <span aria-hidden="true">&times;</span>
-      <span class="sr-only">Close</span>
-    </button>
-  }
   @if (options?.messageLocation === 'top') {
     <div>
       @if (options?.helpBlock) {
@@ -33,30 +24,47 @@
   }
 
   <!--
-  is-invalid sits on this wrapper, not on the control. Bootstrap reveals
+  is-invalid sits on this row, not on the control. Bootstrap reveals
   .invalid-feedback only as a following sibling of the element carrying
   .is-invalid, and select-widget-widget renders its own host element and a
   container div between here and the real input, so the input and the
-  message can never be siblings.
+  message can never be siblings. The row is a flex container only for a
+  removable array item, which is also what stops .close taking its built in
+  float and leaving normal flow.
   -->
-  <div [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
-       [class.is-invalid]="options?.enableErrorState && formControl?.errors &&
-             (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)">
-    @if (options?.fieldAddonLeft) {
-      <div class="input-group-prepend">
-        <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonLeft)"></span>
-      </div>
-    }
+  <div
+    [class.d-flex]="showRemoveButton"
+    [class.align-items-center]="showRemoveButton"
+    [class.is-invalid]="options?.enableErrorState && formControl?.errors &&
+          (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)">
+    <div [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
+         [class.flex-grow-1]="showRemoveButton">
+      @if (options?.fieldAddonLeft) {
+        <div class="input-group-prepend">
+          <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonLeft)"></span>
+        </div>
+      }
 
-    <select-widget-widget
-      [layoutNode]="widgetLayoutNode"
-      [dataIndex]="dataIndex"
-    [layoutIndex]="layoutIndex"></select-widget-widget>
+      <select-widget-widget
+        [layoutNode]="widgetLayoutNode"
+        [dataIndex]="dataIndex"
+      [layoutIndex]="layoutIndex"></select-widget-widget>
 
-    @if (options?.fieldAddonRight) {
-      <div class="input-group-append">
-        <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonRight)"></span>
-      </div>
+      @if (options?.fieldAddonRight) {
+        <div class="input-group-append">
+          <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonRight)"></span>
+        </div>
+      }
+    </div>
+
+    @if (showRemoveButton) {
+      <button
+        class="close ml-2"
+        type="button"
+        (click)="removeItem()">
+        <span aria-hidden="true">&times;</span>
+        <span class="sr-only">Close</span>
+      </button>
     }
   </div>
 

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
@@ -34,7 +34,8 @@
   -->
   <div
     [class.d-flex]="showRemoveButton"
-    [class.align-items-center]="showRemoveButton"
+    [class.align-items-center]="showRemoveButton && options?.isInputWidget"
+    [class.align-items-start]="showRemoveButton && !options?.isInputWidget"
     [class.is-invalid]="options?.enableErrorState && formControl?.errors &&
           (formControl?.touched || formControl?.dirty || options?.feedbackOnRender)">
     <div [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -87,7 +87,8 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
       this.formControl = this.jsf.getFormControl(this);
 
       this.options.isInputWidget = inArray(this.layoutNode.type, [
-        'button', 'checkbox', 'checkboxes-inline', 'checkboxes', 'color',
+        'button', 'checkbox', 'checkboxbuttons', 'checkboxes-inline',
+        'checkboxes', 'color',
         'date', 'datetime-local', 'datetime', 'email', 'file', 'hidden',
         'image', 'integer', 'month', 'number', 'password', 'radio',
         'radiobuttons', 'radios-inline', 'radios', 'range', 'reset', 'search',

--- a/projects/ajsf-bootstrap5/README.md
+++ b/projects/ajsf-bootstrap5/README.md
@@ -77,8 +77,10 @@ control's ancestor, that is where the difference is.
 
 The remove button on an array item used to be the first child of the field
 wrapper and floated, so it left normal flow and sat at the top of the row
-rather than beside the control. It now shares a flex row with the field and
-aligns to its centre.
+rather than beside the control. It now shares a flex row with the field. Beside
+a single control it aligns to that control's centre; when the item is a group
+of fields it anchors at the group's top edge, because a group's midpoint moves
+as its contents grow.
 
 Two details matter if you have written CSS against the old output. Every field
 gains one wrapper element between the outer `form-group` container and the field

--- a/projects/ajsf-bootstrap5/README.md
+++ b/projects/ajsf-bootstrap5/README.md
@@ -73,6 +73,20 @@ through a sibling input too, unlike Bootstrap 4's nested `.btn-group-toggle`.
 If you wrote CSS selecting `label > input` or styling the label as the
 control's ancestor, that is where the difference is.
 
+## Array row layout, changed in 22.2.0
+
+The remove button on an array item used to be the first child of the field
+wrapper and floated, so it left normal flow and sat at the top of the row
+rather than beside the control. It now shares a flex row with the field and
+aligns to its centre.
+
+Two details matter if you have written CSS against the old output. Every field
+gains one wrapper element between the outer `form-group` container and the field
+itself, and that wrapper becomes a flex container only on a removable array
+item. The invalid marker moved onto that wrapper, so a selector written as
+`.input-group.is-invalid` no longer matches; the marker is now on the
+element directly above it.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap5` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap5`.

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -64,6 +64,33 @@ describe('Bootstrap 5 array row', () => {
       'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-end');
   });
 
+
+  // A group-level action anchors at the group's upper edge: the midpoint of a
+  // nested item moves as its contents grow, which would leave the button
+  // looking attached to whichever child happened to sit halfway down.
+  it('anchors the button at the top when the item is a group', () => {
+    const el = render({
+      schema: {
+        people: {
+          type: 'array',
+          title: 'People',
+          items: {
+            type: 'object',
+            properties: { first: { type: 'string' }, last: { type: 'string' } },
+          },
+        },
+      },
+      data: { people: [{ first: 'Jane', last: 'Doe' }] },
+    });
+    const button = el.querySelector('.d-flex > button') as HTMLElement;
+    expect(button, 'a group item is still removable').toBeTruthy();
+    const row = button.parentElement;
+    expect(row.className, 'a group anchors at its top').toContain('align-items-start');
+    expect(row.className, 'and is not centred on its contents').not.toContain('align-items-center');
+    expect(row.querySelectorAll('input').length,
+      'the row really does hold a group rather than one control').toBeGreaterThan(1);
+  });
+
   // showRemoveButton flips while the form is live, so this has to be one
   // fixture crossing minItems rather than two separate renders. Two branches
   // for wrapped and unwrapped would rebuild the surviving control here, taking

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { Subject } from 'rxjs';
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { JsonSchemaFormModule, JsonSchemaFormService, WidgetLibraryModule } from '@ajsf/core';
 import { Bootstrap5FrameworkModule } from './bootstrap5-framework.module';
@@ -63,22 +64,38 @@ describe('Bootstrap 5 array row', () => {
       'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-end');
   });
 
-  // showRemoveButton depends on array length against minItems, so it flips while
-  // the form is live. One structure rather than two branches is what stops the
-  // surviving controls being torn down and rebuilt when it does.
-  it('renders one structure whether or not the button is there', () => {
-    const withButton = render(arrayForm(0, 2));
-    expect(withButton.querySelector('button[type=button]'), 'removable').toBeTruthy();
-    const removableDepth = fieldWrapper(withButton).parentElement.className;
+  // showRemoveButton flips while the form is live, so this has to be one
+  // fixture crossing minItems rather than two separate renders. Two branches
+  // for wrapped and unwrapped would rebuild the surviving control here, taking
+  // its focus and its state with it.
+  it('keeps the surviving control across a removal that crosses minItems', () => {
+    const el = render(arrayForm(1, 2));
+    const items = () => [...el.querySelectorAll('input:not([type=submit])')] as HTMLInputElement[];
+    const removers = () => [...el.querySelectorAll('.d-flex > button')] as HTMLElement[];
 
-    const locked = render(arrayForm(2, 2));
-    expect(locked.querySelector('button[type=button]'),
-      'at minItems there is nothing to remove').toBeFalsy();
-    expect(fieldWrapper(locked).querySelector('input'),
-      'the control still renders at the same depth').toBeTruthy();
-    expect(removableDepth).toContain('d-flex');
-    expect(fieldWrapper(locked).parentElement.className,
-      'the wrapper is always there, it just stops being a flex row').not.toContain('d-flex');
+    expect(items().length, 'two entries render two inputs').toEqual(2);
+    expect(removers().length, 'both are removable above minItems').toEqual(2);
+
+    const survivor = items()[0];
+    const survivorWrapper = survivor.closest('select-widget-widget').parentElement;
+    const survivorRow = survivorWrapper.parentElement;
+    const jsf = fixture.debugElement.query(By.css('json-schema-form'))
+      .injector.get(JsonSchemaFormService);
+    const control = jsf.formGroup.get(['contacts', '0']);
+
+    removers()[1].click();
+    fixture.detectChanges();
+
+    expect(items().length, 'one entry left').toEqual(1);
+    expect(items()[0], 'the surviving input must be the same node').toBe(survivor);
+    expect(items()[0].closest('select-widget-widget').parentElement,
+      'and sit in the same wrapper').toBe(survivorWrapper);
+    expect(survivorWrapper.parentElement, 'inside the same row').toBe(survivorRow);
+    expect(jsf.formGroup.get(['contacts', '0']),
+      'backed by the same control').toBe(control);
+    expect(removers().length, 'at minItems the button goes').toEqual(0);
+    expect(survivorRow.className,
+      'and the row stops being a flex container without being replaced').not.toContain('d-flex');
   });
 
   it('leaves a field outside an array alone', () => {

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -1,0 +1,130 @@
+import { vi } from 'vitest';
+import { Subject } from 'rxjs';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { JsonSchemaFormModule, JsonSchemaFormService, WidgetLibraryModule } from '@ajsf/core';
+import { Bootstrap5FrameworkModule } from './bootstrap5-framework.module';
+import { Bootstrap5FrameworkComponent } from './bootstrap5-framework.component';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap5FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-5"></json-schema-form>`,
+})
+class ArrayHost {
+  form: any;
+}
+
+const arrayForm = (minItems: number, items: number) => ({
+  schema: {
+    contacts: {
+      type: 'array',
+      title: 'Contacts',
+      minItems,
+      items: { type: 'string', title: 'Contact' },
+    },
+  },
+  data: { contacts: Array.from({ length: items }, (_, i) => `c${i}`) },
+});
+
+describe('Bootstrap 5 array row', () => {
+  let fixture: ComponentFixture<ArrayHost>;
+
+  const render = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(ArrayHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  /** The field wrapper of the first array item, whatever classes it carries. */
+  const fieldWrapper = (el: HTMLElement): HTMLElement =>
+    el.querySelector('input').closest('select-widget-widget').parentElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [ArrayHost] }).compileComponents();
+  });
+
+  it('puts the remove button and the field in one flex row', () => {
+    const el = render(arrayForm(0, 2));
+    const button = el.querySelector('button[type=button]') as HTMLElement;
+    expect(button, 'an array item should offer a remove button').toBeTruthy();
+    const row = button.parentElement;
+    expect(row.className, 'the row must be a flex container, or the float stands').toContain('d-flex');
+    expect(row.className, 'the button aligns against the field, not the whole group')
+      .toContain('align-items-center');
+    expect(fieldWrapper(el).parentElement,
+      'the button and the field must be siblings in that row').toBe(row);
+    expect(button.className,
+      'float utilities do nothing to a flex item, so the class should be gone').not.toContain('float-end');
+  });
+
+  // showRemoveButton depends on array length against minItems, so it flips while
+  // the form is live. One structure rather than two branches is what stops the
+  // surviving controls being torn down and rebuilt when it does.
+  it('renders one structure whether or not the button is there', () => {
+    const withButton = render(arrayForm(0, 2));
+    expect(withButton.querySelector('button[type=button]'), 'removable').toBeTruthy();
+    const removableDepth = fieldWrapper(withButton).parentElement.className;
+
+    const locked = render(arrayForm(2, 2));
+    expect(locked.querySelector('button[type=button]'),
+      'at minItems there is nothing to remove').toBeFalsy();
+    expect(fieldWrapper(locked).querySelector('input'),
+      'the control still renders at the same depth').toBeTruthy();
+    expect(removableDepth).toContain('d-flex');
+    expect(fieldWrapper(locked).parentElement.className,
+      'the wrapper is always there, it just stops being a flex row').not.toContain('d-flex');
+  });
+
+  it('leaves a field outside an array alone', () => {
+    const el = render({ schema: { name: { type: 'string', title: 'Name' } } });
+    expect(el.querySelector('button[type=button]'), 'nothing to remove').toBeFalsy();
+    expect(el.querySelectorAll('.d-flex').length, 'no flex row without a button').toEqual(0);
+  });
+});
+
+describe('Bootstrap 5 invalid feedback placement', () => {
+  let component: Bootstrap5FrameworkComponent;
+  let fixture: ComponentFixture<Bootstrap5FrameworkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JsonSchemaFormModule, CommonModule, WidgetLibraryModule],
+      declarations: [Bootstrap5FrameworkComponent],
+      providers: [JsonSchemaFormService],
+    }).compileComponents();
+    fixture = TestBed.createComponent(Bootstrap5FrameworkComponent);
+    component = fixture.componentInstance;
+    component.layoutIndex = [];
+    component.dataIndex = [];
+  });
+
+  // Bootstrap reveals .invalid-feedback only as a following sibling of the
+  // element carrying .is-invalid. The row the remove button joined now carries
+  // that marker, so this is the assertion that the move preserved the rule.
+  it('renders the message as a following sibling of the invalid element', () => {
+    // initializeFramework reassigns formControl from the service, so the stub
+    // has to be the service's answer rather than a field set on the component.
+    const jsf = TestBed.inject(JsonSchemaFormService);
+    vi.spyOn(jsf, 'getFormControl').mockReturnValue({
+      status: 'INVALID',
+      errors: { minLength: true },
+      touched: true,
+      dirty: false,
+      statusChanges: new Subject(),
+    } as any);
+    component.layoutNode = { type: 'text', options: { errorMessage: 'Too short' } };
+    component.initializeFramework();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.is-invalid'), 'the invalid marker should render').toBeTruthy();
+    expect(el.querySelector('.invalid-feedback'), 'the message should render').toBeTruthy();
+    expect(el.querySelectorAll('.is-invalid ~ .invalid-feedback').length,
+      'the message must follow the element carrying is-invalid, not merely exist').toEqual(1);
+  });
+});

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -193,3 +193,42 @@ describe('Bootstrap 5 invalid feedback placement', () => {
       'the message must follow the element carrying is-invalid, not merely exist').toEqual(1);
   });
 });
+
+describe('Bootstrap 5 input widget classification', () => {
+  let component: Bootstrap5FrameworkComponent;
+  let fixture: ComponentFixture<Bootstrap5FrameworkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JsonSchemaFormModule, CommonModule, WidgetLibraryModule],
+      declarations: [Bootstrap5FrameworkComponent],
+      providers: [JsonSchemaFormService],
+    }).compileComponents();
+    fixture = TestBed.createComponent(Bootstrap5FrameworkComponent);
+    component = fixture.componentInstance;
+    component.layoutIndex = [];
+    component.dataIndex = [];
+  });
+
+  const classify = (type: string) => {
+    component.layoutNode = { type, options: {} };
+    component.initializeFramework();
+    return component.options.isInputWidget;
+  };
+
+  // The row alignment reads this flag, so a control missing from the list is
+  // aligned as though it were a group. checkboxbuttons was the one omission,
+  // beside radiobuttons and every other check and radio variant.
+  it('counts every check and radio variant as a control', () => {
+    ['checkbox', 'checkboxes', 'checkboxes-inline', 'checkboxbuttons',
+      'radio', 'radios', 'radios-inline', 'radiobuttons'].forEach((type) => {
+      expect(classify(type), `${type} is a control, not a group`).toBe(true);
+    });
+  });
+
+  it('still counts a container as a group', () => {
+    ['array', 'fieldset', 'section'].forEach((type) => {
+      expect(classify(type), `${type} is a group`).toBeFalsy();
+    });
+  });
+});

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -91,6 +91,27 @@ describe('Bootstrap 5 array row', () => {
       'the row really does hold a group rather than one control').toBeGreaterThan(1);
   });
 
+
+  // A group is a group because of what the layout resolved it to, not because
+  // of how many controls it happens to contain. A child count or a height
+  // would call this one centred.
+  it('treats a group holding a single field as a group', () => {
+    const el = render({
+      schema: {
+        people: {
+          type: 'array',
+          title: 'People',
+          items: { type: 'object', properties: { first: { type: 'string' } } },
+        },
+      },
+      data: { people: [{ first: 'Jane' }] },
+    });
+    const row = (el.querySelector('.d-flex > button') as HTMLElement).parentElement;
+    expect(row.querySelectorAll('input, select, textarea').length,
+      'exactly one control, and it is still a group').toEqual(1);
+    expect(row.className, 'so it anchors at the top').toContain('align-items-start');
+  });
+
   // showRemoveButton flips while the form is live, so this has to be one
   // fixture crossing minItems rather than two separate renders. Two branches
   // for wrapped and unwrapped would rebuild the surviving control here, taking

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -36,7 +36,8 @@ to the field rather than to this container.
   -->
   <div
     [class.d-flex]="showRemoveButton"
-    [class.align-items-center]="showRemoveButton"
+    [class.align-items-center]="showRemoveButton && options?.isInputWidget"
+    [class.align-items-start]="showRemoveButton && !options?.isInputWidget"
     [class.is-invalid]="!!options?.errorMessage">
     <div
       [class.h-100]="true"

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -5,14 +5,6 @@ to the field rather than to this container.
 -->
 <div [class]="options?.htmlClass || ''">
 
-  @if (showRemoveButton) {
-    <button
-      class="float-end btn btn-outline-danger btn-sm"
-      type="button"
-      (click)="removeItem()">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  }
   @if (options?.messageLocation === 'top') {
     <div>
       @if (options?.helpBlock) {
@@ -35,28 +27,49 @@ to the field rather than to this container.
       <strong class="text-danger">*</strong> = required fields
     </p>
   }
+  <!--
+  is-invalid sits on this row rather than on the field inside it, because
+  Bootstrap reveals .invalid-feedback only as a following sibling of the
+  element carrying .is-invalid, and the message below is this row's sibling.
+  The row is a flex container only for a removable array item, which is also
+  what stops the button's float taking it out of normal flow.
+  -->
   <div
-    [class.h-100]="true"
-    [class.mt-1]="true"
-    [class.form-check]="isSingleCheck"
-    [class.is-invalid]="!!options?.errorMessage"
-    [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
-    >
-    @if (options?.fieldAddonLeft) {
-      <div class="input-group-prepend">
-        <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonLeft)"></span>
-      </div>
-    }
+    [class.d-flex]="showRemoveButton"
+    [class.align-items-center]="showRemoveButton"
+    [class.is-invalid]="!!options?.errorMessage">
+    <div
+      [class.h-100]="true"
+      [class.mt-1]="true"
+      [class.form-check]="isSingleCheck"
+      [class.input-group]="options?.fieldAddonLeft || options?.fieldAddonRight"
+      [class.flex-grow-1]="showRemoveButton"
+      >
+      @if (options?.fieldAddonLeft) {
+        <div class="input-group-prepend">
+          <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonLeft)"></span>
+        </div>
+      }
 
-    <select-widget-widget
-      [layoutNode]="widgetLayoutNode"
-      [dataIndex]="dataIndex"
-    [layoutIndex]="layoutIndex"></select-widget-widget>
+      <select-widget-widget
+        [layoutNode]="widgetLayoutNode"
+        [dataIndex]="dataIndex"
+      [layoutIndex]="layoutIndex"></select-widget-widget>
 
-    @if (options?.fieldAddonRight) {
-      <div class="input-group-append">
-        <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonRight)"></span>
-      </div>
+      @if (options?.fieldAddonRight) {
+        <div class="input-group-append">
+          <span class="input-group-text" [innerHTML]="$safeNavigationMigration(options?.fieldAddonRight)"></span>
+        </div>
+      }
+    </div>
+
+    @if (showRemoveButton) {
+      <button
+        class="ms-2 btn btn-outline-danger btn-sm"
+        type="button"
+        (click)="removeItem()">
+        <span aria-hidden="true">&times;</span>
+      </button>
     }
   </div>
 

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -92,7 +92,8 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
       this.formControl = this.jsf.getFormControl(this);
 
       this.options.isInputWidget = inArray(this.layoutNode.type, [
-        'button', 'checkbox', 'checkboxes-inline', 'checkboxes', 'color',
+        'button', 'checkbox', 'checkboxbuttons', 'checkboxes-inline',
+        'checkboxes', 'color',
         'date', 'datetime-local', 'datetime', 'email', 'file', 'hidden',
         'image', 'integer', 'month', 'number', 'password', 'radio',
         'radiobuttons', 'radios-inline', 'radios', 'range', 'reset', 'search',


### PR DESCRIPTION
## Summary

The remove button on an array item floated, so it left normal flow and pinned to the top of its row instead of sitting beside the control it removes.

## Changes

The button now shares a flex row with the field, in `@ajsf/bootstrap4` and `@ajsf/bootstrap5`. Float has no effect on a flex item, so the float classes go rather than being overridden. It centres against a single control and anchors at the top when the item is a group, since a group's midpoint moves as its contents grow; the row binds that on `isInputWidget`, which both components already compute. The invalid marker moves up to that row, keeping the message its following sibling, which is the only relationship that reveals `.invalid-feedback`. The row renders for every field and becomes a flex container only when a button is present, so no control subtree is rebuilt when an array crosses `minItems`. Bootstrap 3 is unchanged.

## Release impact

No publish. Intended for 22.2.0, whose bump is a separate pull request.

## Compatibility

Every field gains one wrapper element, and `.input-group.is-invalid` no longer matches, since the marker sits on the element above.

## Validation

Six suites green at core 2156, bs3 76, bs4 112, bs5 120, with the corpus baseline unmoved. The preservation test removes an entry in one live fixture, crossing `minItems`, and rejects the implementation that branches on the button: swapping that in fails it on node identity.

Measured in Chrome at 1512 by 771, dpr 2, baseline `c147615` on ajsf.netlify.app against `360b5a9` on the deploy preview, offset being the button centre minus the control centre. Single control rows went from minus 43 to minus 2 on Bootstrap 5.3.8 and from minus 39 to 0 on Bootstrap 4.3.1. Group rows of 178 and 118 pixels now start at their column's top edge, overlapping no text. Forcing the form to 480, 360, 280 and 200 pixels produced no overflow and no clipping in the tested examples, with the input shrinking to 95 pixels, so no minimum width override was added.
