### PR TITLE
chore: 22.2.0

### DIFF
--- a/projects/ajsf-bootstrap3/package.json
+++ b/projects/ajsf-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap3",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 3 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.1.0",
+    "@ajsf/core": "^22.2.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap4/package.json
+++ b/projects/ajsf-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap4",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 4 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.1.0",
+    "@ajsf/core": "^22.2.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-bootstrap5/package.json
+++ b/projects/ajsf-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/bootstrap5",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder using Bootstrap 5 UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.1.0",
+    "@ajsf/core": "^22.2.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-core/package.json
+++ b/projects/ajsf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/core",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder core",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [

--- a/projects/ajsf-material/package.json
+++ b/projects/ajsf-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/material",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder using Angular Material UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -29,7 +29,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.1.0",
+    "@ajsf/core": "^22.2.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/projects/ajsf-primeng/package.json
+++ b/projects/ajsf-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajsf/primeng",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "Angular JSON Schema Form builder using PrimeNG UI",
   "author": "https://github.com/hamzahamidi/ajsf/graphs/contributors",
   "keywords": [
@@ -28,7 +28,7 @@
   "funding": "https://github.com/sponsors/hamzahamidi",
   "private": false,
   "dependencies": {
-    "@ajsf/core": "^22.1.0",
+    "@ajsf/core": "^22.2.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Sets the version to 22.2.0 across the six packages, publishing what is already on main.

## Changes

Only the output of `npm run version:set -- 22.2.0 22`: the version in each package manifest and the internal `@ajsf/core` range the five framework packages depend on. No source, test or documentation change.

## Release impact

Publishes 22.2.0 to the latest dist-tag. It carries two consumer visible fixes to the Bootstrap packages: the array remove button now shares a flex row with the field it removes rather than floating to the top of the row (#513), and an array renders its title once, on the legend, instead of twice in two spellings (#514). All three package READMEs already name 22.2.0 as the version carrying them, so those npm pages are wrong until this publishes.

## Validation

Verified on the merged state before the bump: six suites green at core 2156, bs3 83, bs4 122, bs5 130, material 104, primeng 206, the corpus baseline unmoved, and `build:demo` and `smoke:consumer` both passing.
