### PR TITLE
ci: give the Codecov project status a floor

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,24 +1,38 @@
 # Codecov configuration. Reference: https://docs.codecov.com/docs/codecovyml-reference
 #
-# Two different targets, on purpose.
+# Three targets, on purpose.
 #
 # `patch` is a fixed 80%: code being added or changed in a pull request has no
 # legacy excuse, so it carries the real standard.
 #
-# `project` is `auto`, meaning a pull request may not drop total coverage below
-# what main already has. It is deliberately not a fixed 80%, because coverage is
-# well under that today and a fixed target would fail every pull request until
-# the day it is reached, which trains everyone to ignore the check. Raise it in
-# steps as the number climbs, and only to a figure already met.
+# `project/default` stays `auto`, meaning a pull request may not drop total
+# coverage by more than the threshold. That is a ratchet, not a floor: it
+# catches a single bad drop but lets coverage erode slowly, half a point at a
+# time, with every individual pull request passing.
 #
-# `if_not_found: success` matters right now: main has no coverage report yet, so
-# there is nothing to compare against until the first upload lands there.
+# `project/floor` is the floor `auto` cannot be. main measured 77.22% on
+# 2026-09-13, so 76% is a figure already met with room for ordinary movement.
+# Raise it in steps as the number climbs, and only ever to a figure already
+# met: a target set above current coverage fails every pull request until the
+# day it is reached, which trains everyone to ignore the check.
+#
+# `if_not_found: success` covers a base commit that never uploaded a report,
+# which is not the same as main having none. main has had one since 20.0.0.
+codecov:
+  # Without this Codecov reports on `master`, which has not been this
+  # repository's default branch for years and still answers the API with a
+  # twelve file, 19% report.
+  branch: main
+
 coverage:
   status:
     project:
       default:
         target: auto
         threshold: 0.5%
+        if_not_found: success
+      floor:
+        target: 76%
         if_not_found: success
     patch:
       default:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,12 +43,14 @@ title, described further down under Correctness, which still need a design
 pass before code because they change shared widget structure rather than one
 package's class list.
 
-### Raise the Codecov project target
+### The Codecov project target has a floor
 
-`codecov.yml` has `project: auto` because coverage was 56 percent when it was
-written. `@ajsf/core` measured 91.14 percent of statements on 2026-09-12, so
-the target can become a real number. Measure the combined figure before
-choosing one, and only pick a number already met.
+Done. `codecov.yml` had `project: auto` alone because coverage was 56 percent
+when it was written; the combined figure measured 77.22 percent on 2026-09-13,
+so a floor of 76 percent now sits beside the ratchet. `auto` catches one large
+drop, the floor catches slow erosion that every individual pull request would
+otherwise pass. Raise the floor in steps, and only ever to a figure already
+met.
 
 ## Security
 


### PR DESCRIPTION
## Summary

`project: auto` is a ratchet rather than a floor, so coverage can erode indefinitely while every individual pull request passes. This adds the floor beside it, now that there is a figure to set it to.

## Changes

A second project status at 76 percent joins the existing `auto` one. `auto` fails a pull request that drops coverage in one step, and the floor fails one that has let it fall below a line already met, which no per-pull-request comparison can catch. It also pins the reporting branch to main: Codecov still treats master as the default and answers its API with a twelve file, 19 percent report from before the rename. The patch target is untouched at 80 percent. The roadmap item is closed.

## Release impact

No publish. Codecov configuration is not part of the published packages, and no version changes.

## Validation

main measured 77.22 percent across 123 files and 6354 lines at `bf7dd36`, so 76 percent is met with 1.22 points of room. The file passes Codecov's own validator, which echoes the parse back with the floor at 76 and the threshold at 0.5.
