### PR TITLE
fix(bootstrap)!: give an array its title once, on the legend

### DIFF
--- a/projects/ajsf-bootstrap3/README.md
+++ b/projects/ajsf-bootstrap3/README.md
@@ -53,6 +53,17 @@ Where `schema` is a valid JSON schema object, and `onSubmit` calls a function to
 * `bootstrap-4` for 'Bootstrap 4.
 * `no-framework` for (plain HTML).
 
+## Array titles, changed in 22.2.0
+
+An array rendered its title twice: once as the field label, and again as the
+fieldset legend, which the widget rebuilt from the raw property name. A
+`phone_numbers` property showed "Phone Numbers" followed by "Phone_numbers".
+
+The title now belongs to the widget, as it already did for a fieldset, so it
+renders once, on the `<legend>` that names the group, in the normalised
+spelling. If your CSS targets the array label through `labelHtmlClass`, it now
+applies to the legend.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap3` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap3`.

--- a/projects/ajsf-bootstrap3/README.md
+++ b/projects/ajsf-bootstrap3/README.md
@@ -64,6 +64,10 @@ renders once, on the `<legend>` that names the group, in the normalised
 spelling. If your CSS targets the array label through `labelHtmlClass`, it now
 applies to the legend.
 
+The required marker moves with the title. It was previously appended only to
+the framework's own label, so a required fieldset, whose title the widget
+already owned, rendered no asterisk at all; it now does.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap3` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap3`.

--- a/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
@@ -1,0 +1,65 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Bootstrap3FrameworkModule } from './bootstrap3-framework.module';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap3FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-3"></json-schema-form>`,
+})
+class TitleHost {
+  form: any;
+}
+
+describe('Bootstrap 3 array title', () => {
+  let fixture: ComponentFixture<TitleHost>;
+
+  const render = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(TitleHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  const titled = (el: HTMLElement, text: string) =>
+    [...el.querySelectorAll('label, legend')].filter((n) => n.textContent.trim() === text);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TitleHost] }).compileComponents();
+  });
+
+  const underscored = {
+    schema: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
+  // widget fell back to when the framework blanked the title, splits on
+  // whitespace and hyphens only and left the underscore in place.
+  it('renders the title once, normalised', () => {
+    const el = render(underscored);
+    expect(titled(el, 'Phone_numbers').length,
+      'the raw property name should not reach the page').toEqual(0);
+    expect(titled(el, 'Phone Numbers').length,
+      'the array title should render exactly once').toEqual(1);
+  });
+
+  it('puts it on the legend, so it names the fieldset', () => {
+    const el = render(underscored);
+    const title = titled(el, 'Phone Numbers')[0];
+    expect(title.tagName, 'a fieldset is named by its legend').toEqual('LEGEND');
+    expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
+  });
+
+  it('leaves a plain fieldset title alone', () => {
+    const el = render({
+      schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    expect(titled(el, 'Home Address').length,
+      'a fieldset already owned its title and should be unchanged').toEqual(1);
+  });
+});

--- a/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
@@ -54,6 +54,39 @@ describe('Bootstrap 3 array title', () => {
     expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
   });
 
+
+  const requiredArray = {
+    schema: {
+      type: 'object',
+      required: ['phone_numbers'],
+      properties: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // The marker is appended to whichever title renders. Handing the array's
+  // title to the widget without moving the marker with it dropped the
+  // asterisk entirely, because the framework's own title is null by then.
+  it('keeps the required marker on the title it moved', () => {
+    const el = render(requiredArray);
+    const legends = [...el.querySelectorAll('legend')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers'));
+    expect(legends.length, 'one legend for the array').toEqual(1);
+    expect(legends[0].querySelectorAll('.text-danger').length,
+      'a required array keeps exactly one asterisk').toEqual(1);
+    expect([...el.querySelectorAll('label')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers')).length,
+      'and the framework still renders no label of its own').toEqual(0);
+  });
+
+  it('leaves an optional array unmarked', () => {
+    const el = render(underscored);
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim() === 'Phone Numbers');
+    expect(legend.querySelectorAll('.text-danger').length,
+      'nothing required, nothing marked').toEqual(0);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
@@ -87,6 +87,37 @@ describe('Bootstrap 3 array title', () => {
       'nothing required, nothing marked').toEqual(0);
   });
 
+
+  // A submit widget uses its title as the input's value, and a submit input
+  // renders its value as text, so markup appended there shows literally.
+  it('leaves a required submit caption as plain text', () => {
+    const el = render({
+      schema: { name: { type: 'string' } },
+      form: [{ key: 'name' }, { type: 'submit', title: 'Save', required: true }],
+    });
+    const submit = el.querySelector('input[type=submit]') as HTMLInputElement;
+    expect(submit, 'the submit control should render').toBeTruthy();
+    expect(submit.value, 'the caption must not carry markup').toEqual('Save');
+  });
+
+  // The marker was only ever appended to the framework's own title, which
+  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  it('marks a required fieldset, which had been losing its asterisk', () => {
+    const el = render({
+      schema: {
+        type: 'object',
+        required: ['home_address'],
+        properties: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim().startsWith('Home Address'));
+    expect(legend, 'the fieldset keeps its legend').toBeTruthy();
+    expect(legend.querySelectorAll('.text-danger').length,
+      'a required fieldset gets exactly one asterisk').toEqual(1);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -238,6 +238,11 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
+      // An array is a fieldset too: its title belongs to the widget, which
+      // renders it as the legend naming the group. Leaving it to the default
+      // branch blanked it here and had the widget rebuild one from the raw
+      // property name, so the title appeared twice and in two spellings.
+      case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;
         return null;

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -109,9 +109,12 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
         this.options.fieldAddonRight || this.options.append;
 
       // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for a fieldset or an array and leaves none here, so the marker
-      // goes on whichever of the two actually renders.
-      const titled = this.options.title ? this.options : this.widgetOptions;
+      // widget for an array or a fieldset and leaves none here, so the marker
+      // follows it. Named types only: setTitle also returns null for submit,
+      // whose widget uses the title as an input value rather than as HTML, so
+      // markup appended there would render literally.
+      const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
+        ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
         !titled.title.includes('*')

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -108,12 +108,15 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required
-      if (this.options.title && this.layoutNode.type !== 'tab' &&
+      // Add asterisk to titles if required. setTitle hands the title to the
+      // widget for a fieldset or an array and leaves none here, so the marker
+      // goes on whichever of the two actually renders.
+      const titled = this.options.title ? this.options : this.widgetOptions;
+      if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
-        !this.options.title.includes('*')
+        !titled.title.includes('*')
       ) {
-        this.options.title += ' <strong class="text-danger">*</strong>';
+        titled.title += ' <strong class="text-danger">*</strong>';
       }
       // Set miscelaneous styles and settings for each control type
       switch (this.layoutNode.type) {

--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -103,6 +103,17 @@ has no `.btn-check`.
 If you wrote CSS selecting `label > input` or styling the label as the
 control's ancestor, that is where the difference is.
 
+## Array titles, changed in 22.2.0
+
+An array rendered its title twice: once as the field label, and again as the
+fieldset legend, which the widget rebuilt from the raw property name. A
+`phone_numbers` property showed "Phone Numbers" followed by "Phone_numbers".
+
+The title now belongs to the widget, as it already did for a fieldset, so it
+renders once, on the `<legend>` that names the group, in the normalised
+spelling. If your CSS targets the array label through `labelHtmlClass`, it now
+applies to the legend.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap4` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap4`.

--- a/projects/ajsf-bootstrap4/README.md
+++ b/projects/ajsf-bootstrap4/README.md
@@ -114,6 +114,10 @@ renders once, on the `<legend>` that names the group, in the normalised
 spelling. If your CSS targets the array label through `labelHtmlClass`, it now
 applies to the legend.
 
+The required marker moves with the title. It was previously appended only to
+the framework's own label, so a required fieldset, whose title the widget
+already owned, rendered no asterisk at all; it now does.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap4` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap4`.

--- a/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
@@ -1,0 +1,65 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Bootstrap4FrameworkModule } from './bootstrap4-framework.module';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap4FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-4"></json-schema-form>`,
+})
+class TitleHost {
+  form: any;
+}
+
+describe('Bootstrap 4 array title', () => {
+  let fixture: ComponentFixture<TitleHost>;
+
+  const render = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(TitleHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  const titled = (el: HTMLElement, text: string) =>
+    [...el.querySelectorAll('label, legend')].filter((n) => n.textContent.trim() === text);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TitleHost] }).compileComponents();
+  });
+
+  const underscored = {
+    schema: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
+  // widget fell back to when the framework blanked the title, splits on
+  // whitespace and hyphens only and left the underscore in place.
+  it('renders the title once, normalised', () => {
+    const el = render(underscored);
+    expect(titled(el, 'Phone_numbers').length,
+      'the raw property name should not reach the page').toEqual(0);
+    expect(titled(el, 'Phone Numbers').length,
+      'the array title should render exactly once').toEqual(1);
+  });
+
+  it('puts it on the legend, so it names the fieldset', () => {
+    const el = render(underscored);
+    const title = titled(el, 'Phone Numbers')[0];
+    expect(title.tagName, 'a fieldset is named by its legend').toEqual('LEGEND');
+    expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
+  });
+
+  it('leaves a plain fieldset title alone', () => {
+    const el = render({
+      schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    expect(titled(el, 'Home Address').length,
+      'a fieldset already owned its title and should be unchanged').toEqual(1);
+  });
+});

--- a/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
@@ -87,6 +87,37 @@ describe('Bootstrap 4 array title', () => {
       'nothing required, nothing marked').toEqual(0);
   });
 
+
+  // A submit widget uses its title as the input's value, and a submit input
+  // renders its value as text, so markup appended there shows literally.
+  it('leaves a required submit caption as plain text', () => {
+    const el = render({
+      schema: { name: { type: 'string' } },
+      form: [{ key: 'name' }, { type: 'submit', title: 'Save', required: true }],
+    });
+    const submit = el.querySelector('input[type=submit]') as HTMLInputElement;
+    expect(submit, 'the submit control should render').toBeTruthy();
+    expect(submit.value, 'the caption must not carry markup').toEqual('Save');
+  });
+
+  // The marker was only ever appended to the framework's own title, which
+  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  it('marks a required fieldset, which had been losing its asterisk', () => {
+    const el = render({
+      schema: {
+        type: 'object',
+        required: ['home_address'],
+        properties: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim().startsWith('Home Address'));
+    expect(legend, 'the fieldset keeps its legend').toBeTruthy();
+    expect(legend.querySelectorAll('.text-danger').length,
+      'a required fieldset gets exactly one asterisk').toEqual(1);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
@@ -54,6 +54,39 @@ describe('Bootstrap 4 array title', () => {
     expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
   });
 
+
+  const requiredArray = {
+    schema: {
+      type: 'object',
+      required: ['phone_numbers'],
+      properties: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // The marker is appended to whichever title renders. Handing the array's
+  // title to the widget without moving the marker with it dropped the
+  // asterisk entirely, because the framework's own title is null by then.
+  it('keeps the required marker on the title it moved', () => {
+    const el = render(requiredArray);
+    const legends = [...el.querySelectorAll('legend')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers'));
+    expect(legends.length, 'one legend for the array').toEqual(1);
+    expect(legends[0].querySelectorAll('.text-danger').length,
+      'a required array keeps exactly one asterisk').toEqual(1);
+    expect([...el.querySelectorAll('label')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers')).length,
+      'and the framework still renders no label of its own').toEqual(0);
+  });
+
+  it('leaves an optional array unmarked', () => {
+    const el = render(underscored);
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim() === 'Phone Numbers');
+    expect(legend.querySelectorAll('.text-danger').length,
+      'nothing required, nothing marked').toEqual(0);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -266,6 +266,11 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
+      // An array is a fieldset too: its title belongs to the widget, which
+      // renders it as the legend naming the group. Leaving it to the default
+      // branch blanked it here and had the widget rebuild one from the raw
+      // property name, so the title appeared twice and in two spellings.
+      case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;
         return null;

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -115,12 +115,15 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required
-      if (this.options.title && this.layoutNode.type !== 'tab' &&
+      // Add asterisk to titles if required. setTitle hands the title to the
+      // widget for a fieldset or an array and leaves none here, so the marker
+      // goes on whichever of the two actually renders.
+      const titled = this.options.title ? this.options : this.widgetOptions;
+      if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
-        !this.options.title.includes('*')
+        !titled.title.includes('*')
       ) {
-        this.options.title += ' <strong class="text-danger">*</strong>';
+        titled.title += ' <strong class="text-danger">*</strong>';
       }
       // Set miscelaneous styles and settings for each control type
       switch (this.layoutNode.type) {

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -116,9 +116,12 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         this.options.fieldAddonRight || this.options.append;
 
       // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for a fieldset or an array and leaves none here, so the marker
-      // goes on whichever of the two actually renders.
-      const titled = this.options.title ? this.options : this.widgetOptions;
+      // widget for an array or a fieldset and leaves none here, so the marker
+      // follows it. Named types only: setTitle also returns null for submit,
+      // whose widget uses the title as an input value rather than as HTML, so
+      // markup appended there would render literally.
+      const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
+        ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
         !titled.title.includes('*')

--- a/projects/ajsf-bootstrap5/README.md
+++ b/projects/ajsf-bootstrap5/README.md
@@ -84,6 +84,10 @@ renders once, on the `<legend>` that names the group, in the normalised
 spelling. If your CSS targets the array label through `labelHtmlClass`, it now
 applies to the legend.
 
+The required marker moves with the title. It was previously appended only to
+the framework's own label, so a required fieldset, whose title the widget
+already owned, rendered no asterisk at all; it now does.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap5` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap5`.

--- a/projects/ajsf-bootstrap5/README.md
+++ b/projects/ajsf-bootstrap5/README.md
@@ -73,6 +73,17 @@ through a sibling input too, unlike Bootstrap 4's nested `.btn-group-toggle`.
 If you wrote CSS selecting `label > input` or styling the label as the
 control's ancestor, that is where the difference is.
 
+## Array titles, changed in 22.2.0
+
+An array rendered its title twice: once as the field label, and again as the
+fieldset legend, which the widget rebuilt from the raw property name. A
+`phone_numbers` property showed "Phone Numbers" followed by "Phone_numbers".
+
+The title now belongs to the widget, as it already did for a fieldset, so it
+renders once, on the `<legend>` that names the group, in the normalised
+spelling. If your CSS targets the array label through `labelHtmlClass`, it now
+applies to the legend.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project @ajsf/bootstrap5` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project @ajsf/bootstrap5`.

--- a/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
@@ -87,6 +87,37 @@ describe('Bootstrap 5 array title', () => {
       'nothing required, nothing marked').toEqual(0);
   });
 
+
+  // A submit widget uses its title as the input's value, and a submit input
+  // renders its value as text, so markup appended there shows literally.
+  it('leaves a required submit caption as plain text', () => {
+    const el = render({
+      schema: { name: { type: 'string' } },
+      form: [{ key: 'name' }, { type: 'submit', title: 'Save', required: true }],
+    });
+    const submit = el.querySelector('input[type=submit]') as HTMLInputElement;
+    expect(submit, 'the submit control should render').toBeTruthy();
+    expect(submit.value, 'the caption must not carry markup').toEqual('Save');
+  });
+
+  // The marker was only ever appended to the framework's own title, which
+  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  it('marks a required fieldset, which had been losing its asterisk', () => {
+    const el = render({
+      schema: {
+        type: 'object',
+        required: ['home_address'],
+        properties: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim().startsWith('Home Address'));
+    expect(legend, 'the fieldset keeps its legend').toBeTruthy();
+    expect(legend.querySelectorAll('.text-danger').length,
+      'a required fieldset gets exactly one asterisk').toEqual(1);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
@@ -1,0 +1,65 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Bootstrap5FrameworkModule } from './bootstrap5-framework.module';
+
+@Component({
+  standalone: true,
+  imports: [Bootstrap5FrameworkModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<json-schema-form
+    [form]="form"
+    framework="bootstrap-5"></json-schema-form>`,
+})
+class TitleHost {
+  form: any;
+}
+
+describe('Bootstrap 5 array title', () => {
+  let fixture: ComponentFixture<TitleHost>;
+
+  const render = (form: any): HTMLElement => {
+    fixture = TestBed.createComponent(TitleHost);
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+    return fixture.nativeElement;
+  };
+
+  const titled = (el: HTMLElement, text: string) =>
+    [...el.querySelectorAll('label, legend')].filter((n) => n.textContent.trim() === text);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TitleHost] }).compileComponents();
+  });
+
+  const underscored = {
+    schema: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
+  // widget fell back to when the framework blanked the title, splits on
+  // whitespace and hyphens only and left the underscore in place.
+  it('renders the title once, normalised', () => {
+    const el = render(underscored);
+    expect(titled(el, 'Phone_numbers').length,
+      'the raw property name should not reach the page').toEqual(0);
+    expect(titled(el, 'Phone Numbers').length,
+      'the array title should render exactly once').toEqual(1);
+  });
+
+  it('puts it on the legend, so it names the fieldset', () => {
+    const el = render(underscored);
+    const title = titled(el, 'Phone Numbers')[0];
+    expect(title.tagName, 'a fieldset is named by its legend').toEqual('LEGEND');
+    expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
+  });
+
+  it('leaves a plain fieldset title alone', () => {
+    const el = render({
+      schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },
+      form: [{ key: 'home_address', type: 'fieldset' }],
+    });
+    expect(titled(el, 'Home Address').length,
+      'a fieldset already owned its title and should be unchanged').toEqual(1);
+  });
+});

--- a/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
@@ -54,6 +54,39 @@ describe('Bootstrap 5 array title', () => {
     expect(title.closest('fieldset'), 'and the legend must be inside it').toBeTruthy();
   });
 
+
+  const requiredArray = {
+    schema: {
+      type: 'object',
+      required: ['phone_numbers'],
+      properties: { phone_numbers: { type: 'array', items: { type: 'string' } } },
+    },
+    data: { phone_numbers: ['702-123-4567'] },
+  };
+
+  // The marker is appended to whichever title renders. Handing the array's
+  // title to the widget without moving the marker with it dropped the
+  // asterisk entirely, because the framework's own title is null by then.
+  it('keeps the required marker on the title it moved', () => {
+    const el = render(requiredArray);
+    const legends = [...el.querySelectorAll('legend')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers'));
+    expect(legends.length, 'one legend for the array').toEqual(1);
+    expect(legends[0].querySelectorAll('.text-danger').length,
+      'a required array keeps exactly one asterisk').toEqual(1);
+    expect([...el.querySelectorAll('label')]
+      .filter((n) => n.textContent.trim().startsWith('Phone Numbers')).length,
+      'and the framework still renders no label of its own').toEqual(0);
+  });
+
+  it('leaves an optional array unmarked', () => {
+    const el = render(underscored);
+    const legend = [...el.querySelectorAll('legend')]
+      .find((n) => n.textContent.trim() === 'Phone Numbers');
+    expect(legend.querySelectorAll('.text-danger').length,
+      'nothing required, nothing marked').toEqual(0);
+  });
+
   it('leaves a plain fieldset title alone', () => {
     const el = render({
       schema: { home_address: { type: 'object', properties: { city: { type: 'string' } } } },

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -120,12 +120,15 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required
-      if (this.options.title && this.layoutNode.type !== 'tab' &&
+      // Add asterisk to titles if required. setTitle hands the title to the
+      // widget for a fieldset or an array and leaves none here, so the marker
+      // goes on whichever of the two actually renders.
+      const titled = this.options.title ? this.options : this.widgetOptions;
+      if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
-        !this.options.title.includes('*')
+        !titled.title.includes('*')
       ) {
-        this.options.title += ' <strong class="text-danger">*</strong>';
+        titled.title += ' <strong class="text-danger">*</strong>';
       }
       // Set miscelaneous styles and settings for each control type
       switch (this.layoutNode.type) {

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -121,9 +121,12 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
         this.options.fieldAddonRight || this.options.append;
 
       // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for a fieldset or an array and leaves none here, so the marker
-      // goes on whichever of the two actually renders.
-      const titled = this.options.title ? this.options : this.widgetOptions;
+      // widget for an array or a fieldset and leaves none here, so the marker
+      // follows it. Named types only: setTitle also returns null for submit,
+      // whose widget uses the title as an input value rather than as HTML, so
+      // markup appended there would render literally.
+      const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
+        ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
         !this.options.notitle && this.options.required &&
         !titled.title.includes('*')

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -271,6 +271,11 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
+      // An array is a fieldset too: its title belongs to the widget, which
+      // renders it as the legend naming the group. Leaving it to the default
+      // branch blanked it here and had the widget rebuild one from the raw
+      // property name, so the title appeared twice and in two spellings.
+      case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;
         return null;


### PR DESCRIPTION
## Summary

An array rendered its title twice, and in two different spellings: a `phone_numbers` property showed "Phone Numbers" as the field label and "Phone_numbers" as the fieldset legend.

## Changes

The framework component blanked the widget's title for an array and rendered a label itself, and the widget then rebuilt one from the raw property name through `setItemTitle`'s fallback, which splits on whitespace and hyphens but not underscores. An array now takes the title ownership a fieldset already had in all three packages: the widget keeps the title and renders it on the `<legend>` that names the group, and the framework renders no label. The required marker follows the title it decorates, for arrays and fieldsets only, since a submit widget uses its title as an input value rather than as HTML. `setItemTitle` is untouched and `@ajsf/core` is not modified.

## Release impact

No publish. Intended for 22.2.0, whose bump is a separate pull request.

## Compatibility

The array title moves from a `<label>` to the `<legend>` it already shared the page with, so `labelHtmlClass` now lands on the legend. A required fieldset gains an asterisk it had been losing the same way. Material and PrimeNG have no such switch, never blanked a title and never duplicated one.

## Validation

Six suites green at core 2156, bs3 83, bs4 114, bs5 122, material 104, primeng 206, with the corpus baseline unmoved. Reverting the title ownership fails two of the seven new tests in every package, reverting only the marker change fails the required array test, and widening the marker target back fails the submit caption test, which otherwise renders the literal markup as the button's caption.
