### PR TITLE
chore: cut the comments back to one sentence each

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,12 +2,13 @@
 #
 # patch is a fixed 80%: new code has no legacy excuse.
 #
-# project/default is auto, a ratchet against the base commit. project/floor is
-# the floor auto cannot be, since auto passes erosion under the threshold.
-# Raise the floor in steps, and only ever to a figure already met: a target
-# above current coverage fails every pull request until the day it is reached.
+# project/default is a ratchet against the base commit; project/floor is the
+# floor it cannot be, since auto passes erosion under the threshold.
 #
-# The default branch is a Codecov account setting, not a key here.
+# Raise the floor only to a figure already met.
+
+codecov:
+  branch: main
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,28 +1,13 @@
 # Codecov configuration. Reference: https://docs.codecov.com/docs/codecovyml-reference
 #
-# Three targets, on purpose.
+# patch is a fixed 80%: new code has no legacy excuse.
 #
-# `patch` is a fixed 80%: code being added or changed in a pull request has no
-# legacy excuse, so it carries the real standard.
+# project/default is auto, a ratchet against the base commit. project/floor is
+# the floor auto cannot be, since auto passes erosion under the threshold.
+# Raise the floor in steps, and only ever to a figure already met: a target
+# above current coverage fails every pull request until the day it is reached.
 #
-# `project/default` stays `auto`, meaning a pull request may not drop total
-# coverage by more than the threshold. That is a ratchet, not a floor: it
-# catches a single bad drop but lets coverage erode slowly, half a point at a
-# time, with every individual pull request passing.
-#
-# `project/floor` is the floor `auto` cannot be. main measured 77.22% on
-# 2026-09-13, so 76% is a figure already met with room for ordinary movement.
-# Raise it in steps as the number climbs, and only ever to a figure already
-# met: a target set above current coverage fails every pull request until the
-# day it is reached, which trains everyone to ignore the check.
-#
-# `if_not_found: success` covers a base commit that never uploaded a report,
-# which is not the same as main having none. main has had one since 20.0.0.
-codecov:
-  # Without this Codecov reports on `master`, which has not been this
-  # repository's default branch for years and still answers the API with a
-  # twelve file, 19% report.
-  branch: main
+# The default branch is a Codecov account setting, not a key here.
 
 coverage:
   status:

--- a/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap3/src/lib/array-title.spec.ts
@@ -36,9 +36,7 @@ describe('Bootstrap 3 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
-  // widget fell back to when the framework blanked the title, splits on
-  // whitespace and hyphens only and left the underscore in place.
+  // toTitleCase, the old fallback, does not split on underscores.
   it('renders the title once, normalised', () => {
     const el = render(underscored);
     expect(titled(el, 'Phone_numbers').length,
@@ -64,9 +62,7 @@ describe('Bootstrap 3 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // The marker is appended to whichever title renders. Handing the array's
-  // title to the widget without moving the marker with it dropped the
-  // asterisk entirely, because the framework's own title is null by then.
+  // The framework's own title is null here, so the marker has to follow.
   it('keeps the required marker on the title it moved', () => {
     const el = render(requiredArray);
     const legends = [...el.querySelectorAll('legend')]
@@ -88,8 +84,7 @@ describe('Bootstrap 3 array title', () => {
   });
 
 
-  // A submit widget uses its title as the input's value, and a submit input
-  // renders its value as text, so markup appended there shows literally.
+  // A submit input renders its value as text, so markup would show literally.
   it('leaves a required submit caption as plain text', () => {
     const el = render({
       schema: { name: { type: 'string' } },
@@ -100,8 +95,7 @@ describe('Bootstrap 3 array title', () => {
     expect(submit.value, 'the caption must not carry markup').toEqual('Save');
   });
 
-  // The marker was only ever appended to the framework's own title, which
-  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  // A fieldset's title is the widget's too, so it had been losing the marker.
   it('marks a required fieldset, which had been losing its asterisk', () => {
     const el = render({
       schema: {

--- a/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
+++ b/projects/ajsf-bootstrap3/src/lib/bootstrap3-framework.component.ts
@@ -108,11 +108,8 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for an array or a fieldset and leaves none here, so the marker
-      // follows it. Named types only: setTitle also returns null for submit,
-      // whose widget uses the title as an input value rather than as HTML, so
-      // markup appended there would render literally.
+      // Named types only: submit also has a null title here, and its widget
+      // uses the title as an input value, where markup would render literally.
       const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
         ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
@@ -244,10 +241,7 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
-      // An array is a fieldset too: its title belongs to the widget, which
-      // renders it as the legend naming the group. Leaving it to the default
-      // branch blanked it here and had the widget rebuild one from the raw
-      // property name, so the title appeared twice and in two spellings.
+      // An array is a fieldset: the widget owns the title and renders the legend.
       case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;

--- a/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-row.spec.ts
@@ -65,9 +65,7 @@ describe('Bootstrap 4 array row', () => {
   });
 
 
-  // A group-level action anchors at the group's upper edge: the midpoint of a
-  // nested item moves as its contents grow, which would leave the button
-  // looking attached to whichever child happened to sit halfway down.
+  // A group's midpoint moves as it grows, so the action anchors at its top.
   it('anchors the button at the top when the item is a group', () => {
     const el = render({
       schema: {
@@ -92,9 +90,7 @@ describe('Bootstrap 4 array row', () => {
   });
 
 
-  // A group is a group because of what the layout resolved it to, not because
-  // of how many controls it happens to contain. A child count or a height
-  // would call this one centred.
+  // What the layout resolved it to decides this, not how many controls it has.
   it('treats a group holding a single field as a group', () => {
     const el = render({
       schema: {
@@ -112,10 +108,7 @@ describe('Bootstrap 4 array row', () => {
     expect(row.className, 'so it anchors at the top').toContain('align-items-start');
   });
 
-  // showRemoveButton flips while the form is live, so this has to be one
-  // fixture crossing minItems rather than two separate renders. Two branches
-  // for wrapped and unwrapped would rebuild the surviving control here, taking
-  // its focus and its state with it.
+  // Two branches would rebuild the surviving control as this flag flips.
   it('keeps the surviving control across a removal that crosses minItems', () => {
     const el = render(arrayForm(1, 2));
     const items = () => [...el.querySelectorAll('input:not([type=submit])')] as HTMLInputElement[];
@@ -169,12 +162,9 @@ describe('Bootstrap 4 invalid feedback placement', () => {
     component.dataIndex = [];
   });
 
-  // Bootstrap reveals .invalid-feedback only as a following sibling of the
-  // element carrying .is-invalid. The row the remove button joined now carries
-  // that marker, so this is the assertion that the move preserved the rule.
+  // Bootstrap reveals .invalid-feedback only after the .is-invalid element.
   it('renders the message as a following sibling of the invalid element', () => {
-    // initializeFramework reassigns formControl from the service, so the stub
-    // has to be the service's answer rather than a field set on the component.
+    // initializeFramework reassigns formControl, so stub the service instead.
     const jsf = TestBed.inject(JsonSchemaFormService);
     vi.spyOn(jsf, 'getFormControl').mockReturnValue({
       status: 'INVALID',
@@ -216,9 +206,7 @@ describe('Bootstrap 4 input widget classification', () => {
     return component.options.isInputWidget;
   };
 
-  // The row alignment reads this flag, so a control missing from the list is
-  // aligned as though it were a group. checkboxbuttons was the one omission,
-  // beside radiobuttons and every other check and radio variant.
+  // The row alignment reads this flag: a missing type aligns as a group.
   it('counts every check and radio variant as a control', () => {
     ['checkbox', 'checkboxes', 'checkboxes-inline', 'checkboxbuttons',
       'radio', 'radios', 'radios-inline', 'radiobuttons'].forEach((type) => {

--- a/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap4/src/lib/array-title.spec.ts
@@ -36,9 +36,7 @@ describe('Bootstrap 4 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
-  // widget fell back to when the framework blanked the title, splits on
-  // whitespace and hyphens only and left the underscore in place.
+  // toTitleCase, the old fallback, does not split on underscores.
   it('renders the title once, normalised', () => {
     const el = render(underscored);
     expect(titled(el, 'Phone_numbers').length,
@@ -64,9 +62,7 @@ describe('Bootstrap 4 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // The marker is appended to whichever title renders. Handing the array's
-  // title to the widget without moving the marker with it dropped the
-  // asterisk entirely, because the framework's own title is null by then.
+  // The framework's own title is null here, so the marker has to follow.
   it('keeps the required marker on the title it moved', () => {
     const el = render(requiredArray);
     const legends = [...el.querySelectorAll('legend')]
@@ -88,8 +84,7 @@ describe('Bootstrap 4 array title', () => {
   });
 
 
-  // A submit widget uses its title as the input's value, and a submit input
-  // renders its value as text, so markup appended there shows literally.
+  // A submit input renders its value as text, so markup would show literally.
   it('leaves a required submit caption as plain text', () => {
     const el = render({
       schema: { name: { type: 'string' } },
@@ -100,8 +95,7 @@ describe('Bootstrap 4 array title', () => {
     expect(submit.value, 'the caption must not carry markup').toEqual('Save');
   });
 
-  // The marker was only ever appended to the framework's own title, which
-  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  // A fieldset's title is the widget's too, so it had been losing the marker.
   it('marks a required fieldset, which had been losing its asterisk', () => {
     const el = render({
       schema: {

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.html
@@ -23,15 +23,8 @@
     </p>
   }
 
-  <!--
-  is-invalid sits on this row, not on the control. Bootstrap reveals
-  .invalid-feedback only as a following sibling of the element carrying
-  .is-invalid, and select-widget-widget renders its own host element and a
-  container div between here and the real input, so the input and the
-  message can never be siblings. The row is a flex container only for a
-  removable array item, which is also what stops .close taking its built in
-  float and leaving normal flow.
-  -->
+  <!-- Bootstrap reveals .invalid-feedback only after the element carrying
+  .is-invalid, so the marker belongs on this row, not on the control. -->
   <div
     [class.d-flex]="showRemoveButton"
     [class.align-items-center]="showRemoveButton && options?.isInputWidget"

--- a/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/bootstrap4-framework.component.ts
@@ -116,11 +116,8 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for an array or a fieldset and leaves none here, so the marker
-      // follows it. Named types only: setTitle also returns null for submit,
-      // whose widget uses the title as an input value rather than as HTML, so
-      // markup appended there would render literally.
+      // Named types only: submit also has a null title here, and its widget
+      // uses the title as an input value, where markup would render literally.
       const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
         ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
@@ -273,10 +270,7 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
-      // An array is a fieldset too: its title belongs to the widget, which
-      // renders it as the legend naming the group. Leaving it to the default
-      // branch blanked it here and had the widget rebuild one from the raw
-      // property name, so the title appeared twice and in two spellings.
+      // An array is a fieldset: the widget owns the title and renders the legend.
       case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
@@ -2,12 +2,9 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CheckboxComponent } from '@ajsf/core';
 
 /**
- * Bootstrap 4 wants the input and label as siblings inside .form-check. The
- * core widget nests the input inside the label, which is the Bootstrap 3
- * shape this package was originally copied from.
+ * Bootstrap 4 wants the input and label as siblings inside .form-check.
  *
- * Template only. No constructor: Angular inherits the base's injection
- * through its generated factory, and adding one would break that.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-checkbox-widget',

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkbox.component.ts
@@ -3,8 +3,6 @@ import { CheckboxComponent } from '@ajsf/core';
 
 /**
  * Bootstrap 4 wants the input and label as siblings inside .form-check.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-checkbox-widget',

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
@@ -2,17 +2,10 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CheckboxesComponent } from '@ajsf/core';
 
 /**
- * Bootstrap 4 splits these two ways, so this template does too.
+ * Siblings, except checkboxbuttons: Bootstrap 4 has no .btn-check, so its toggle
+ * buttons keep the nested input .btn-group-toggle documents.
  *
- * Vertical checkboxes take the sibling form, which is what Bootstrap 4
- * documents for .form-check. The horizontal branch splits again on
- * layoutNode.type: checkboxes-inline is .form-check.form-check-inline, the
- * same sibling shape as vertical, while checkboxbuttons keeps the input
- * inside the label, because Bootstrap 4's toggle buttons are
- * .btn-group-toggle with a nested input and it has no .btn-check. That is
- * deliberate, not a widget that was missed.
- *
- * Template only. No constructor.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-checkboxes-widget',

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-checkboxes.component.ts
@@ -4,8 +4,6 @@ import { CheckboxesComponent } from '@ajsf/core';
 /**
  * Siblings, except checkboxbuttons: Bootstrap 4 has no .btn-check, so its toggle
  * buttons keep the nested input .btn-group-toggle documents.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-checkboxes-widget',

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
@@ -4,8 +4,6 @@ import { RadiosComponent } from '@ajsf/core';
 /**
  * Siblings, except radiobuttons: Bootstrap 4 has no .btn-check, so its toggle
  * buttons keep the nested input .btn-group-toggle documents.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-radios-widget',

--- a/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
+++ b/projects/ajsf-bootstrap4/src/lib/widgets/bootstrap4-radios.component.ts
@@ -2,17 +2,10 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RadiosComponent } from '@ajsf/core';
 
 /**
- * Bootstrap 4 splits these two ways, so this template does too.
+ * Siblings, except radiobuttons: Bootstrap 4 has no .btn-check, so its toggle
+ * buttons keep the nested input .btn-group-toggle documents.
  *
- * Vertical radios take the sibling form, which is what Bootstrap 4
- * documents for .form-check. The horizontal branch splits again on
- * layoutNode.type: radios-inline is .form-check.form-check-inline, the
- * same sibling shape as vertical, while radiobuttons keeps the input
- * inside the label, because Bootstrap 4's toggle buttons are
- * .btn-group-toggle with a nested input and it has no .btn-check. That is
- * deliberate, not a widget that was missed.
- *
- * Template only. No constructor.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap4-radios-widget',

--- a/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-row.spec.ts
@@ -65,9 +65,7 @@ describe('Bootstrap 5 array row', () => {
   });
 
 
-  // A group-level action anchors at the group's upper edge: the midpoint of a
-  // nested item moves as its contents grow, which would leave the button
-  // looking attached to whichever child happened to sit halfway down.
+  // A group's midpoint moves as it grows, so the action anchors at its top.
   it('anchors the button at the top when the item is a group', () => {
     const el = render({
       schema: {
@@ -92,9 +90,7 @@ describe('Bootstrap 5 array row', () => {
   });
 
 
-  // A group is a group because of what the layout resolved it to, not because
-  // of how many controls it happens to contain. A child count or a height
-  // would call this one centred.
+  // What the layout resolved it to decides this, not how many controls it has.
   it('treats a group holding a single field as a group', () => {
     const el = render({
       schema: {
@@ -112,10 +108,7 @@ describe('Bootstrap 5 array row', () => {
     expect(row.className, 'so it anchors at the top').toContain('align-items-start');
   });
 
-  // showRemoveButton flips while the form is live, so this has to be one
-  // fixture crossing minItems rather than two separate renders. Two branches
-  // for wrapped and unwrapped would rebuild the surviving control here, taking
-  // its focus and its state with it.
+  // Two branches would rebuild the surviving control as this flag flips.
   it('keeps the surviving control across a removal that crosses minItems', () => {
     const el = render(arrayForm(1, 2));
     const items = () => [...el.querySelectorAll('input:not([type=submit])')] as HTMLInputElement[];
@@ -169,12 +162,9 @@ describe('Bootstrap 5 invalid feedback placement', () => {
     component.dataIndex = [];
   });
 
-  // Bootstrap reveals .invalid-feedback only as a following sibling of the
-  // element carrying .is-invalid. The row the remove button joined now carries
-  // that marker, so this is the assertion that the move preserved the rule.
+  // Bootstrap reveals .invalid-feedback only after the .is-invalid element.
   it('renders the message as a following sibling of the invalid element', () => {
-    // initializeFramework reassigns formControl from the service, so the stub
-    // has to be the service's answer rather than a field set on the component.
+    // initializeFramework reassigns formControl, so stub the service instead.
     const jsf = TestBed.inject(JsonSchemaFormService);
     vi.spyOn(jsf, 'getFormControl').mockReturnValue({
       status: 'INVALID',
@@ -216,9 +206,7 @@ describe('Bootstrap 5 input widget classification', () => {
     return component.options.isInputWidget;
   };
 
-  // The row alignment reads this flag, so a control missing from the list is
-  // aligned as though it were a group. checkboxbuttons was the one omission,
-  // beside radiobuttons and every other check and radio variant.
+  // The row alignment reads this flag: a missing type aligns as a group.
   it('counts every check and radio variant as a control', () => {
     ['checkbox', 'checkboxes', 'checkboxes-inline', 'checkboxbuttons',
       'radio', 'radios', 'radios-inline', 'radiobuttons'].forEach((type) => {

--- a/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
+++ b/projects/ajsf-bootstrap5/src/lib/array-title.spec.ts
@@ -36,9 +36,7 @@ describe('Bootstrap 5 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // fixTitle turns phone_numbers into Phone Numbers; toTitleCase, which the
-  // widget fell back to when the framework blanked the title, splits on
-  // whitespace and hyphens only and left the underscore in place.
+  // toTitleCase, the old fallback, does not split on underscores.
   it('renders the title once, normalised', () => {
     const el = render(underscored);
     expect(titled(el, 'Phone_numbers').length,
@@ -64,9 +62,7 @@ describe('Bootstrap 5 array title', () => {
     data: { phone_numbers: ['702-123-4567'] },
   };
 
-  // The marker is appended to whichever title renders. Handing the array's
-  // title to the widget without moving the marker with it dropped the
-  // asterisk entirely, because the framework's own title is null by then.
+  // The framework's own title is null here, so the marker has to follow.
   it('keeps the required marker on the title it moved', () => {
     const el = render(requiredArray);
     const legends = [...el.querySelectorAll('legend')]
@@ -88,8 +84,7 @@ describe('Bootstrap 5 array title', () => {
   });
 
 
-  // A submit widget uses its title as the input's value, and a submit input
-  // renders its value as text, so markup appended there shows literally.
+  // A submit input renders its value as text, so markup would show literally.
   it('leaves a required submit caption as plain text', () => {
     const el = render({
       schema: { name: { type: 'string' } },
@@ -100,8 +95,7 @@ describe('Bootstrap 5 array title', () => {
     expect(submit.value, 'the caption must not carry markup').toEqual('Save');
   });
 
-  // The marker was only ever appended to the framework's own title, which
-  // setTitle leaves null for a fieldset, so a required fieldset rendered none.
+  // A fieldset's title is the widget's too, so it had been losing the marker.
   it('marks a required fieldset, which had been losing its asterisk', () => {
     const el = render({
       schema: {

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.html
@@ -27,13 +27,8 @@ to the field rather than to this container.
       <strong class="text-danger">*</strong> = required fields
     </p>
   }
-  <!--
-  is-invalid sits on this row rather than on the field inside it, because
-  Bootstrap reveals .invalid-feedback only as a following sibling of the
-  element carrying .is-invalid, and the message below is this row's sibling.
-  The row is a flex container only for a removable array item, which is also
-  what stops the button's float taking it out of normal flow.
-  -->
+  <!-- Bootstrap reveals .invalid-feedback only after the element carrying
+  .is-invalid, so the marker belongs on this row, not on the control. -->
   <div
     [class.d-flex]="showRemoveButton"
     [class.align-items-center]="showRemoveButton && options?.isInputWidget"

--- a/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/bootstrap5-framework.component.ts
@@ -121,11 +121,8 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
       this.options.fieldAddonRight =
         this.options.fieldAddonRight || this.options.append;
 
-      // Add asterisk to titles if required. setTitle hands the title to the
-      // widget for an array or a fieldset and leaves none here, so the marker
-      // follows it. Named types only: setTitle also returns null for submit,
-      // whose widget uses the title as an input value rather than as HTML, so
-      // markup appended there would render literally.
+      // Named types only: submit also has a null title here, and its widget
+      // uses the title as an input value, where markup would render literally.
       const titled = this.layoutNode.type === 'array' || this.layoutNode.type === 'fieldset'
         ? this.widgetOptions : this.options;
       if (titled.title && this.layoutNode.type !== 'tab' &&
@@ -278,10 +275,7 @@ export class Bootstrap5FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
-      // An array is a fieldset too: its title belongs to the widget, which
-      // renders it as the legend naming the group. Leaving it to the default
-      // branch blanked it here and had the widget rebuild one from the raw
-      // property name, so the title appeared twice and in two spellings.
+      // An array is a fieldset: the widget owns the title and renders the legend.
       case 'array':
       case 'fieldset':
         this.widgetOptions.title = this.options.title;

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
@@ -3,8 +3,6 @@ import { CheckboxComponent } from '@ajsf/core';
 
 /**
  * Bootstrap 5 wants the input and label as siblings inside .form-check.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-checkbox-widget',

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkbox.component.ts
@@ -2,12 +2,9 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CheckboxComponent } from '@ajsf/core';
 
 /**
- * Bootstrap 5 wants the input and label as siblings inside .form-check, and
- * styles the input's state through sibling selectors. The core widget nests
- * the input inside the label, which is the Bootstrap 3 shape.
+ * Bootstrap 5 wants the input and label as siblings inside .form-check.
  *
- * Template only. No constructor: Angular inherits the base's injection
- * through its generated factory, and adding one would break that.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-checkbox-widget',

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
@@ -2,18 +2,10 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CheckboxesComponent } from '@ajsf/core';
 
 /**
- * Sibling input and label per item, for checkboxes, checkboxes-inline and
- * checkboxbuttons alike. The horizontal branch splits on layoutNode.type:
- * checkboxbuttons keeps the one shared wrapper, because btn-group belongs on
- * a single element around the whole set and Bootstrap 5's btn-check idiom is
- * a sibling input there too. checkboxes-inline gives each item its own
- * wrapper, because Bootstrap 5 documents one .form-check.form-check-inline
- * per item, not one around the whole set.
+ * Siblings throughout: Bootstrap 5 button sets use .btn-check, which is a
+ * sibling input too.
  *
- * activeClass and style.selected stay on the label, where the core widget
- * puts them, so the button idiom keeps working.
- *
- * Template only. No constructor.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-checkboxes-widget',

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-checkboxes.component.ts
@@ -4,8 +4,6 @@ import { CheckboxesComponent } from '@ajsf/core';
 /**
  * Siblings throughout: Bootstrap 5 button sets use .btn-check, which is a
  * sibling input too.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-checkboxes-widget',

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
@@ -2,15 +2,10 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RadiosComponent } from '@ajsf/core';
 
 /**
- * Sibling input and label per item, for radios, radios-inline and
- * radiobuttons alike. The horizontal branch splits on layoutNode.type:
- * radiobuttons keeps the one shared wrapper, because btn-group belongs on a
- * single element around the whole set and Bootstrap 5's btn-check idiom is a
- * sibling input there too. radios-inline gives each item its own wrapper,
- * because Bootstrap 5 documents one .form-check.form-check-inline per item,
- * not one around the whole set.
+ * Siblings throughout: Bootstrap 5 button sets use .btn-check, which is a
+ * sibling input too.
  *
- * Template only. No constructor.
+ * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-radios-widget',

--- a/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
+++ b/projects/ajsf-bootstrap5/src/lib/widgets/bootstrap5-radios.component.ts
@@ -4,8 +4,6 @@ import { RadiosComponent } from '@ajsf/core';
 /**
  * Siblings throughout: Bootstrap 5 button sets use .btn-check, which is a
  * sibling input too.
- *
- * Template only: a constructor would break the inherited injection factory.
  */
 @Component({
   selector: 'bootstrap5-radios-widget',


### PR DESCRIPTION
## Summary

The comments added with the Bootstrap widget components and the array row work ran to paragraphs, against the one short sentence rule in AGENTS.md.

## Changes

Every comment added by that work is now a single sentence. The six widget doc blocks keep only the Bootstrap rule that explains the shape, losing both the restatement of the template underneath them and a claim about inherited injection that was wrong as well as long: a derived component may declare a constructor if it forwards to `super`, so that guardrail is a project decision belonging in its commit rather than the source. The framework component and spec comments lose the narration of why a decision was taken. `codecov.yml` loses two thirds of its preamble and keeps `codecov.branch`.

## Release impact

No publish. Comments do not reach the built packages and no version changes.

## Validation

179 lines of comment removed against 59 added across 17 files. Rebuilt the libraries and reran the three Bootstrap suites: bs3 83, bs4 122, bs5 130. `codecov.yml` passes Codecov's validator.