### PR TITLE
ci: drop the codecov branch key that changed nothing

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,12 +18,13 @@
 #
 # `if_not_found: success` covers a base commit that never uploaded a report,
 # which is not the same as main having none. main has had one since 20.0.0.
-codecov:
-  # Without this Codecov reports on `master`, which has not been this
-  # repository's default branch for years and still answers the API with a
-  # twelve file, 19% report.
-  branch: main
-
+#
+# There is no `codecov: branch:` key here on purpose. Codecov's own record of
+# this repository's default branch still says `master`, a name git has not had
+# here for years, so its dashboard and API answer with a twelve file, 19%
+# report. Setting that key changed nothing across a successful upload from
+# main, so it is an account setting rather than a repository one. The badge
+# asks for `branch/main` by URL and is unaffected.
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

The `codecov: branch: main` key added in #516 does not do what its comment claimed, so it is removed rather than left looking like the problem is handled.

## Changes

Drops the key and replaces it with a note recording what was tried, what happened, and where the setting actually lives. The project floor and every other status are untouched.

## Release impact

No publish. Codecov configuration is not part of the published packages.

## Validation

CI ran on main at `a846f6b` after #516 merged, succeeded, and uploaded with the key in place. Codecov's API still answered `branch: master` with its twelve file, 19.05 percent report, unchanged in updatestamp, both immediately after and several minutes later. The file still passes Codecov's own validator.
